### PR TITLE
fix: update reth dependencies and remove unused packages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,15 +110,16 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.0.9"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad451f9a70c341d951bca4e811d74dbe1e193897acd17e9dbac1353698cc430b"
+checksum = "2bcb57295c4b632b6b3941a089ee82d00ff31ff9eb3eac801bf605ffddc81041"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
  "alloy-trie",
+ "alloy-tx-macros",
  "auto_impl",
  "c-kzg",
  "derive_more",
@@ -134,9 +135,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.0.9"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142daffb15d5be1a2b20d2cd540edbcef03037b55d4ff69dc06beb4d06286dba"
+checksum = "3ab669be40024565acb719daf1b2a050e6dc065fc0bec6050d97a81cdb860bd7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -203,9 +204,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "1.0.9"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3056872f6da48046913e76edb5ddced272861f6032f09461aea1a2497be5ae5d"
+checksum = "4f853de9ca1819f54de80de5d03bfc1bb7c9fafcf092b480a654447141bc354d"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -236,7 +237,24 @@ dependencies = [
  "alloy-sol-types",
  "auto_impl",
  "derive_more",
- "op-alloy-consensus",
+ "revm",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "alloy-evm"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ed976ec0c32f8c6d79703e96249d0866b6c444c0a2649c10bfd5203e7e13adf"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-hardforks",
+ "alloy-primitives",
+ "alloy-sol-types",
+ "auto_impl",
+ "derive_more",
+ "op-alloy-consensus 0.18.6",
  "op-revm",
  "revm",
  "thiserror 2.0.12",
@@ -244,9 +262,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "1.0.9"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c98fb40f07997529235cc474de814cd7bd9de561e101716289095696c0e4639d"
+checksum = "8500bcc1037901953771c25cb77e0d4ec0bffd938d93a04715390230d21a612d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -283,12 +301,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "1.0.9"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc08b31ebf9273839bd9a01f9333cbb7a3abb4e820c312ade349dd18bdc79581"
+checksum = "f4997a9873c8639d079490f218e50e5fa07e70f957e9fc187c0a0535977f482f"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
+ "http",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -297,9 +316,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "1.0.9"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed117b08f0cc190312bf0c38c34cf4f0dabfb4ea8f330071c587cd7160a88cb2"
+checksum = "a0306e8d148b7b94d988615d367443c1b9d6d2e9fecd2e1f187ac5153dce56f5"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -323,9 +342,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "1.0.9"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7162ff7be8649c0c391f4e248d1273e85c62076703a1f3ec7daf76b283d886d"
+checksum = "3eef189583f4c53d231dd1297b28a675ff842b551fb34715f562868a1937431a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -364,9 +383,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "1.0.9"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d84eba1fd8b6fe8b02f2acd5dd7033d0f179e304bd722d11e817db570d1fa6c4"
+checksum = "ea624ddcdad357c33652b86aa7df9bd21afd2080973389d3facf1a221c573948"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -391,6 +410,7 @@ dependencies = [
  "either",
  "futures",
  "futures-utils-wasm",
+ "http",
  "lru 0.13.0",
  "parking_lot",
  "pin-project",
@@ -406,9 +426,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "1.0.9"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8550f7306e0230fc835eb2ff4af0a96362db4b6fc3f25767d161e0ad0ac765bf"
+checksum = "1ea3227fa5f627d22b7781e88bc2fe79ba1792d5535b4161bc8fc99cdcd8bedd"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -449,9 +469,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "1.0.9"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "518a699422a3eab800f3dac2130d8f2edba8e4fff267b27a9c7dc6a2b0d313ee"
+checksum = "e43d00b4de38432304c4e4b01ae6a3601490fd9824c852329d158763ec18663c"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -477,9 +497,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "1.0.9"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c000cab4ec26a4b3e29d144e999e1c539c2fa0abed871bf90311eb3466187ca8"
+checksum = "3bf22ddb69a436f28bbdda7daf34fe011ee9926fa13bfce89fa023aca9ce2b2f"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -490,9 +510,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-admin"
-version = "1.0.9"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ebdc864f573645c5288370c208912b85b5cacc8025b700c50c2b74d06ab9830"
+checksum = "5fa84dd9d9465d6d3718e91b017d42498ec51a702d9712ebce64c2b0b7ed9383"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -502,9 +522,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "1.0.9"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8abecc34549a208b5f91bc7f02df3205c36e2aa6586f1d9375c3382da1066b3b"
+checksum = "1ecd1c60085d8cbc3562e16e264a3cd68f42e54dc16b0d40645e5e42841bc042"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -514,9 +534,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "1.0.9"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "508b2fbe66d952089aa694e53802327798806498cd29ff88c75135770ecaabfc"
+checksum = "5958f2310d69f4806e6f6b90ceb4f2b781cc5a843517a7afe2e7cfec6de3cfb9"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -525,9 +545,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-beacon"
-version = "1.0.9"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "241aba7808bddc3ad1c6228e296a831f326f89118b1017012090709782a13334"
+checksum = "e83868430cddb02bb952d858f125b824ddbc74dde0fb4cdc5c345c732d66936b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -543,9 +563,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "1.0.9"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c832f2e851801093928dbb4b7bd83cd22270faf76b2e080646b806a285c8757"
+checksum = "c293df0c58d15330e65599f776e30945ea078c93b1594e5c4ba0efaad3f0a739"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -553,9 +573,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "1.0.9"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab52691970553d84879d777419fa7b6a2e92e9fe8641f9324cc071008c2f656"
+checksum = "2e5b09d86d0c015cb8400c5d1d0483425670bef4fc1260336aea9ef6d4b9540c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -573,9 +593,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.0.9"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcaf7dff0fdd756a714d58014f4f8354a1706ebf9fa2cf73431e0aeec3c9431e"
+checksum = "1826285e4ffc2372a8c061d5cc145858e67a0be3309b768c5b77ddb6b9e6cbc7"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -593,9 +613,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-mev"
-version = "1.0.9"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18bd1c5d7b9f3f1caeeaa1c082aa28ba7ce2d67127b12b2a9b462712c8f6e1c5"
+checksum = "b94fb27232aac9ee5785bee2ebfc3f9c6384a890a658737263c861c203165355"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -608,9 +628,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "1.0.9"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e3507a04e868dd83219ad3cd6a8c58aefccb64d33f426b3934423a206343e84"
+checksum = "d1e8f7fa774a1d6f7b3654686f68955631e55f687e03da39c0bd77a9418d57a1"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -622,9 +642,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "1.0.9"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eec36272621c3ac82b47dd77f0508346687730b1c2e3e10d3715705c217c0a05"
+checksum = "d39d9218a0fd802dbccd7e0ce601a6bdefb61190386e97a437d97a31661cd358"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -634,9 +654,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "1.0.9"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "730e8f2edf2fc224cabd1c25d090e1655fa6137b2e409f92e5eec735903f1507"
+checksum = "906ce0190afeded19cb2e963cb8507c975a7862216b9e74f39bf91ddee6ae74b"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -645,9 +665,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "1.0.9"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b0d2428445ec13edc711909e023d7779618504c4800be055a5b940025dbafe3"
+checksum = "c89baab06195c4be9c5d66f15c55e948013d1aff3ec1cfb0ed469e1423313fce"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -660,9 +680,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "1.0.9"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14fe6fedb7fe6e0dfae47fe020684f1d8e063274ef14bca387ddb7a6efa8ec1"
+checksum = "8a249a923e302ac6db932567c43945392f0b6832518aab3c4274858f58756774"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -746,9 +766,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "1.0.9"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a712bdfeff42401a7dd9518f72f617574c36226a9b5414537fedc34350b73bf9"
+checksum = "6d1ae10b1bc77fde38161e242749e41e65e34000d05da0a3d3f631e03bfcb19e"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -769,9 +789,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "1.0.9"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ea5a76d7f2572174a382aedf36875bedf60bcc41116c9f031cf08040703a2dc"
+checksum = "b234272ee449e32c9f1afbbe4ee08ea7c4b52f14479518f95c844ab66163c545"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -784,9 +804,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "1.0.9"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "606af17a7e064d219746f6d2625676122c79d78bf73dfe746d6db9ecd7dbcb85"
+checksum = "061672d736144eb5aae13ca67cfec8e5e69a65bef818cb1a2ab2345d55c50ab4"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -804,9 +824,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "1.0.9"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c6f9b37cd8d44aab959613966cc9d4d7a9b429c575cec43b3e5b46ea109a79"
+checksum = "40b01f10382c2aea797d710279b24687a1e9e09a09ecd145f84f636f2a8a3fcc"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -834,6 +854,19 @@ dependencies = [
  "serde",
  "smallvec",
  "tracing",
+]
+
+[[package]]
+name = "alloy-tx-macros"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75ef8609ea2b31c799b0a56c724dca4c73105c5ccc205d9dfeb1d038df6a1da"
+dependencies = [
+ "alloy-primitives",
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1234,9 +1267,9 @@ checksum = "155a5a185e42c6b77ac7b88a15143d930a9e9727a5b7b77eed417404ab15c247"
 
 [[package]]
 name = "async-compression"
-version = "0.4.24"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d615619615a650c571269c00dca41db04b9210037fa76ed8239f70404ab56985"
+checksum = "40f6024f3f856663b45fd0c9b6f2024034a702f453549449e0d84a305900dad4"
 dependencies = [
  "brotli",
  "flate2",
@@ -1321,9 +1354,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "backon"
@@ -1402,7 +1435,7 @@ dependencies = [
  "reth-node-ethereum",
  "reth-rpc",
  "reth-tracing",
- "reth-trie-db",
+ "reth-trie-db 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
  "serde",
  "thiserror 2.0.12",
  "tracing",
@@ -2425,9 +2458,9 @@ dependencies = [
 
 [[package]]
 name = "derive-where"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e73f2692d4bd3cac41dca28934a39894200c9fabf49586d77d0e5954af1d7902"
+checksum = "510c292c8cf384b1a340b816a9a6cf2599eb8f566a44949024af88418000c50b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4291,9 +4324,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.173"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8cfeafaffdbc32176b64fb251369d52ea9f0a8fbc6f8759edffef7b525d64bb"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libgit2-sys"
@@ -4648,9 +4681,9 @@ dependencies = [
 
 [[package]]
 name = "metrics-util"
-version = "0.19.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8496cc523d1f94c1385dd8f0f0c2c480b2b8aeccb5b7e4485ad6365523ae376"
+checksum = "39803e5c24a697c54492a76469034eee8247bd61825502e0410defc3e98eedf0"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -5032,15 +5065,31 @@ dependencies = [
  "alloy-serde",
  "derive_more",
  "serde",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "op-alloy-consensus"
+version = "0.18.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5448a4ef9ef1ee241a67fe533ae3563716bbcd719acbd0544ad1ac9f03cfde6"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "derive_more",
+ "serde",
  "serde_with",
  "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "op-alloy-rpc-types"
-version = "0.17.2"
+version = "0.18.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f82a315004b6720fbf756afdcfdc97ea7ddbcdccfec86ea7df7562bb0da29a3f"
+checksum = "bcbf5ee458a2ad66833e7dcc28d78f33d3d4eba53f432c93d7030f5c02331861"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5049,7 +5098,7 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-serde",
  "derive_more",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.18.6",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -5057,9 +5106,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-rpc-types-engine"
-version = "0.17.2"
+version = "0.18.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47aea08d8ad3f533df0c5082d3e93428a4c57898b7ade1be928fa03918f22e71"
+checksum = "712c2b1be5c3414f29800d1b29cd16f0049b847687143adb19814de587ecb3f6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5068,7 +5117,8 @@ dependencies = [
  "alloy-rpc-types-engine",
  "derive_more",
  "ethereum_ssz",
- "op-alloy-consensus",
+ "ethereum_ssz_derive",
+ "op-alloy-consensus 0.18.6",
  "snap",
  "thiserror 2.0.12",
 ]
@@ -5587,9 +5637,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "radium"
@@ -5890,7 +5940,7 @@ checksum = "95325155c684b1c89f7765e30bc1c42e4a6da51ca513615660cb8a62ef9a88e3"
 [[package]]
 name = "reth"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-rpc-types",
  "aquamarine",
@@ -5904,7 +5954,7 @@ dependencies = [
  "reth-db",
  "reth-ethereum-cli",
  "reth-ethereum-payload-builder",
- "reth-ethereum-primitives",
+ "reth-ethereum-primitives 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-evm",
  "reth-network",
  "reth-network-api",
@@ -5936,7 +5986,7 @@ dependencies = [
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5949,7 +5999,7 @@ dependencies = [
  "reth-payload-builder",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
- "reth-primitives-traits",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-revm",
  "reth-storage-api",
  "reth-tasks",
@@ -5960,7 +6010,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5972,12 +6022,12 @@ dependencies = [
  "rand 0.9.1",
  "reth-chainspec",
  "reth-errors",
- "reth-ethereum-primitives",
+ "reth-ethereum-primitives 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-execution-types",
  "reth-metrics",
- "reth-primitives-traits",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-storage-api",
- "reth-trie",
+ "reth-trie 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "revm-database",
  "revm-state",
  "serde",
@@ -5989,12 +6039,12 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm",
+ "alloy-evm 0.11.0",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-trie",
@@ -6002,14 +6052,14 @@ dependencies = [
  "derive_more",
  "reth-ethereum-forks",
  "reth-network-peers",
- "reth-primitives-traits",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "serde_json",
 ]
 
 [[package]]
 name = "reth-cli"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -6023,7 +6073,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "ahash",
  "alloy-chains",
@@ -6047,11 +6097,11 @@ dependencies = [
  "reth-cli",
  "reth-cli-runner",
  "reth-cli-util",
- "reth-codecs",
+ "reth-codecs 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-config",
  "reth-consensus",
  "reth-db",
- "reth-db-api",
+ "reth-db-api 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-db-common",
  "reth-discv4",
  "reth-discv5",
@@ -6073,14 +6123,14 @@ dependencies = [
  "reth-node-core",
  "reth-node-events",
  "reth-node-metrics",
- "reth-primitives-traits",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-provider",
  "reth-prune",
  "reth-stages",
  "reth-static-file",
- "reth-static-file-types",
- "reth-trie",
- "reth-trie-db",
+ "reth-static-file-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-trie 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-trie-db 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "secp256k1",
  "serde",
  "serde_json",
@@ -6094,7 +6144,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -6104,7 +6154,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6122,6 +6172,24 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.4.8"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-genesis",
+ "alloy-primitives",
+ "alloy-trie",
+ "bytes",
+ "modular-bitfield",
+ "op-alloy-consensus 0.18.6",
+ "reth-codecs-derive 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-zstd-compressors 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "serde",
+]
+
+[[package]]
+name = "reth-codecs"
+version = "1.4.8"
 source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
 dependencies = [
  "alloy-consensus",
@@ -6131,10 +6199,21 @@ dependencies = [
  "alloy-trie",
  "bytes",
  "modular-bitfield",
- "op-alloy-consensus",
- "reth-codecs-derive",
- "reth-zstd-compressors",
+ "op-alloy-consensus 0.17.2",
+ "reth-codecs-derive 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
+ "reth-zstd-compressors 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
  "serde",
+]
+
+[[package]]
+name = "reth-codecs-derive"
+version = "1.4.8"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -6151,13 +6230,13 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "eyre",
  "humantime-serde",
  "reth-network-types",
- "reth-prune-types",
- "reth-stages-types",
+ "reth-prune-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-stages-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "serde",
  "toml",
  "url",
@@ -6166,33 +6245,32 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "auto_impl",
  "reth-execution-types",
- "reth-primitives-traits",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "reth-consensus-common"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "reth-chainspec",
  "reth-consensus",
- "reth-primitives-traits",
- "tracing",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
 ]
 
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6206,7 +6284,7 @@ dependencies = [
  "futures",
  "reqwest",
  "reth-node-api",
- "reth-primitives-traits",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-tracing",
  "ringbuffer",
  "serde",
@@ -6216,25 +6294,50 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-primitives",
  "derive_more",
  "eyre",
  "metrics",
  "page_size",
- "reth-db-api",
+ "reth-db-api 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-fs-util",
  "reth-libmdbx",
  "reth-metrics",
  "reth-nippy-jar",
- "reth-static-file-types",
- "reth-storage-errors",
+ "reth-static-file-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-storage-errors 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-tracing",
  "rustc-hash 2.1.1",
  "strum 0.27.1",
  "sysinfo",
  "thiserror 2.0.12",
+]
+
+[[package]]
+name = "reth-db-api"
+version = "1.4.8"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+dependencies = [
+ "alloy-consensus",
+ "alloy-genesis",
+ "alloy-primitives",
+ "bytes",
+ "derive_more",
+ "metrics",
+ "modular-bitfield",
+ "parity-scale-codec",
+ "reth-codecs 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-db-models 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-ethereum-primitives 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-prune-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-stages-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-storage-errors 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-trie-common 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "roaring",
+ "serde",
 ]
 
 [[package]]
@@ -6250,14 +6353,14 @@ dependencies = [
  "metrics",
  "modular-bitfield",
  "parity-scale-codec",
- "reth-codecs",
- "reth-db-models",
- "reth-ethereum-primitives",
- "reth-primitives-traits",
- "reth-prune-types",
- "reth-stages-types",
- "reth-storage-errors",
- "reth-trie-common",
+ "reth-codecs 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
+ "reth-db-models 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
+ "reth-ethereum-primitives 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
+ "reth-prune-types 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
+ "reth-stages-types 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
+ "reth-storage-errors 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
+ "reth-trie-common 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
  "roaring",
  "serde",
 ]
@@ -6265,7 +6368,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -6273,22 +6376,36 @@ dependencies = [
  "boyer-moore-magiclen",
  "eyre",
  "reth-chainspec",
- "reth-codecs",
+ "reth-codecs 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-config",
- "reth-db-api",
+ "reth-db-api 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-etl",
  "reth-fs-util",
  "reth-node-types",
- "reth-primitives-traits",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-provider",
- "reth-stages-types",
- "reth-static-file-types",
- "reth-trie",
- "reth-trie-db",
+ "reth-stages-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-static-file-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-trie 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-trie-db 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
  "tracing",
+]
+
+[[package]]
+name = "reth-db-models"
+version = "1.4.8"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+dependencies = [
+ "alloy-eips",
+ "alloy-primitives",
+ "bytes",
+ "modular-bitfield",
+ "reth-codecs 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "serde",
 ]
 
 [[package]]
@@ -6300,15 +6417,15 @@ dependencies = [
  "alloy-primitives",
  "bytes",
  "modular-bitfield",
- "reth-codecs",
- "reth-primitives-traits",
+ "reth-codecs 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
  "serde",
 ]
 
 [[package]]
 name = "reth-discv4"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -6334,7 +6451,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -6358,7 +6475,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -6382,7 +6499,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6399,7 +6516,7 @@ dependencies = [
  "reth-metrics",
  "reth-network-p2p",
  "reth-network-peers",
- "reth-primitives-traits",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-storage-api",
  "reth-tasks",
  "thiserror 2.0.12",
@@ -6412,7 +6529,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -6443,7 +6560,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -6465,7 +6582,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6475,13 +6592,13 @@ dependencies = [
  "futures",
  "reth-chain-state",
  "reth-errors",
- "reth-ethereum-primitives",
+ "reth-ethereum-primitives 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-execution-types",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
- "reth-primitives-traits",
- "reth-trie",
- "reth-trie-common",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-trie 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-trie-common 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "serde",
  "thiserror 2.0.12",
  "tokio",
@@ -6490,7 +6607,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-service"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "futures",
  "pin-project",
@@ -6498,7 +6615,7 @@ dependencies = [
  "reth-consensus",
  "reth-engine-primitives",
  "reth-engine-tree",
- "reth-ethereum-primitives",
+ "reth-ethereum-primitives 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-evm",
  "reth-network-p2p",
  "reth-node-types",
@@ -6513,11 +6630,11 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm",
+ "alloy-evm 0.11.0",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-engine",
@@ -6533,22 +6650,22 @@ dependencies = [
  "reth-db",
  "reth-engine-primitives",
  "reth-errors",
- "reth-ethereum-primitives",
+ "reth-ethereum-primitives 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-evm",
  "reth-metrics",
  "reth-network-p2p",
  "reth-payload-builder",
  "reth-payload-primitives",
- "reth-primitives-traits",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-provider",
  "reth-prune",
  "reth-revm",
  "reth-stages-api",
  "reth-tasks",
- "reth-trie",
- "reth-trie-db",
+ "reth-trie 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-trie-db 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-trie-parallel",
- "reth-trie-sparse",
+ "reth-trie-sparse 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "revm",
  "revm-primitives",
  "schnellru",
@@ -6560,7 +6677,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -6574,7 +6691,7 @@ dependencies = [
  "reth-evm",
  "reth-fs-util",
  "reth-payload-primitives",
- "reth-primitives-traits",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-revm",
  "reth-storage-api",
  "serde",
@@ -6587,7 +6704,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6595,7 +6712,7 @@ dependencies = [
  "alloy-rlp",
  "ethereum_ssz",
  "ethereum_ssz_derive",
- "reth-ethereum-primitives",
+ "reth-ethereum-primitives 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "snap",
  "thiserror 2.0.12",
 ]
@@ -6603,7 +6720,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -6618,18 +6735,19 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-primitives",
  "eyre",
  "futures-util",
- "reth-db-api",
+ "reth-db-api 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-era",
  "reth-era-downloader",
  "reth-etl",
  "reth-fs-util",
- "reth-primitives-traits",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-provider",
+ "reth-stages-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-storage-api",
  "tokio",
  "tracing",
@@ -6638,18 +6756,18 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "reth-consensus",
- "reth-execution-errors",
- "reth-storage-errors",
+ "reth-execution-errors 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-storage-errors 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "reth-eth-wire"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -6658,13 +6776,13 @@ dependencies = [
  "derive_more",
  "futures",
  "pin-project",
- "reth-codecs",
+ "reth-codecs 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-ecies",
  "reth-eth-wire-types",
  "reth-ethereum-forks",
  "reth-metrics",
  "reth-network-peers",
- "reth-primitives-traits",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "serde",
  "snap",
  "thiserror 2.0.12",
@@ -6677,7 +6795,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -6688,9 +6806,9 @@ dependencies = [
  "bytes",
  "derive_more",
  "reth-chainspec",
- "reth-codecs-derive",
- "reth-ethereum-primitives",
- "reth-primitives-traits",
+ "reth-codecs-derive 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-ethereum-primitives 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "serde",
  "thiserror 2.0.12",
 ]
@@ -6698,7 +6816,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6718,11 +6836,11 @@ dependencies = [
  "reth-config",
  "reth-consensus",
  "reth-db",
- "reth-db-api",
+ "reth-db-api 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-downloaders",
  "reth-errors",
  "reth-ethereum-payload-builder",
- "reth-ethereum-primitives",
+ "reth-ethereum-primitives 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-evm",
  "reth-execution-types",
  "reth-exex",
@@ -6737,7 +6855,7 @@ dependencies = [
  "reth-node-events",
  "reth-node-metrics",
  "reth-payload-builder",
- "reth-primitives-traits",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-provider",
  "reth-prune",
  "reth-revm",
@@ -6746,8 +6864,8 @@ dependencies = [
  "reth-tasks",
  "reth-tracing",
  "reth-transaction-pool",
- "reth-trie",
- "reth-trie-db",
+ "reth-trie 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-trie-db 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "serde_json",
  "similar-asserts",
  "tokio",
@@ -6757,7 +6875,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6766,23 +6884,23 @@ dependencies = [
  "reth-consensus",
  "reth-consensus-common",
  "reth-execution-types",
- "reth-primitives-traits",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "tracing",
 ]
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-engine",
  "reth-engine-primitives",
- "reth-ethereum-primitives",
+ "reth-ethereum-primitives 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-payload-primitives",
- "reth-primitives-traits",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "serde",
  "sha2 0.10.9",
  "thiserror 2.0.12",
@@ -6791,7 +6909,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -6804,7 +6922,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6813,19 +6931,36 @@ dependencies = [
  "reth-basic-payload-builder",
  "reth-chainspec",
  "reth-errors",
- "reth-ethereum-primitives",
+ "reth-ethereum-primitives 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-evm",
  "reth-evm-ethereum",
  "reth-payload-builder",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
  "reth-payload-validator",
- "reth-primitives-traits",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-revm",
  "reth-storage-api",
  "reth-transaction-pool",
  "revm",
  "tracing",
+]
+
+[[package]]
+name = "reth-ethereum-primitives"
+version = "1.4.8"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "modular-bitfield",
+ "reth-codecs 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-zstd-compressors 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "serde",
+ "serde_with",
 ]
 
 [[package]]
@@ -6838,9 +6973,9 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "modular-bitfield",
- "reth-codecs",
- "reth-primitives-traits",
- "reth-zstd-compressors",
+ "reth-codecs 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
+ "reth-zstd-compressors 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
  "serde",
  "serde_with",
 ]
@@ -6848,53 +6983,66 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "rayon",
- "reth-db-api",
+ "reth-db-api 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "tempfile",
 ]
 
 [[package]]
 name = "reth-evm"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm",
+ "alloy-evm 0.11.0",
  "alloy-primitives",
  "auto_impl",
  "derive_more",
  "futures-util",
  "metrics",
- "reth-execution-errors",
+ "reth-execution-errors 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-execution-types",
  "reth-metrics",
- "reth-primitives-traits",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-storage-api",
- "reth-storage-errors",
- "reth-trie-common",
+ "reth-storage-errors 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-trie-common 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "revm",
 ]
 
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm",
+ "alloy-evm 0.11.0",
  "alloy-primitives",
  "derive_more",
  "reth-chainspec",
  "reth-ethereum-forks",
- "reth-ethereum-primitives",
+ "reth-ethereum-primitives 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-evm",
  "reth-execution-types",
- "reth-primitives-traits",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "revm",
+]
+
+[[package]]
+name = "reth-execution-errors"
+version = "1.4.8"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+dependencies = [
+ "alloy-evm 0.11.0",
+ "alloy-primitives",
+ "alloy-rlp",
+ "nybbles",
+ "reth-storage-errors 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -6902,27 +7050,27 @@ name = "reth-execution-errors"
 version = "1.4.8"
 source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
 dependencies = [
- "alloy-evm",
+ "alloy-evm 0.10.0",
  "alloy-primitives",
  "alloy-rlp",
  "nybbles",
- "reth-storage-errors",
+ "reth-storage-errors 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
  "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "reth-execution-types"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm",
+ "alloy-evm 0.11.0",
  "alloy-primitives",
  "derive_more",
- "reth-ethereum-primitives",
- "reth-primitives-traits",
- "reth-trie-common",
+ "reth-ethereum-primitives 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-trie-common 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "revm",
  "serde",
  "serde_with",
@@ -6931,7 +7079,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6944,7 +7092,7 @@ dependencies = [
  "reth-chain-state",
  "reth-chainspec",
  "reth-config",
- "reth-ethereum-primitives",
+ "reth-ethereum-primitives 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-evm",
  "reth-exex-types",
  "reth-fs-util",
@@ -6952,9 +7100,9 @@ dependencies = [
  "reth-node-api",
  "reth-node-core",
  "reth-payload-builder",
- "reth-primitives-traits",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-provider",
- "reth-prune-types",
+ "reth-prune-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-revm",
  "reth-stages-api",
  "reth-tasks",
@@ -6969,13 +7117,13 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "reth-chain-state",
  "reth-execution-types",
- "reth-primitives-traits",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "serde",
  "serde_with",
 ]
@@ -6983,7 +7131,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "serde",
  "serde_json",
@@ -6993,7 +7141,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7006,12 +7154,12 @@ dependencies = [
  "reth-chainspec",
  "reth-engine-primitives",
  "reth-evm",
- "reth-primitives-traits",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-provider",
  "reth-revm",
  "reth-rpc-api",
  "reth-tracing",
- "reth-trie",
+ "reth-trie 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "revm-bytecode",
  "revm-database",
  "serde",
@@ -7021,7 +7169,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "bytes",
  "futures",
@@ -7041,7 +7189,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "bitflags 2.9.1",
  "byteorder",
@@ -7058,7 +7206,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "bindgen",
  "cc",
@@ -7067,7 +7215,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "futures",
  "metrics",
@@ -7079,7 +7227,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-primitives",
 ]
@@ -7087,7 +7235,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -7101,7 +7249,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7128,7 +7276,7 @@ dependencies = [
  "reth-eth-wire",
  "reth-eth-wire-types",
  "reth-ethereum-forks",
- "reth-ethereum-primitives",
+ "reth-ethereum-primitives 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-fs-util",
  "reth-metrics",
  "reth-net-banlist",
@@ -7136,7 +7284,7 @@ dependencies = [
  "reth-network-p2p",
  "reth-network-peers",
  "reth-network-types",
- "reth-primitives-traits",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-storage-api",
  "reth-tasks",
  "reth-tokio-util",
@@ -7156,7 +7304,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-admin",
@@ -7179,7 +7327,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7189,11 +7337,11 @@ dependencies = [
  "futures",
  "reth-consensus",
  "reth-eth-wire-types",
- "reth-ethereum-primitives",
+ "reth-ethereum-primitives 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-network-peers",
  "reth-network-types",
- "reth-primitives-traits",
- "reth-storage-errors",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-storage-errors 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "tokio",
  "tracing",
 ]
@@ -7201,7 +7349,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7216,7 +7364,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -7230,7 +7378,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "anyhow",
  "bincode",
@@ -7247,13 +7395,13 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
  "reth-basic-payload-builder",
  "reth-consensus",
- "reth-db-api",
+ "reth-db-api 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-engine-primitives",
  "reth-evm",
  "reth-network-api",
@@ -7271,7 +7419,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7292,7 +7440,7 @@ dependencies = [
  "reth-config",
  "reth-consensus",
  "reth-consensus-debug-client",
- "reth-db-api",
+ "reth-db-api 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-db-common",
  "reth-downloaders",
  "reth-engine-local",
@@ -7335,7 +7483,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7361,14 +7509,14 @@ dependencies = [
  "reth-network",
  "reth-network-p2p",
  "reth-network-peers",
- "reth-primitives-traits",
- "reth-prune-types",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-prune-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-rpc-eth-types",
  "reth-rpc-server-types",
  "reth-rpc-types-compat",
- "reth-stages-types",
+ "reth-stages-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-storage-api",
- "reth-storage-errors",
+ "reth-storage-errors 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-tracing",
  "reth-transaction-pool",
  "secp256k1",
@@ -7386,7 +7534,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-eips",
  "alloy-rpc-types-engine",
@@ -7398,14 +7546,14 @@ dependencies = [
  "reth-ethereum-consensus",
  "reth-ethereum-engine-primitives",
  "reth-ethereum-payload-builder",
- "reth-ethereum-primitives",
+ "reth-ethereum-primitives 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-evm",
  "reth-evm-ethereum",
  "reth-network",
  "reth-node-api",
  "reth-node-builder",
  "reth-payload-primitives",
- "reth-primitives-traits",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-provider",
  "reth-revm",
  "reth-rpc",
@@ -7415,14 +7563,14 @@ dependencies = [
  "reth-rpc-server-types",
  "reth-tracing",
  "reth-transaction-pool",
- "reth-trie-db",
+ "reth-trie-db 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "revm",
 ]
 
 [[package]]
 name = "reth-node-events"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7434,10 +7582,10 @@ dependencies = [
  "pin-project",
  "reth-engine-primitives",
  "reth-network-api",
- "reth-primitives-traits",
- "reth-prune-types",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-prune-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-stages",
- "reth-static-file-types",
+ "reth-static-file-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-storage-api",
  "tokio",
  "tracing",
@@ -7446,7 +7594,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "eyre",
  "http",
@@ -7467,29 +7615,29 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "reth-chainspec",
- "reth-db-api",
+ "reth-db-api 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-engine-primitives",
  "reth-payload-primitives",
- "reth-primitives-traits",
- "reth-trie-db",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-trie-db 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
 ]
 
 [[package]]
 name = "reth-optimism-primitives"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "bytes",
- "op-alloy-consensus",
- "reth-codecs",
- "reth-primitives-traits",
+ "op-alloy-consensus 0.18.6",
+ "reth-codecs 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "serde",
  "serde_with",
 ]
@@ -7497,7 +7645,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types",
@@ -7508,7 +7656,7 @@ dependencies = [
  "reth-metrics",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
- "reth-primitives-traits",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -7517,7 +7665,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -7529,7 +7677,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7539,7 +7687,7 @@ dependencies = [
  "reth-chain-state",
  "reth-chainspec",
  "reth-errors",
- "reth-primitives-traits",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "serde",
  "thiserror 2.0.12",
  "tokio",
@@ -7548,24 +7696,54 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
- "reth-primitives-traits",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
 ]
 
 [[package]]
 name = "reth-primitives"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-consensus",
  "once_cell",
  "reth-ethereum-forks",
- "reth-ethereum-primitives",
- "reth-primitives-traits",
- "reth-static-file-types",
+ "reth-ethereum-primitives 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-static-file-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+]
+
+[[package]]
+name = "reth-primitives-traits"
+version = "1.4.8"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-genesis",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-rpc-types-eth",
+ "alloy-trie",
+ "auto_impl",
+ "byteorder",
+ "bytes",
+ "derive_more",
+ "modular-bitfield",
+ "once_cell",
+ "op-alloy-consensus 0.18.6",
+ "rayon",
+ "reth-codecs 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "revm-bytecode",
+ "revm-primitives",
+ "revm-state",
+ "secp256k1",
+ "serde",
+ "serde_with",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -7585,9 +7763,8 @@ dependencies = [
  "derive_more",
  "modular-bitfield",
  "once_cell",
- "op-alloy-consensus",
- "rayon",
- "reth-codecs",
+ "op-alloy-consensus 0.17.2",
+ "reth-codecs 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
  "revm-bytecode",
  "revm-primitives",
  "revm-state",
@@ -7600,7 +7777,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7615,25 +7792,25 @@ dependencies = [
  "rayon",
  "reth-chain-state",
  "reth-chainspec",
- "reth-codecs",
+ "reth-codecs 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-db",
- "reth-db-api",
+ "reth-db-api 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-errors",
- "reth-ethereum-primitives",
+ "reth-ethereum-primitives 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-evm",
  "reth-execution-types",
  "reth-fs-util",
  "reth-metrics",
  "reth-nippy-jar",
  "reth-node-types",
- "reth-primitives-traits",
- "reth-prune-types",
- "reth-stages-types",
- "reth-static-file-types",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-prune-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-stages-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-static-file-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-storage-api",
- "reth-storage-errors",
- "reth-trie",
- "reth-trie-db",
+ "reth-storage-errors 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-trie 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-trie-db 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "revm-database",
  "strum 0.27.1",
  "tracing",
@@ -7642,7 +7819,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7652,14 +7829,14 @@ dependencies = [
  "rayon",
  "reth-chainspec",
  "reth-config",
- "reth-db-api",
+ "reth-db-api 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-errors",
  "reth-exex-types",
  "reth-metrics",
- "reth-primitives-traits",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-provider",
- "reth-prune-types",
- "reth-static-file-types",
+ "reth-prune-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-static-file-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-tokio-util",
  "rustc-hash 2.1.1",
  "thiserror 2.0.12",
@@ -7670,12 +7847,25 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.4.8"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+dependencies = [
+ "alloy-primitives",
+ "derive_more",
+ "modular-bitfield",
+ "reth-codecs 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "serde",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "reth-prune-types"
+version = "1.4.8"
 source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
 dependencies = [
  "alloy-primitives",
  "derive_more",
  "modular-bitfield",
- "reth-codecs",
+ "reth-codecs 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
  "serde",
  "thiserror 2.0.12",
 ]
@@ -7683,17 +7873,17 @@ dependencies = [
 [[package]]
 name = "reth-ress-protocol"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "alloy-rlp",
  "futures",
  "reth-eth-wire",
- "reth-ethereum-primitives",
+ "reth-ethereum-primitives 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-network",
  "reth-network-api",
- "reth-storage-errors",
+ "reth-storage-errors 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -7702,7 +7892,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-provider"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7711,16 +7901,16 @@ dependencies = [
  "parking_lot",
  "reth-chain-state",
  "reth-errors",
- "reth-ethereum-primitives",
+ "reth-ethereum-primitives 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-evm",
  "reth-node-api",
- "reth-primitives-traits",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-ress-protocol",
  "reth-revm",
  "reth-storage-api",
  "reth-tasks",
  "reth-tokio-util",
- "reth-trie",
+ "reth-trie 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "schnellru",
  "tokio",
  "tracing",
@@ -7729,25 +7919,25 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-primitives",
- "reth-primitives-traits",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-storage-api",
- "reth-storage-errors",
- "reth-trie",
+ "reth-storage-errors 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-trie 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "revm",
 ]
 
 [[package]]
 name = "reth-rpc"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
  "alloy-eips",
- "alloy-evm",
+ "alloy-evm 0.11.0",
  "alloy-genesis",
  "alloy-network",
  "alloy-primitives",
@@ -7780,7 +7970,7 @@ dependencies = [
  "reth-consensus",
  "reth-engine-primitives",
  "reth-errors",
- "reth-ethereum-primitives",
+ "reth-ethereum-primitives 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-evm",
  "reth-evm-ethereum",
  "reth-execution-types",
@@ -7789,7 +7979,7 @@ dependencies = [
  "reth-network-peers",
  "reth-network-types",
  "reth-node-api",
- "reth-primitives-traits",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-revm",
  "reth-rpc-api",
  "reth-rpc-engine-api",
@@ -7800,7 +7990,7 @@ dependencies = [
  "reth-storage-api",
  "reth-tasks",
  "reth-transaction-pool",
- "reth-trie-common",
+ "reth-trie-common 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "revm",
  "revm-inspectors",
  "revm-primitives",
@@ -7818,7 +8008,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -7840,13 +8030,13 @@ dependencies = [
  "reth-engine-primitives",
  "reth-network-peers",
  "reth-rpc-eth-api",
- "reth-trie-common",
+ "reth-trie-common 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
 ]
 
 [[package]]
 name = "reth-rpc-builder"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -7862,7 +8052,7 @@ dependencies = [
  "reth-metrics",
  "reth-network-api",
  "reth-node-core",
- "reth-primitives-traits",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-rpc",
  "reth-rpc-api",
  "reth-rpc-eth-api",
@@ -7884,7 +8074,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7900,7 +8090,7 @@ dependencies = [
  "reth-payload-builder",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
- "reth-primitives-traits",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-rpc-api",
  "reth-storage-api",
  "reth-tasks",
@@ -7914,7 +8104,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -7933,13 +8123,14 @@ dependencies = [
  "jsonrpsee",
  "jsonrpsee-types",
  "parking_lot",
+ "reth-chain-state",
  "reth-chainspec",
  "reth-errors",
  "reth-evm",
  "reth-network-api",
  "reth-node-api",
  "reth-payload-builder",
- "reth-primitives-traits",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-revm",
  "reth-rpc-eth-types",
  "reth-rpc-server-types",
@@ -7947,7 +8138,7 @@ dependencies = [
  "reth-storage-api",
  "reth-tasks",
  "reth-transaction-pool",
- "reth-trie-common",
+ "reth-trie-common 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "revm",
  "revm-inspectors",
  "tokio",
@@ -7957,7 +8148,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7974,18 +8165,18 @@ dependencies = [
  "reth-chain-state",
  "reth-chainspec",
  "reth-errors",
- "reth-ethereum-primitives",
+ "reth-ethereum-primitives 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-evm",
  "reth-execution-types",
  "reth-metrics",
- "reth-primitives-traits",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-revm",
  "reth-rpc-server-types",
  "reth-rpc-types-compat",
  "reth-storage-api",
  "reth-tasks",
  "reth-transaction-pool",
- "reth-trie",
+ "reth-trie 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "revm",
  "revm-inspectors",
  "schnellru",
@@ -7999,7 +8190,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -8013,7 +8204,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8029,19 +8220,19 @@ dependencies = [
 [[package]]
 name = "reth-rpc-types-compat"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
  "alloy-primitives",
  "alloy-rpc-types-eth",
  "jsonrpsee-types",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.18.6",
  "op-alloy-rpc-types",
  "op-revm",
  "reth-evm",
  "reth-optimism-primitives",
- "reth-primitives-traits",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-storage-api",
  "revm-context",
  "serde",
@@ -8051,7 +8242,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8064,11 +8255,11 @@ dependencies = [
  "num-traits",
  "rayon",
  "reqwest",
- "reth-codecs",
+ "reth-codecs 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-config",
  "reth-consensus",
  "reth-db",
- "reth-db-api",
+ "reth-db-api 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-era",
  "reth-era-downloader",
  "reth-era-utils",
@@ -8078,16 +8269,16 @@ dependencies = [
  "reth-exex",
  "reth-fs-util",
  "reth-network-p2p",
- "reth-primitives-traits",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-provider",
  "reth-prune",
- "reth-prune-types",
+ "reth-prune-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-revm",
  "reth-stages-api",
- "reth-static-file-types",
- "reth-storage-errors",
- "reth-trie",
- "reth-trie-db",
+ "reth-static-file-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-storage-errors 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-trie 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-trie-db 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "serde",
  "thiserror 2.0.12",
  "tokio",
@@ -8097,7 +8288,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8109,16 +8300,29 @@ dependencies = [
  "reth-errors",
  "reth-metrics",
  "reth-network-p2p",
- "reth-primitives-traits",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-provider",
  "reth-prune",
- "reth-stages-types",
+ "reth-stages-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-static-file",
- "reth-static-file-types",
+ "reth-static-file-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-tokio-util",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "reth-stages-types"
+version = "1.4.8"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+dependencies = [
+ "alloy-primitives",
+ "bytes",
+ "modular-bitfield",
+ "reth-codecs 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-trie-common 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "serde",
 ]
 
 [[package]]
@@ -8129,27 +8333,27 @@ dependencies = [
  "alloy-primitives",
  "bytes",
  "modular-bitfield",
- "reth-codecs",
- "reth-trie-common",
+ "reth-codecs 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
+ "reth-trie-common 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
  "serde",
 ]
 
 [[package]]
 name = "reth-static-file"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
  "rayon",
- "reth-codecs",
- "reth-db-api",
- "reth-primitives-traits",
+ "reth-codecs 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-db-api 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-provider",
- "reth-prune-types",
- "reth-stages-types",
- "reth-static-file-types",
- "reth-storage-errors",
+ "reth-prune-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-stages-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-static-file-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-storage-errors 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-tokio-util",
  "tracing",
 ]
@@ -8157,7 +8361,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -8167,9 +8371,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-storage-api"
+name = "reth-static-file-types"
 version = "1.4.8"
 source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+dependencies = [
+ "alloy-primitives",
+ "derive_more",
+ "serde",
+ "strum 0.27.1",
+]
+
+[[package]]
+name = "reth-storage-api"
+version = "1.4.8"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8177,17 +8392,33 @@ dependencies = [
  "alloy-rpc-types-engine",
  "auto_impl",
  "reth-chainspec",
- "reth-db-api",
- "reth-db-models",
- "reth-ethereum-primitives",
+ "reth-db-api 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-db-models 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-ethereum-primitives 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-execution-types",
- "reth-primitives-traits",
- "reth-prune-types",
- "reth-stages-types",
- "reth-storage-errors",
- "reth-trie-common",
- "reth-trie-db",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-prune-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-stages-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-storage-errors 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-trie-common 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-trie-db 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "revm-database",
+]
+
+[[package]]
+name = "reth-storage-errors"
+version = "1.4.8"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+dependencies = [
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "derive_more",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-prune-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-static-file-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "revm-database-interface",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -8199,9 +8430,9 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "derive_more",
- "reth-primitives-traits",
- "reth-prune-types",
- "reth-static-file-types",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
+ "reth-prune-types 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
+ "reth-static-file-types 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
  "revm-database-interface",
  "thiserror 2.0.12",
 ]
@@ -8209,7 +8440,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -8227,7 +8458,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -8237,7 +8468,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "clap",
  "eyre",
@@ -8252,7 +8483,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8268,11 +8499,11 @@ dependencies = [
  "reth-chain-state",
  "reth-chainspec",
  "reth-eth-wire-types",
- "reth-ethereum-primitives",
+ "reth-ethereum-primitives 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-execution-types",
  "reth-fs-util",
  "reth-metrics",
- "reth-primitives-traits",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-storage-api",
  "reth-tasks",
  "revm-interpreter",
@@ -8290,7 +8521,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8300,13 +8531,35 @@ dependencies = [
  "auto_impl",
  "itertools 0.14.0",
  "metrics",
- "reth-execution-errors",
+ "reth-execution-errors 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-metrics",
- "reth-primitives-traits",
- "reth-stages-types",
- "reth-storage-errors",
- "reth-trie-common",
- "reth-trie-sparse",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-stages-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-storage-errors 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-trie-common 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-trie-sparse 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "revm-database",
+ "tracing",
+]
+
+[[package]]
+name = "reth-trie"
+version = "1.4.8"
+source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-trie",
+ "auto_impl",
+ "itertools 0.14.0",
+ "reth-execution-errors 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
+ "reth-stages-types 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
+ "reth-storage-errors 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
+ "reth-trie-common 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
+ "reth-trie-sparse 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
  "revm-database",
  "tracing",
 ]
@@ -8314,7 +8567,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8327,11 +8580,45 @@ dependencies = [
  "itertools 0.14.0",
  "nybbles",
  "rayon",
- "reth-codecs",
- "reth-primitives-traits",
+ "reth-codecs 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "revm-database",
  "serde",
  "serde_with",
+]
+
+[[package]]
+name = "reth-trie-common"
+version = "1.4.8"
+source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+dependencies = [
+ "alloy-consensus",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-rpc-types-eth",
+ "alloy-trie",
+ "bytes",
+ "derive_more",
+ "itertools 0.14.0",
+ "nybbles",
+ "rayon",
+ "reth-codecs 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
+ "revm-database",
+ "serde",
+]
+
+[[package]]
+name = "reth-trie-db"
+version = "1.4.8"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+dependencies = [
+ "alloy-primitives",
+ "reth-db-api 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-execution-errors 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-trie 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "tracing",
 ]
 
 [[package]]
@@ -8340,17 +8627,17 @@ version = "1.4.8"
 source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
 dependencies = [
  "alloy-primitives",
- "reth-db-api",
- "reth-execution-errors",
- "reth-primitives-traits",
- "reth-trie",
+ "reth-db-api 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
+ "reth-execution-errors 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
+ "reth-trie 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
  "tracing",
 ]
 
 [[package]]
 name = "reth-trie-parallel"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8358,17 +8645,35 @@ dependencies = [
  "itertools 0.14.0",
  "metrics",
  "rayon",
- "reth-db-api",
- "reth-execution-errors",
+ "reth-db-api 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-execution-errors 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "reth-metrics",
  "reth-provider",
- "reth-storage-errors",
- "reth-trie",
- "reth-trie-common",
- "reth-trie-db",
- "reth-trie-sparse",
+ "reth-storage-errors 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-trie 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-trie-common 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-trie-db 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-trie-sparse 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
  "thiserror 2.0.12",
  "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "reth-trie-sparse"
+version = "1.4.8"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-trie",
+ "auto_impl",
+ "metrics",
+ "reth-execution-errors 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-metrics",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-trie-common 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "smallvec",
  "tracing",
 ]
 
@@ -8381,13 +8686,19 @@ dependencies = [
  "alloy-rlp",
  "alloy-trie",
  "auto_impl",
- "metrics",
- "reth-execution-errors",
- "reth-metrics",
- "reth-primitives-traits",
- "reth-trie-common",
+ "reth-execution-errors 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
+ "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
+ "reth-trie-common 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
  "smallvec",
  "tracing",
+]
+
+[[package]]
+name = "reth-zstd-compressors"
+version = "1.4.8"
+source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+dependencies = [
+ "zstd",
 ]
 
 [[package]]
@@ -8814,9 +9125,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.27"
+version = "0.23.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
+checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
 dependencies = [
  "log",
  "once_cell",
@@ -9961,9 +10272,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1ffbcf9c6f6b99d386e7444eb608ba646ae452a36b39737deb9663b610f662"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10468,9 +10779,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtimer"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0048ad49a55b9deb3953841fa1fc5858f0efbcb7a18868c899a360269fac1b23"
+checksum = "d8d49b5d6c64e8558d9b1b065014426f35c18de636895d24893dbbd329743446"
 dependencies = [
  "futures",
  "js-sys",
@@ -11228,18 +11539,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,23 +226,6 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "394b09cf3a32773eedf11828987f9c72dfa74545040be0422e3f5f09a2a3fab9"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-hardforks",
- "alloy-primitives",
- "alloy-sol-types",
- "auto_impl",
- "derive_more",
- "revm",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "alloy-evm"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ed976ec0c32f8c6d79703e96249d0866b6c444c0a2649c10bfd5203e7e13adf"
@@ -254,7 +237,7 @@ dependencies = [
  "alloy-sol-types",
  "auto_impl",
  "derive_more",
- "op-alloy-consensus 0.18.6",
+ "op-alloy-consensus",
  "op-revm",
  "revm",
  "thiserror 2.0.12",
@@ -1419,7 +1402,6 @@ dependencies = [
  "derive_more",
  "eyre",
  "jsonrpsee-core",
- "log",
  "reth",
  "reth-chainspec",
  "reth-cli",
@@ -1430,12 +1412,9 @@ dependencies = [
  "reth-evm",
  "reth-evm-ethereum",
  "reth-network-peers",
- "reth-node-api",
  "reth-node-builder",
  "reth-node-ethereum",
- "reth-rpc",
  "reth-tracing",
- "reth-trie-db 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
  "serde",
  "thiserror 2.0.12",
  "tracing",
@@ -5054,22 +5033,6 @@ checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "op-alloy-consensus"
-version = "0.17.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2423a125ef2daa0d15dacc361805a0b6f76d6acfc6e24a1ff6473582087fe75"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde",
- "derive_more",
- "serde",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "op-alloy-consensus"
 version = "0.18.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5448a4ef9ef1ee241a67fe533ae3563716bbcd719acbd0544ad1ac9f03cfde6"
@@ -5098,7 +5061,7 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-serde",
  "derive_more",
- "op-alloy-consensus 0.18.6",
+ "op-alloy-consensus",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -5118,7 +5081,7 @@ dependencies = [
  "derive_more",
  "ethereum_ssz",
  "ethereum_ssz_derive",
- "op-alloy-consensus 0.18.6",
+ "op-alloy-consensus",
  "snap",
  "thiserror 2.0.12",
 ]
@@ -5954,7 +5917,7 @@ dependencies = [
  "reth-db",
  "reth-ethereum-cli",
  "reth-ethereum-payload-builder",
- "reth-ethereum-primitives 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-ethereum-primitives",
  "reth-evm",
  "reth-network",
  "reth-network-api",
@@ -5999,7 +5962,7 @@ dependencies = [
  "reth-payload-builder",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-primitives-traits",
  "reth-revm",
  "reth-storage-api",
  "reth-tasks",
@@ -6022,12 +5985,12 @@ dependencies = [
  "rand 0.9.1",
  "reth-chainspec",
  "reth-errors",
- "reth-ethereum-primitives 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-ethereum-primitives",
  "reth-execution-types",
  "reth-metrics",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-primitives-traits",
  "reth-storage-api",
- "reth-trie 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-trie",
  "revm-database",
  "revm-state",
  "serde",
@@ -6044,7 +6007,7 @@ dependencies = [
  "alloy-chains",
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm 0.11.0",
+ "alloy-evm",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-trie",
@@ -6052,7 +6015,7 @@ dependencies = [
  "derive_more",
  "reth-ethereum-forks",
  "reth-network-peers",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-primitives-traits",
  "serde_json",
 ]
 
@@ -6097,11 +6060,11 @@ dependencies = [
  "reth-cli",
  "reth-cli-runner",
  "reth-cli-util",
- "reth-codecs 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-codecs",
  "reth-config",
  "reth-consensus",
  "reth-db",
- "reth-db-api 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-db-api",
  "reth-db-common",
  "reth-discv4",
  "reth-discv5",
@@ -6123,14 +6086,14 @@ dependencies = [
  "reth-node-core",
  "reth-node-events",
  "reth-node-metrics",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-primitives-traits",
  "reth-provider",
  "reth-prune",
  "reth-stages",
  "reth-static-file",
- "reth-static-file-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-trie 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-trie-db 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-static-file-types",
+ "reth-trie",
+ "reth-trie-db",
  "secp256k1",
  "serde",
  "serde_json",
@@ -6181,27 +6144,9 @@ dependencies = [
  "alloy-trie",
  "bytes",
  "modular-bitfield",
- "op-alloy-consensus 0.18.6",
- "reth-codecs-derive 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-zstd-compressors 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "serde",
-]
-
-[[package]]
-name = "reth-codecs"
-version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-genesis",
- "alloy-primitives",
- "alloy-trie",
- "bytes",
- "modular-bitfield",
- "op-alloy-consensus 0.17.2",
- "reth-codecs-derive 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
- "reth-zstd-compressors 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
+ "op-alloy-consensus",
+ "reth-codecs-derive",
+ "reth-zstd-compressors",
  "serde",
 ]
 
@@ -6209,17 +6154,6 @@ dependencies = [
 name = "reth-codecs-derive"
 version = "1.4.8"
 source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
-dependencies = [
- "convert_case",
- "proc-macro2",
- "quote",
- "syn 2.0.103",
-]
-
-[[package]]
-name = "reth-codecs-derive"
-version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -6235,8 +6169,8 @@ dependencies = [
  "eyre",
  "humantime-serde",
  "reth-network-types",
- "reth-prune-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-stages-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-prune-types",
+ "reth-stages-types",
  "serde",
  "toml",
  "url",
@@ -6251,7 +6185,7 @@ dependencies = [
  "alloy-primitives",
  "auto_impl",
  "reth-execution-types",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-primitives-traits",
  "thiserror 2.0.12",
 ]
 
@@ -6264,7 +6198,7 @@ dependencies = [
  "alloy-eips",
  "reth-chainspec",
  "reth-consensus",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-primitives-traits",
 ]
 
 [[package]]
@@ -6284,7 +6218,7 @@ dependencies = [
  "futures",
  "reqwest",
  "reth-node-api",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-primitives-traits",
  "reth-tracing",
  "ringbuffer",
  "serde",
@@ -6301,13 +6235,13 @@ dependencies = [
  "eyre",
  "metrics",
  "page_size",
- "reth-db-api 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-db-api",
  "reth-fs-util",
  "reth-libmdbx",
  "reth-metrics",
  "reth-nippy-jar",
- "reth-static-file-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-storage-errors 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-static-file-types",
+ "reth-storage-errors",
  "reth-tracing",
  "rustc-hash 2.1.1",
  "strum 0.27.1",
@@ -6328,39 +6262,14 @@ dependencies = [
  "metrics",
  "modular-bitfield",
  "parity-scale-codec",
- "reth-codecs 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-db-models 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-ethereum-primitives 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-prune-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-stages-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-storage-errors 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-trie-common 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "roaring",
- "serde",
-]
-
-[[package]]
-name = "reth-db-api"
-version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
-dependencies = [
- "alloy-consensus",
- "alloy-genesis",
- "alloy-primitives",
- "bytes",
- "derive_more",
- "metrics",
- "modular-bitfield",
- "parity-scale-codec",
- "reth-codecs 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
- "reth-db-models 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
- "reth-ethereum-primitives 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
- "reth-prune-types 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
- "reth-stages-types 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
- "reth-storage-errors 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
- "reth-trie-common 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
+ "reth-codecs",
+ "reth-db-models",
+ "reth-ethereum-primitives",
+ "reth-primitives-traits",
+ "reth-prune-types",
+ "reth-stages-types",
+ "reth-storage-errors",
+ "reth-trie-common",
  "roaring",
  "serde",
 ]
@@ -6376,18 +6285,18 @@ dependencies = [
  "boyer-moore-magiclen",
  "eyre",
  "reth-chainspec",
- "reth-codecs 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-codecs",
  "reth-config",
- "reth-db-api 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-db-api",
  "reth-etl",
  "reth-fs-util",
  "reth-node-types",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-primitives-traits",
  "reth-provider",
- "reth-stages-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-static-file-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-trie 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-trie-db 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-stages-types",
+ "reth-static-file-types",
+ "reth-trie",
+ "reth-trie-db",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -6403,22 +6312,8 @@ dependencies = [
  "alloy-primitives",
  "bytes",
  "modular-bitfield",
- "reth-codecs 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "serde",
-]
-
-[[package]]
-name = "reth-db-models"
-version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
-dependencies = [
- "alloy-eips",
- "alloy-primitives",
- "bytes",
- "modular-bitfield",
- "reth-codecs 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
+ "reth-codecs",
+ "reth-primitives-traits",
  "serde",
 ]
 
@@ -6516,7 +6411,7 @@ dependencies = [
  "reth-metrics",
  "reth-network-p2p",
  "reth-network-peers",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-primitives-traits",
  "reth-storage-api",
  "reth-tasks",
  "thiserror 2.0.12",
@@ -6592,13 +6487,13 @@ dependencies = [
  "futures",
  "reth-chain-state",
  "reth-errors",
- "reth-ethereum-primitives 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-ethereum-primitives",
  "reth-execution-types",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-trie 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-trie-common 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-primitives-traits",
+ "reth-trie",
+ "reth-trie-common",
  "serde",
  "thiserror 2.0.12",
  "tokio",
@@ -6615,7 +6510,7 @@ dependencies = [
  "reth-consensus",
  "reth-engine-primitives",
  "reth-engine-tree",
- "reth-ethereum-primitives 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-ethereum-primitives",
  "reth-evm",
  "reth-network-p2p",
  "reth-node-types",
@@ -6634,7 +6529,7 @@ source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-r
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm 0.11.0",
+ "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-engine",
@@ -6650,22 +6545,22 @@ dependencies = [
  "reth-db",
  "reth-engine-primitives",
  "reth-errors",
- "reth-ethereum-primitives 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-ethereum-primitives",
  "reth-evm",
  "reth-metrics",
  "reth-network-p2p",
  "reth-payload-builder",
  "reth-payload-primitives",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-primitives-traits",
  "reth-provider",
  "reth-prune",
  "reth-revm",
  "reth-stages-api",
  "reth-tasks",
- "reth-trie 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-trie-db 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-trie",
+ "reth-trie-db",
  "reth-trie-parallel",
- "reth-trie-sparse 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-trie-sparse",
  "revm",
  "revm-primitives",
  "schnellru",
@@ -6691,7 +6586,7 @@ dependencies = [
  "reth-evm",
  "reth-fs-util",
  "reth-payload-primitives",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-primitives-traits",
  "reth-revm",
  "reth-storage-api",
  "serde",
@@ -6712,7 +6607,7 @@ dependencies = [
  "alloy-rlp",
  "ethereum_ssz",
  "ethereum_ssz_derive",
- "reth-ethereum-primitives 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-ethereum-primitives",
  "snap",
  "thiserror 2.0.12",
 ]
@@ -6740,14 +6635,14 @@ dependencies = [
  "alloy-primitives",
  "eyre",
  "futures-util",
- "reth-db-api 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-db-api",
  "reth-era",
  "reth-era-downloader",
  "reth-etl",
  "reth-fs-util",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-primitives-traits",
  "reth-provider",
- "reth-stages-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-stages-types",
  "reth-storage-api",
  "tokio",
  "tracing",
@@ -6759,8 +6654,8 @@ version = "1.4.8"
 source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "reth-consensus",
- "reth-execution-errors 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-storage-errors 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-execution-errors",
+ "reth-storage-errors",
  "thiserror 2.0.12",
 ]
 
@@ -6776,13 +6671,13 @@ dependencies = [
  "derive_more",
  "futures",
  "pin-project",
- "reth-codecs 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-codecs",
  "reth-ecies",
  "reth-eth-wire-types",
  "reth-ethereum-forks",
  "reth-metrics",
  "reth-network-peers",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-primitives-traits",
  "serde",
  "snap",
  "thiserror 2.0.12",
@@ -6806,9 +6701,9 @@ dependencies = [
  "bytes",
  "derive_more",
  "reth-chainspec",
- "reth-codecs-derive 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-ethereum-primitives 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-codecs-derive",
+ "reth-ethereum-primitives",
+ "reth-primitives-traits",
  "serde",
  "thiserror 2.0.12",
 ]
@@ -6836,11 +6731,11 @@ dependencies = [
  "reth-config",
  "reth-consensus",
  "reth-db",
- "reth-db-api 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-db-api",
  "reth-downloaders",
  "reth-errors",
  "reth-ethereum-payload-builder",
- "reth-ethereum-primitives 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-ethereum-primitives",
  "reth-evm",
  "reth-execution-types",
  "reth-exex",
@@ -6855,7 +6750,7 @@ dependencies = [
  "reth-node-events",
  "reth-node-metrics",
  "reth-payload-builder",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-primitives-traits",
  "reth-provider",
  "reth-prune",
  "reth-revm",
@@ -6864,8 +6759,8 @@ dependencies = [
  "reth-tasks",
  "reth-tracing",
  "reth-transaction-pool",
- "reth-trie 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-trie-db 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-trie",
+ "reth-trie-db",
  "serde_json",
  "similar-asserts",
  "tokio",
@@ -6884,7 +6779,7 @@ dependencies = [
  "reth-consensus",
  "reth-consensus-common",
  "reth-execution-types",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-primitives-traits",
  "tracing",
 ]
 
@@ -6898,9 +6793,9 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types-engine",
  "reth-engine-primitives",
- "reth-ethereum-primitives 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-ethereum-primitives",
  "reth-payload-primitives",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-primitives-traits",
  "serde",
  "sha2 0.10.9",
  "thiserror 2.0.12",
@@ -6931,14 +6826,14 @@ dependencies = [
  "reth-basic-payload-builder",
  "reth-chainspec",
  "reth-errors",
- "reth-ethereum-primitives 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-ethereum-primitives",
  "reth-evm",
  "reth-evm-ethereum",
  "reth-payload-builder",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
  "reth-payload-validator",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-primitives-traits",
  "reth-revm",
  "reth-storage-api",
  "reth-transaction-pool",
@@ -6956,26 +6851,9 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "modular-bitfield",
- "reth-codecs 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-zstd-compressors 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "serde",
- "serde_with",
-]
-
-[[package]]
-name = "reth-ethereum-primitives"
-version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "modular-bitfield",
- "reth-codecs 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
- "reth-zstd-compressors 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
+ "reth-codecs",
+ "reth-primitives-traits",
+ "reth-zstd-compressors",
  "serde",
  "serde_with",
 ]
@@ -6986,7 +6864,7 @@ version = "1.4.8"
 source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "rayon",
- "reth-db-api 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-db-api",
  "tempfile",
 ]
 
@@ -6997,19 +6875,19 @@ source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-r
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm 0.11.0",
+ "alloy-evm",
  "alloy-primitives",
  "auto_impl",
  "derive_more",
  "futures-util",
  "metrics",
- "reth-execution-errors 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-execution-errors",
  "reth-execution-types",
  "reth-metrics",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-primitives-traits",
  "reth-storage-api",
- "reth-storage-errors 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-trie-common 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-storage-errors",
+ "reth-trie-common",
  "revm",
 ]
 
@@ -7020,15 +6898,15 @@ source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-r
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm 0.11.0",
+ "alloy-evm",
  "alloy-primitives",
  "derive_more",
  "reth-chainspec",
  "reth-ethereum-forks",
- "reth-ethereum-primitives 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-ethereum-primitives",
  "reth-evm",
  "reth-execution-types",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-primitives-traits",
  "revm",
 ]
 
@@ -7037,24 +6915,11 @@ name = "reth-execution-errors"
 version = "1.4.8"
 source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
- "alloy-evm 0.11.0",
+ "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
  "nybbles",
- "reth-storage-errors 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "reth-execution-errors"
-version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
-dependencies = [
- "alloy-evm 0.10.0",
- "alloy-primitives",
- "alloy-rlp",
- "nybbles",
- "reth-storage-errors 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
+ "reth-storage-errors",
  "thiserror 2.0.12",
 ]
 
@@ -7065,12 +6930,12 @@ source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-r
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm 0.11.0",
+ "alloy-evm",
  "alloy-primitives",
  "derive_more",
- "reth-ethereum-primitives 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-trie-common 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-ethereum-primitives",
+ "reth-primitives-traits",
+ "reth-trie-common",
  "revm",
  "serde",
  "serde_with",
@@ -7092,7 +6957,7 @@ dependencies = [
  "reth-chain-state",
  "reth-chainspec",
  "reth-config",
- "reth-ethereum-primitives 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-ethereum-primitives",
  "reth-evm",
  "reth-exex-types",
  "reth-fs-util",
@@ -7100,9 +6965,9 @@ dependencies = [
  "reth-node-api",
  "reth-node-core",
  "reth-payload-builder",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-primitives-traits",
  "reth-provider",
- "reth-prune-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-prune-types",
  "reth-revm",
  "reth-stages-api",
  "reth-tasks",
@@ -7123,7 +6988,7 @@ dependencies = [
  "alloy-primitives",
  "reth-chain-state",
  "reth-execution-types",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-primitives-traits",
  "serde",
  "serde_with",
 ]
@@ -7154,12 +7019,12 @@ dependencies = [
  "reth-chainspec",
  "reth-engine-primitives",
  "reth-evm",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-primitives-traits",
  "reth-provider",
  "reth-revm",
  "reth-rpc-api",
  "reth-tracing",
- "reth-trie 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-trie",
  "revm-bytecode",
  "revm-database",
  "serde",
@@ -7276,7 +7141,7 @@ dependencies = [
  "reth-eth-wire",
  "reth-eth-wire-types",
  "reth-ethereum-forks",
- "reth-ethereum-primitives 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-ethereum-primitives",
  "reth-fs-util",
  "reth-metrics",
  "reth-net-banlist",
@@ -7284,7 +7149,7 @@ dependencies = [
  "reth-network-p2p",
  "reth-network-peers",
  "reth-network-types",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-primitives-traits",
  "reth-storage-api",
  "reth-tasks",
  "reth-tokio-util",
@@ -7337,11 +7202,11 @@ dependencies = [
  "futures",
  "reth-consensus",
  "reth-eth-wire-types",
- "reth-ethereum-primitives 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-ethereum-primitives",
  "reth-network-peers",
  "reth-network-types",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-storage-errors 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-primitives-traits",
+ "reth-storage-errors",
  "tokio",
  "tracing",
 ]
@@ -7401,7 +7266,7 @@ dependencies = [
  "eyre",
  "reth-basic-payload-builder",
  "reth-consensus",
- "reth-db-api 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-db-api",
  "reth-engine-primitives",
  "reth-evm",
  "reth-network-api",
@@ -7440,7 +7305,7 @@ dependencies = [
  "reth-config",
  "reth-consensus",
  "reth-consensus-debug-client",
- "reth-db-api 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-db-api",
  "reth-db-common",
  "reth-downloaders",
  "reth-engine-local",
@@ -7509,14 +7374,14 @@ dependencies = [
  "reth-network",
  "reth-network-p2p",
  "reth-network-peers",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-prune-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-primitives-traits",
+ "reth-prune-types",
  "reth-rpc-eth-types",
  "reth-rpc-server-types",
  "reth-rpc-types-compat",
- "reth-stages-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-stages-types",
  "reth-storage-api",
- "reth-storage-errors 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-storage-errors",
  "reth-tracing",
  "reth-transaction-pool",
  "secp256k1",
@@ -7546,14 +7411,14 @@ dependencies = [
  "reth-ethereum-consensus",
  "reth-ethereum-engine-primitives",
  "reth-ethereum-payload-builder",
- "reth-ethereum-primitives 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-ethereum-primitives",
  "reth-evm",
  "reth-evm-ethereum",
  "reth-network",
  "reth-node-api",
  "reth-node-builder",
  "reth-payload-primitives",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-primitives-traits",
  "reth-provider",
  "reth-revm",
  "reth-rpc",
@@ -7563,7 +7428,7 @@ dependencies = [
  "reth-rpc-server-types",
  "reth-tracing",
  "reth-transaction-pool",
- "reth-trie-db 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-trie-db",
  "revm",
 ]
 
@@ -7582,10 +7447,10 @@ dependencies = [
  "pin-project",
  "reth-engine-primitives",
  "reth-network-api",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-prune-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-primitives-traits",
+ "reth-prune-types",
  "reth-stages",
- "reth-static-file-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-static-file-types",
  "reth-storage-api",
  "tokio",
  "tracing",
@@ -7618,11 +7483,11 @@ version = "1.4.8"
 source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "reth-chainspec",
- "reth-db-api 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-db-api",
  "reth-engine-primitives",
  "reth-payload-primitives",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-trie-db 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-primitives-traits",
+ "reth-trie-db",
 ]
 
 [[package]]
@@ -7635,9 +7500,9 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "bytes",
- "op-alloy-consensus 0.18.6",
- "reth-codecs 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "op-alloy-consensus",
+ "reth-codecs",
+ "reth-primitives-traits",
  "serde",
  "serde_with",
 ]
@@ -7656,7 +7521,7 @@ dependencies = [
  "reth-metrics",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-primitives-traits",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -7687,7 +7552,7 @@ dependencies = [
  "reth-chain-state",
  "reth-chainspec",
  "reth-errors",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-primitives-traits",
  "serde",
  "thiserror 2.0.12",
  "tokio",
@@ -7700,7 +7565,7 @@ source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-r
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-primitives-traits",
 ]
 
 [[package]]
@@ -7711,9 +7576,9 @@ dependencies = [
  "alloy-consensus",
  "once_cell",
  "reth-ethereum-forks",
- "reth-ethereum-primitives 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-static-file-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-ethereum-primitives",
+ "reth-primitives-traits",
+ "reth-static-file-types",
 ]
 
 [[package]]
@@ -7734,37 +7599,9 @@ dependencies = [
  "derive_more",
  "modular-bitfield",
  "once_cell",
- "op-alloy-consensus 0.18.6",
+ "op-alloy-consensus",
  "rayon",
- "reth-codecs 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "revm-bytecode",
- "revm-primitives",
- "revm-state",
- "secp256k1",
- "serde",
- "serde_with",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "reth-primitives-traits"
-version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-genesis",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-trie",
- "auto_impl",
- "byteorder",
- "bytes",
- "derive_more",
- "modular-bitfield",
- "once_cell",
- "op-alloy-consensus 0.17.2",
- "reth-codecs 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
+ "reth-codecs",
  "revm-bytecode",
  "revm-primitives",
  "revm-state",
@@ -7792,25 +7629,25 @@ dependencies = [
  "rayon",
  "reth-chain-state",
  "reth-chainspec",
- "reth-codecs 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-codecs",
  "reth-db",
- "reth-db-api 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-db-api",
  "reth-errors",
- "reth-ethereum-primitives 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-ethereum-primitives",
  "reth-evm",
  "reth-execution-types",
  "reth-fs-util",
  "reth-metrics",
  "reth-nippy-jar",
  "reth-node-types",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-prune-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-stages-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-static-file-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-primitives-traits",
+ "reth-prune-types",
+ "reth-stages-types",
+ "reth-static-file-types",
  "reth-storage-api",
- "reth-storage-errors 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-trie 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-trie-db 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-storage-errors",
+ "reth-trie",
+ "reth-trie-db",
  "revm-database",
  "strum 0.27.1",
  "tracing",
@@ -7829,14 +7666,14 @@ dependencies = [
  "rayon",
  "reth-chainspec",
  "reth-config",
- "reth-db-api 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-db-api",
  "reth-errors",
  "reth-exex-types",
  "reth-metrics",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-primitives-traits",
  "reth-provider",
- "reth-prune-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-static-file-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-prune-types",
+ "reth-static-file-types",
  "reth-tokio-util",
  "rustc-hash 2.1.1",
  "thiserror 2.0.12",
@@ -7852,20 +7689,7 @@ dependencies = [
  "alloy-primitives",
  "derive_more",
  "modular-bitfield",
- "reth-codecs 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "serde",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "reth-prune-types"
-version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
-dependencies = [
- "alloy-primitives",
- "derive_more",
- "modular-bitfield",
- "reth-codecs 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
+ "reth-codecs",
  "serde",
  "thiserror 2.0.12",
 ]
@@ -7880,10 +7704,10 @@ dependencies = [
  "alloy-rlp",
  "futures",
  "reth-eth-wire",
- "reth-ethereum-primitives 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-ethereum-primitives",
  "reth-network",
  "reth-network-api",
- "reth-storage-errors 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-storage-errors",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -7901,16 +7725,16 @@ dependencies = [
  "parking_lot",
  "reth-chain-state",
  "reth-errors",
- "reth-ethereum-primitives 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-ethereum-primitives",
  "reth-evm",
  "reth-node-api",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-primitives-traits",
  "reth-ress-protocol",
  "reth-revm",
  "reth-storage-api",
  "reth-tasks",
  "reth-tokio-util",
- "reth-trie 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-trie",
  "schnellru",
  "tokio",
  "tracing",
@@ -7922,10 +7746,10 @@ version = "1.4.8"
 source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-primitives",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-primitives-traits",
  "reth-storage-api",
- "reth-storage-errors 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-trie 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-storage-errors",
+ "reth-trie",
  "revm",
 ]
 
@@ -7937,7 +7761,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
  "alloy-eips",
- "alloy-evm 0.11.0",
+ "alloy-evm",
  "alloy-genesis",
  "alloy-network",
  "alloy-primitives",
@@ -7970,7 +7794,7 @@ dependencies = [
  "reth-consensus",
  "reth-engine-primitives",
  "reth-errors",
- "reth-ethereum-primitives 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-ethereum-primitives",
  "reth-evm",
  "reth-evm-ethereum",
  "reth-execution-types",
@@ -7979,7 +7803,7 @@ dependencies = [
  "reth-network-peers",
  "reth-network-types",
  "reth-node-api",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-primitives-traits",
  "reth-revm",
  "reth-rpc-api",
  "reth-rpc-engine-api",
@@ -7990,7 +7814,7 @@ dependencies = [
  "reth-storage-api",
  "reth-tasks",
  "reth-transaction-pool",
- "reth-trie-common 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-trie-common",
  "revm",
  "revm-inspectors",
  "revm-primitives",
@@ -8030,7 +7854,7 @@ dependencies = [
  "reth-engine-primitives",
  "reth-network-peers",
  "reth-rpc-eth-api",
- "reth-trie-common 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-trie-common",
 ]
 
 [[package]]
@@ -8052,7 +7876,7 @@ dependencies = [
  "reth-metrics",
  "reth-network-api",
  "reth-node-core",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-primitives-traits",
  "reth-rpc",
  "reth-rpc-api",
  "reth-rpc-eth-api",
@@ -8090,7 +7914,7 @@ dependencies = [
  "reth-payload-builder",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-primitives-traits",
  "reth-rpc-api",
  "reth-storage-api",
  "reth-tasks",
@@ -8130,7 +7954,7 @@ dependencies = [
  "reth-network-api",
  "reth-node-api",
  "reth-payload-builder",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-primitives-traits",
  "reth-revm",
  "reth-rpc-eth-types",
  "reth-rpc-server-types",
@@ -8138,7 +7962,7 @@ dependencies = [
  "reth-storage-api",
  "reth-tasks",
  "reth-transaction-pool",
- "reth-trie-common 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-trie-common",
  "revm",
  "revm-inspectors",
  "tokio",
@@ -8165,18 +7989,18 @@ dependencies = [
  "reth-chain-state",
  "reth-chainspec",
  "reth-errors",
- "reth-ethereum-primitives 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-ethereum-primitives",
  "reth-evm",
  "reth-execution-types",
  "reth-metrics",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-primitives-traits",
  "reth-revm",
  "reth-rpc-server-types",
  "reth-rpc-types-compat",
  "reth-storage-api",
  "reth-tasks",
  "reth-transaction-pool",
- "reth-trie 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-trie",
  "revm",
  "revm-inspectors",
  "schnellru",
@@ -8227,12 +8051,12 @@ dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
  "jsonrpsee-types",
- "op-alloy-consensus 0.18.6",
+ "op-alloy-consensus",
  "op-alloy-rpc-types",
  "op-revm",
  "reth-evm",
  "reth-optimism-primitives",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-primitives-traits",
  "reth-storage-api",
  "revm-context",
  "serde",
@@ -8255,11 +8079,11 @@ dependencies = [
  "num-traits",
  "rayon",
  "reqwest",
- "reth-codecs 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-codecs",
  "reth-config",
  "reth-consensus",
  "reth-db",
- "reth-db-api 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-db-api",
  "reth-era",
  "reth-era-downloader",
  "reth-era-utils",
@@ -8269,16 +8093,16 @@ dependencies = [
  "reth-exex",
  "reth-fs-util",
  "reth-network-p2p",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-primitives-traits",
  "reth-provider",
  "reth-prune",
- "reth-prune-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-prune-types",
  "reth-revm",
  "reth-stages-api",
- "reth-static-file-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-storage-errors 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-trie 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-trie-db 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-static-file-types",
+ "reth-storage-errors",
+ "reth-trie",
+ "reth-trie-db",
  "serde",
  "thiserror 2.0.12",
  "tokio",
@@ -8300,12 +8124,12 @@ dependencies = [
  "reth-errors",
  "reth-metrics",
  "reth-network-p2p",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-primitives-traits",
  "reth-provider",
  "reth-prune",
- "reth-stages-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-stages-types",
  "reth-static-file",
- "reth-static-file-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-static-file-types",
  "reth-tokio-util",
  "thiserror 2.0.12",
  "tokio",
@@ -8320,21 +8144,8 @@ dependencies = [
  "alloy-primitives",
  "bytes",
  "modular-bitfield",
- "reth-codecs 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-trie-common 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "serde",
-]
-
-[[package]]
-name = "reth-stages-types"
-version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
-dependencies = [
- "alloy-primitives",
- "bytes",
- "modular-bitfield",
- "reth-codecs 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
- "reth-trie-common 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
+ "reth-codecs",
+ "reth-trie-common",
  "serde",
 ]
 
@@ -8346,14 +8157,14 @@ dependencies = [
  "alloy-primitives",
  "parking_lot",
  "rayon",
- "reth-codecs 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-db-api 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-codecs",
+ "reth-db-api",
+ "reth-primitives-traits",
  "reth-provider",
- "reth-prune-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-stages-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-static-file-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-storage-errors 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-prune-types",
+ "reth-stages-types",
+ "reth-static-file-types",
+ "reth-storage-errors",
  "reth-tokio-util",
  "tracing",
 ]
@@ -8371,17 +8182,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-static-file-types"
-version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
-dependencies = [
- "alloy-primitives",
- "derive_more",
- "serde",
- "strum 0.27.1",
-]
-
-[[package]]
 name = "reth-storage-api"
 version = "1.4.8"
 source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
@@ -8392,16 +8192,16 @@ dependencies = [
  "alloy-rpc-types-engine",
  "auto_impl",
  "reth-chainspec",
- "reth-db-api 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-db-models 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-ethereum-primitives 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-db-api",
+ "reth-db-models",
+ "reth-ethereum-primitives",
  "reth-execution-types",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-prune-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-stages-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-storage-errors 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-trie-common 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-trie-db 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-primitives-traits",
+ "reth-prune-types",
+ "reth-stages-types",
+ "reth-storage-errors",
+ "reth-trie-common",
+ "reth-trie-db",
  "revm-database",
 ]
 
@@ -8414,25 +8214,9 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "derive_more",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-prune-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-static-file-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "revm-database-interface",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "reth-storage-errors"
-version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
-dependencies = [
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "derive_more",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
- "reth-prune-types 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
- "reth-static-file-types 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
+ "reth-primitives-traits",
+ "reth-prune-types",
+ "reth-static-file-types",
  "revm-database-interface",
  "thiserror 2.0.12",
 ]
@@ -8499,11 +8283,11 @@ dependencies = [
  "reth-chain-state",
  "reth-chainspec",
  "reth-eth-wire-types",
- "reth-ethereum-primitives 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-ethereum-primitives",
  "reth-execution-types",
  "reth-fs-util",
  "reth-metrics",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-primitives-traits",
  "reth-storage-api",
  "reth-tasks",
  "revm-interpreter",
@@ -8531,35 +8315,13 @@ dependencies = [
  "auto_impl",
  "itertools 0.14.0",
  "metrics",
- "reth-execution-errors 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-execution-errors",
  "reth-metrics",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-stages-types 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-storage-errors 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-trie-common 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-trie-sparse 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "revm-database",
- "tracing",
-]
-
-[[package]]
-name = "reth-trie"
-version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-trie",
- "auto_impl",
- "itertools 0.14.0",
- "reth-execution-errors 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
- "reth-stages-types 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
- "reth-storage-errors 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
- "reth-trie-common 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
- "reth-trie-sparse 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
+ "reth-primitives-traits",
+ "reth-stages-types",
+ "reth-storage-errors",
+ "reth-trie-common",
+ "reth-trie-sparse",
  "revm-database",
  "tracing",
 ]
@@ -8580,32 +8342,11 @@ dependencies = [
  "itertools 0.14.0",
  "nybbles",
  "rayon",
- "reth-codecs 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-codecs",
+ "reth-primitives-traits",
  "revm-database",
  "serde",
  "serde_with",
-]
-
-[[package]]
-name = "reth-trie-common"
-version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
-dependencies = [
- "alloy-consensus",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-rpc-types-eth",
- "alloy-trie",
- "bytes",
- "derive_more",
- "itertools 0.14.0",
- "nybbles",
- "rayon",
- "reth-codecs 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
- "revm-database",
- "serde",
 ]
 
 [[package]]
@@ -8614,23 +8355,10 @@ version = "1.4.8"
 source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
 dependencies = [
  "alloy-primitives",
- "reth-db-api 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-execution-errors 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-trie 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "tracing",
-]
-
-[[package]]
-name = "reth-trie-db"
-version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
-dependencies = [
- "alloy-primitives",
- "reth-db-api 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
- "reth-execution-errors 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
- "reth-trie 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
+ "reth-db-api",
+ "reth-execution-errors",
+ "reth-primitives-traits",
+ "reth-trie",
  "tracing",
 ]
 
@@ -8645,15 +8373,15 @@ dependencies = [
  "itertools 0.14.0",
  "metrics",
  "rayon",
- "reth-db-api 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-execution-errors 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-db-api",
+ "reth-execution-errors",
  "reth-metrics",
  "reth-provider",
- "reth-storage-errors 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-trie 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-trie-common 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-trie-db 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-trie-sparse 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-storage-errors",
+ "reth-trie",
+ "reth-trie-common",
+ "reth-trie-db",
+ "reth-trie-sparse",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -8669,26 +8397,10 @@ dependencies = [
  "alloy-trie",
  "auto_impl",
  "metrics",
- "reth-execution-errors 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
+ "reth-execution-errors",
  "reth-metrics",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "reth-trie-common 1.4.8 (git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose)",
- "smallvec",
- "tracing",
-]
-
-[[package]]
-name = "reth-trie-sparse"
-version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
-dependencies = [
- "alloy-primitives",
- "alloy-rlp",
- "alloy-trie",
- "auto_impl",
- "reth-execution-errors 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
- "reth-primitives-traits 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
- "reth-trie-common 1.4.8 (git+https://github.com/rezbera/reth?branch=with-rose)",
+ "reth-primitives-traits",
+ "reth-trie-common",
  "smallvec",
  "tracing",
 ]
@@ -8697,14 +8409,6 @@ dependencies = [
 name = "reth-zstd-compressors"
 version = "1.4.8"
 source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
-dependencies = [
- "zstd",
-]
-
-[[package]]
-name = "reth-zstd-compressors"
-version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=with-rose#bcee34e20931a53389c3e38f6827b13f104f824c"
 dependencies = [
  "zstd",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ clap = { version = "4.5.39", features = ["derive"] }
 derive_more = "2.0.1"
 eyre = "0.6"
 jsonrpsee-core = "0.25.1"
-log = "0.4.27"
 reth = { git = "https://github.com/rezbera/reth", branch = "basefee/centralize-with-rose" }
 reth-chainspec = { git = "https://github.com/rezbera/reth", branch = "basefee/centralize-with-rose" }
 reth-cli = { git = "https://github.com/rezbera/reth", branch = "basefee/centralize-with-rose" }
@@ -24,12 +23,9 @@ reth-ethereum-cli = { git = "https://github.com/rezbera/reth", branch = "basefee
 reth-evm = { git = "https://github.com/rezbera/reth", branch = "basefee/centralize-with-rose" }
 reth-evm-ethereum = { git = "https://github.com/rezbera/reth", branch = "basefee/centralize-with-rose" }
 reth-network-peers = { git = "https://github.com/rezbera/reth", branch = "basefee/centralize-with-rose" }
-reth-node-api = { git = "https://github.com/rezbera/reth", branch = "basefee/centralize-with-rose" }
 reth-node-builder = { git = "https://github.com/rezbera/reth", branch = "basefee/centralize-with-rose" }
 reth-node-ethereum = { git = "https://github.com/rezbera/reth", branch = "basefee/centralize-with-rose" }
-reth-rpc = { git = "https://github.com/rezbera/reth", branch = "basefee/centralize-with-rose" }
 reth-tracing = { git = "https://github.com/rezbera/reth", branch = "basefee/centralize-with-rose" }
-reth-trie-db = { git = "https://github.com/rezbera/reth", branch = "with-rose" }
 serde = { version = "1.0", features = ["derive"], default-features = false }
 thiserror = "2.0"
 tracing = "0.1.41"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,21 +14,21 @@ derive_more = "2.0.1"
 eyre = "0.6"
 jsonrpsee-core = "0.25.1"
 log = "0.4.27"
-reth = { git = "https://github.com/rezbera/reth", branch = "with-rose" }
-reth-chainspec = { git = "https://github.com/rezbera/reth", branch = "with-rose" }
-reth-cli = { git = "https://github.com/rezbera/reth", branch = "with-rose" }
-reth-cli-commands = { git = "https://github.com/rezbera/reth", branch = "with-rose" }
-reth-cli-util = { git = "https://github.com/rezbera/reth", branch = "with-rose" }
-reth-db = { git = "https://github.com/rezbera/reth", branch = "with-rose" }
-reth-ethereum-cli = { git = "https://github.com/rezbera/reth", branch = "with-rose" }
-reth-evm = { git = "https://github.com/rezbera/reth", branch = "with-rose" }
-reth-evm-ethereum = { git = "https://github.com/rezbera/reth", branch = "with-rose" }
-reth-network-peers = { git = "https://github.com/rezbera/reth", branch = "with-rose" }
-reth-node-api = { git = "https://github.com/rezbera/reth", branch = "with-rose" }
-reth-node-builder = { git = "https://github.com/rezbera/reth", branch = "with-rose" }
-reth-node-ethereum = { git = "https://github.com/rezbera/reth", branch = "with-rose" }
-reth-rpc = { git = "https://github.com/rezbera/reth", branch = "with-rose" }
-reth-tracing = { git = "https://github.com/rezbera/reth", branch = "with-rose" }
+reth = { git = "https://github.com/rezbera/reth", branch = "basefee/centralize-with-rose" }
+reth-chainspec = { git = "https://github.com/rezbera/reth", branch = "basefee/centralize-with-rose" }
+reth-cli = { git = "https://github.com/rezbera/reth", branch = "basefee/centralize-with-rose" }
+reth-cli-commands = { git = "https://github.com/rezbera/reth", branch = "basefee/centralize-with-rose" }
+reth-cli-util = { git = "https://github.com/rezbera/reth", branch = "basefee/centralize-with-rose" }
+reth-db = { git = "https://github.com/rezbera/reth", branch = "basefee/centralize-with-rose" }
+reth-ethereum-cli = { git = "https://github.com/rezbera/reth", branch = "basefee/centralize-with-rose" }
+reth-evm = { git = "https://github.com/rezbera/reth", branch = "basefee/centralize-with-rose" }
+reth-evm-ethereum = { git = "https://github.com/rezbera/reth", branch = "basefee/centralize-with-rose" }
+reth-network-peers = { git = "https://github.com/rezbera/reth", branch = "basefee/centralize-with-rose" }
+reth-node-api = { git = "https://github.com/rezbera/reth", branch = "basefee/centralize-with-rose" }
+reth-node-builder = { git = "https://github.com/rezbera/reth", branch = "basefee/centralize-with-rose" }
+reth-node-ethereum = { git = "https://github.com/rezbera/reth", branch = "basefee/centralize-with-rose" }
+reth-rpc = { git = "https://github.com/rezbera/reth", branch = "basefee/centralize-with-rose" }
+reth-tracing = { git = "https://github.com/rezbera/reth", branch = "basefee/centralize-with-rose" }
 reth-trie-db = { git = "https://github.com/rezbera/reth", branch = "with-rose" }
 serde = { version = "1.0", features = ["derive"], default-features = false }
 thiserror = "2.0"


### PR DESCRIPTION
## Summary
- Updates reth dependencies to use the latest basefee/centralize-with-rose branch
- Removes unused dependencies to reduce build complexity
- Adapts code to match updated API signatures

## Changes
- Updated chainspec import from `alloy_evm` to `alloy::evm` following upstream reorganization
- Added missing timestamp parameter to `next_block_base_fee` method calls
- Removed 4 unused dependencies: `log`, `reth-node-api`, `reth-rpc`, and `reth-trie-db`
- Ran `cargo update` to resolve version conflicts and consolidate duplicate dependencies

## Test plan
- [x] Run `make pr` to ensure all quality checks pass
- [x] Verify tests pass with `cargo test`
- [ ] Run integration test with BeaconKit locally