### PR TITLE
feat: update reth dependencies to berachain/reth prague1-berachain-reth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,8 +111,7 @@ dependencies = [
 [[package]]
 name = "alloy-consensus"
 version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bcb57295c4b632b6b3941a089ee82d00ff31ff9eb3eac801bf605ffddc81041"
+source = "git+https://github.com/alloy-rs/alloy?rev=08fa016ed950b6e65f810fc9cdef7cf38fbc63f6#08fa016ed950b6e65f810fc9cdef7cf38fbc63f6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -127,7 +126,7 @@ dependencies = [
  "k256",
  "once_cell",
  "rand 0.8.5",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde",
  "serde_with",
  "thiserror 2.0.12",
@@ -136,8 +135,7 @@ dependencies = [
 [[package]]
 name = "alloy-consensus-any"
 version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab669be40024565acb719daf1b2a050e6dc065fc0bec6050d97a81cdb860bd7"
+source = "git+https://github.com/alloy-rs/alloy?rev=08fa016ed950b6e65f810fc9cdef7cf38fbc63f6#08fa016ed950b6e65f810fc9cdef7cf38fbc63f6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -149,9 +147,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9135eb501feccf7f4cb8a183afd406a65483fdad7bbd7332d0470e5d725c92f"
+checksum = "7b95b3deca680efc7e9cba781f1a1db352fa1ea50e6384a514944dcf4419e652"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -205,8 +203,7 @@ dependencies = [
 [[package]]
 name = "alloy-eips"
 version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f853de9ca1819f54de80de5d03bfc1bb7c9fafcf092b480a654447141bc354d"
+source = "git+https://github.com/alloy-rs/alloy?rev=08fa016ed950b6e65f810fc9cdef7cf38fbc63f6#08fa016ed950b6e65f810fc9cdef7cf38fbc63f6"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -226,14 +223,15 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.11.0"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ed976ec0c32f8c6d79703e96249d0866b6c444c0a2649c10bfd5203e7e13adf"
+checksum = "ff5aae4c6dc600734b206b175f3200085ee82dcdaa388760358830a984ca9869"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-hardforks",
  "alloy-primitives",
+ "alloy-rpc-types-eth",
  "alloy-sol-types",
  "auto_impl",
  "derive_more",
@@ -246,8 +244,7 @@ dependencies = [
 [[package]]
 name = "alloy-genesis"
 version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8500bcc1037901953771c25cb77e0d4ec0bffd938d93a04715390230d21a612d"
+source = "git+https://github.com/alloy-rs/alloy?rev=08fa016ed950b6e65f810fc9cdef7cf38fbc63f6#08fa016ed950b6e65f810fc9cdef7cf38fbc63f6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -272,9 +269,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b26fdd571915bafe857fccba4ee1a4f352965800e46a53e4a5f50187b7776fa"
+checksum = "15516116086325c157c18261d768a20677f0f699348000ed391d4ad0dcb82530"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -285,8 +282,7 @@ dependencies = [
 [[package]]
 name = "alloy-json-rpc"
 version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4997a9873c8639d079490f218e50e5fa07e70f957e9fc187c0a0535977f482f"
+source = "git+https://github.com/alloy-rs/alloy?rev=08fa016ed950b6e65f810fc9cdef7cf38fbc63f6#08fa016ed950b6e65f810fc9cdef7cf38fbc63f6"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -300,8 +296,7 @@ dependencies = [
 [[package]]
 name = "alloy-network"
 version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0306e8d148b7b94d988615d367443c1b9d6d2e9fecd2e1f187ac5153dce56f5"
+source = "git+https://github.com/alloy-rs/alloy?rev=08fa016ed950b6e65f810fc9cdef7cf38fbc63f6#08fa016ed950b6e65f810fc9cdef7cf38fbc63f6"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -326,8 +321,7 @@ dependencies = [
 [[package]]
 name = "alloy-network-primitives"
 version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eef189583f4c53d231dd1297b28a675ff842b551fb34715f562868a1937431a"
+source = "git+https://github.com/alloy-rs/alloy?rev=08fa016ed950b6e65f810fc9cdef7cf38fbc63f6#08fa016ed950b6e65f810fc9cdef7cf38fbc63f6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -338,9 +332,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a326d47106039f38b811057215a92139f46eef7983a4b77b10930a0ea5685b1e"
+checksum = "6177ed26655d4e84e00b65cb494d4e0b8830e7cae7ef5d63087d445a2600fb55"
 dependencies = [
  "alloy-rlp",
  "bytes",
@@ -367,8 +361,7 @@ dependencies = [
 [[package]]
 name = "alloy-provider"
 version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea624ddcdad357c33652b86aa7df9bd21afd2080973389d3facf1a221c573948"
+source = "git+https://github.com/alloy-rs/alloy?rev=08fa016ed950b6e65f810fc9cdef7cf38fbc63f6#08fa016ed950b6e65f810fc9cdef7cf38fbc63f6"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -410,8 +403,7 @@ dependencies = [
 [[package]]
 name = "alloy-pubsub"
 version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ea3227fa5f627d22b7781e88bc2fe79ba1792d5535b4161bc8fc99cdcd8bedd"
+source = "git+https://github.com/alloy-rs/alloy?rev=08fa016ed950b6e65f810fc9cdef7cf38fbc63f6#08fa016ed950b6e65f810fc9cdef7cf38fbc63f6"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -447,14 +439,13 @@ checksum = "64b728d511962dda67c1bc7ea7c03736ec275ed2cf4c35d9585298ac9ccf3b73"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "alloy-rpc-client"
 version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e43d00b4de38432304c4e4b01ae6a3601490fd9824c852329d158763ec18663c"
+source = "git+https://github.com/alloy-rs/alloy?rev=08fa016ed950b6e65f810fc9cdef7cf38fbc63f6#08fa016ed950b6e65f810fc9cdef7cf38fbc63f6"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -481,8 +472,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types"
 version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bf22ddb69a436f28bbdda7daf34fe011ee9926fa13bfce89fa023aca9ce2b2f"
+source = "git+https://github.com/alloy-rs/alloy?rev=08fa016ed950b6e65f810fc9cdef7cf38fbc63f6#08fa016ed950b6e65f810fc9cdef7cf38fbc63f6"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -494,8 +484,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-admin"
 version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fa84dd9d9465d6d3718e91b017d42498ec51a702d9712ebce64c2b0b7ed9383"
+source = "git+https://github.com/alloy-rs/alloy?rev=08fa016ed950b6e65f810fc9cdef7cf38fbc63f6#08fa016ed950b6e65f810fc9cdef7cf38fbc63f6"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -506,8 +495,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-anvil"
 version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ecd1c60085d8cbc3562e16e264a3cd68f42e54dc16b0d40645e5e42841bc042"
+source = "git+https://github.com/alloy-rs/alloy?rev=08fa016ed950b6e65f810fc9cdef7cf38fbc63f6#08fa016ed950b6e65f810fc9cdef7cf38fbc63f6"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -518,8 +506,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-any"
 version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5958f2310d69f4806e6f6b90ceb4f2b781cc5a843517a7afe2e7cfec6de3cfb9"
+source = "git+https://github.com/alloy-rs/alloy?rev=08fa016ed950b6e65f810fc9cdef7cf38fbc63f6#08fa016ed950b6e65f810fc9cdef7cf38fbc63f6"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -529,8 +516,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-beacon"
 version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83868430cddb02bb952d858f125b824ddbc74dde0fb4cdc5c345c732d66936b"
+source = "git+https://github.com/alloy-rs/alloy?rev=08fa016ed950b6e65f810fc9cdef7cf38fbc63f6#08fa016ed950b6e65f810fc9cdef7cf38fbc63f6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -547,8 +533,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-debug"
 version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c293df0c58d15330e65599f776e30945ea078c93b1594e5c4ba0efaad3f0a739"
+source = "git+https://github.com/alloy-rs/alloy?rev=08fa016ed950b6e65f810fc9cdef7cf38fbc63f6#08fa016ed950b6e65f810fc9cdef7cf38fbc63f6"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -557,8 +542,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-engine"
 version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5b09d86d0c015cb8400c5d1d0483425670bef4fc1260336aea9ef6d4b9540c"
+source = "git+https://github.com/alloy-rs/alloy?rev=08fa016ed950b6e65f810fc9cdef7cf38fbc63f6#08fa016ed950b6e65f810fc9cdef7cf38fbc63f6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -577,8 +561,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-eth"
 version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1826285e4ffc2372a8c061d5cc145858e67a0be3309b768c5b77ddb6b9e6cbc7"
+source = "git+https://github.com/alloy-rs/alloy?rev=08fa016ed950b6e65f810fc9cdef7cf38fbc63f6#08fa016ed950b6e65f810fc9cdef7cf38fbc63f6"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -588,7 +571,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -597,8 +580,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-mev"
 version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b94fb27232aac9ee5785bee2ebfc3f9c6384a890a658737263c861c203165355"
+source = "git+https://github.com/alloy-rs/alloy?rev=08fa016ed950b6e65f810fc9cdef7cf38fbc63f6#08fa016ed950b6e65f810fc9cdef7cf38fbc63f6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -612,8 +594,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-trace"
 version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1e8f7fa774a1d6f7b3654686f68955631e55f687e03da39c0bd77a9418d57a1"
+source = "git+https://github.com/alloy-rs/alloy?rev=08fa016ed950b6e65f810fc9cdef7cf38fbc63f6#08fa016ed950b6e65f810fc9cdef7cf38fbc63f6"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -626,8 +607,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-txpool"
 version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39d9218a0fd802dbccd7e0ce601a6bdefb61190386e97a437d97a31661cd358"
+source = "git+https://github.com/alloy-rs/alloy?rev=08fa016ed950b6e65f810fc9cdef7cf38fbc63f6#08fa016ed950b6e65f810fc9cdef7cf38fbc63f6"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -638,8 +618,7 @@ dependencies = [
 [[package]]
 name = "alloy-serde"
 version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "906ce0190afeded19cb2e963cb8507c975a7862216b9e74f39bf91ddee6ae74b"
+source = "git+https://github.com/alloy-rs/alloy?rev=08fa016ed950b6e65f810fc9cdef7cf38fbc63f6#08fa016ed950b6e65f810fc9cdef7cf38fbc63f6"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -649,8 +628,7 @@ dependencies = [
 [[package]]
 name = "alloy-signer"
 version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89baab06195c4be9c5d66f15c55e948013d1aff3ec1cfb0ed469e1423313fce"
+source = "git+https://github.com/alloy-rs/alloy?rev=08fa016ed950b6e65f810fc9cdef7cf38fbc63f6#08fa016ed950b6e65f810fc9cdef7cf38fbc63f6"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -664,8 +642,7 @@ dependencies = [
 [[package]]
 name = "alloy-signer-local"
 version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a249a923e302ac6db932567c43945392f0b6832518aab3c4274858f58756774"
+source = "git+https://github.com/alloy-rs/alloy?rev=08fa016ed950b6e65f810fc9cdef7cf38fbc63f6#08fa016ed950b6e65f810fc9cdef7cf38fbc63f6"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -679,23 +656,23 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4be1ce1274ddd7fdfac86e5ece1b225e9bba1f2327e20fbb30ee6b9cc1423fe"
+checksum = "a14f21d053aea4c6630687c2f4ad614bed4c81e14737a9b904798b24f30ea849"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01e92f3708ea4e0d9139001c86c051c538af0146944a2a9c7181753bd944bf57"
+checksum = "34d99282e7c9ef14eb62727981a985a01869e586d1dec729d3bb33679094c100"
 dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
@@ -704,16 +681,16 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
  "syn-solidity",
  "tiny-keccak",
 ]
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afe1bd348a41f8c9b4b54dfb314886786d6201235b0b3f47198b9d910c86bb2"
+checksum = "eda029f955b78e493360ee1d7bd11e1ab9f2a220a5715449babc79d6d0a01105"
 dependencies = [
  "const-hex",
  "dunce",
@@ -721,15 +698,15 @@ dependencies = [
  "macro-string",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
  "syn-solidity",
 ]
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6195df2acd42df92a380a8db6205a5c7b41282d0ce3f4c665ecf7911ac292f1"
+checksum = "10db1bd7baa35bc8d4a1b07efbf734e73e5ba09f2580fb8cee3483a36087ceb2"
 dependencies = [
  "serde",
  "winnow",
@@ -737,9 +714,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6185e98a79cf19010722f48a74b5a65d153631d2f038cabd250f4b9e9813b8ad"
+checksum = "58377025a47d8b8426b3e4846a251f2c1991033b27f517aade368146f6ab1dfe"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -750,8 +727,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport"
 version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d1ae10b1bc77fde38161e242749e41e65e34000d05da0a3d3f631e03bfcb19e"
+source = "git+https://github.com/alloy-rs/alloy?rev=08fa016ed950b6e65f810fc9cdef7cf38fbc63f6#08fa016ed950b6e65f810fc9cdef7cf38fbc63f6"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -773,8 +749,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-http"
 version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b234272ee449e32c9f1afbbe4ee08ea7c4b52f14479518f95c844ab66163c545"
+source = "git+https://github.com/alloy-rs/alloy?rev=08fa016ed950b6e65f810fc9cdef7cf38fbc63f6#08fa016ed950b6e65f810fc9cdef7cf38fbc63f6"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -788,8 +763,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-ipc"
 version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061672d736144eb5aae13ca67cfec8e5e69a65bef818cb1a2ab2345d55c50ab4"
+source = "git+https://github.com/alloy-rs/alloy?rev=08fa016ed950b6e65f810fc9cdef7cf38fbc63f6#08fa016ed950b6e65f810fc9cdef7cf38fbc63f6"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -808,8 +782,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-ws"
 version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b01f10382c2aea797d710279b24687a1e9e09a09ecd145f84f636f2a8a3fcc"
+source = "git+https://github.com/alloy-rs/alloy?rev=08fa016ed950b6e65f810fc9cdef7cf38fbc63f6#08fa016ed950b6e65f810fc9cdef7cf38fbc63f6"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -825,9 +798,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-trie"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "983d99aa81f586cef9dae38443245e585840fcf0fc58b09aee0b1f27aed1d500"
+checksum = "bada1fc392a33665de0dc50d401a3701b62583c655e3522a323490a5da016962"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -842,14 +815,13 @@ dependencies = [
 [[package]]
 name = "alloy-tx-macros"
 version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b75ef8609ea2b31c799b0a56c724dca4c73105c5ccc205d9dfeb1d038df6a1da"
+source = "git+https://github.com/alloy-rs/alloy?rev=08fa016ed950b6e65f810fc9cdef7cf38fbc63f6#08fa016ed950b6e65f810fc9cdef7cf38fbc63f6"
 dependencies = [
  "alloy-primitives",
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -934,7 +906,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1067,7 +1039,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
 dependencies = [
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1105,7 +1077,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1194,7 +1166,7 @@ checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1283,7 +1255,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1294,7 +1266,7 @@ checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1332,7 +1304,7 @@ checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1340,6 +1312,12 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "az"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
 
 [[package]]
 name = "backon"
@@ -1450,7 +1428,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1661,7 +1639,7 @@ checksum = "9fd3f870829131332587f607a7ff909f1af5fc523fd1b192db55fbbdf52e8d3c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
  "synstructure",
 ]
 
@@ -1755,9 +1733,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.18.1"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "byte-slice-cast"
@@ -1788,7 +1766,7 @@ checksum = "7ecc273b49b3205b83d648f0690daa588925572cc5063745bfe547fe7ec8e1a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1986,7 +1964,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2296,7 +2274,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2320,7 +2298,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2331,7 +2309,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2384,7 +2362,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2443,7 +2421,7 @@ checksum = "510c292c8cf384b1a340b816a9a6cf2599eb8f566a44949024af88418000c50b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2464,7 +2442,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2474,7 +2452,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2495,7 +2473,7 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
  "unicode-xid",
 ]
 
@@ -2609,7 +2587,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2679,7 +2657,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2731,7 +2709,7 @@ dependencies = [
  "k256",
  "log",
  "rand 0.8.5",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde",
  "sha3",
  "zeroize",
@@ -2746,7 +2724,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2766,7 +2744,7 @@ checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2777,12 +2755,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2842,7 +2820,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3041,7 +3019,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3222,6 +3200,16 @@ dependencies = [
  "serde_json",
  "wasm-bindgen",
  "web-sys",
+]
+
+[[package]]
+name = "gmp-mpfr-sys"
+version = "1.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66d61197a68f6323b9afa616cf83d55d69191e1bf364d4eb7d35ae18defe776"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3513,7 +3501,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.0",
+ "webpki-roots 1.0.1",
 ]
 
 [[package]]
@@ -3765,7 +3753,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3822,7 +3810,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3918,7 +3906,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4158,7 +4146,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4309,9 +4297,9 @@ checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.18.1+1.9.0"
+version = "0.18.2+1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1dcb20f84ffcdd825c7a311ae347cce604a6f084a767dec4a4929829645290e"
+checksum = "1c42fe03df2bd3c53a3a9c7317ad91d80c81cd1fb0caec8d7cc4cd2bfa10c222"
 dependencies = [
  "cc",
  "libc",
@@ -4549,15 +4537,15 @@ dependencies = [
 
 [[package]]
 name = "lz4_flex"
-version = "0.11.4"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c592ad9fbc1b7838633b3ae55ce69b17d01150c72fcef229fbb819d39ee51ee"
+checksum = "08ab2867e3eeeca90e844d1940eab391c9dc5228783db2ed999acbc0a9ed375a"
 
 [[package]]
 name = "mach2"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b955cdeb2a02b9117f121ce63aa52d08ade45de53e48fe6a38b39c10f6f709"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
 dependencies = [
  "libc",
 ]
@@ -4570,7 +4558,7 @@ checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4625,7 +4613,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4660,9 +4648,9 @@ dependencies = [
 
 [[package]]
 name = "metrics-util"
-version = "0.19.2"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39803e5c24a697c54492a76469034eee8247bd61825502e0410defc3e98eedf0"
+checksum = "b8496cc523d1f94c1385dd8f0f0c2c480b2b8aeccb5b7e4485ad6365523ae376"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -4965,23 +4953,24 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
+checksum = "a973b4e44ce6cad84ce69d797acf9a044532e4184c4f267913d1b546a0727b7a"
 dependencies = [
  "num_enum_derive",
+ "rustversion",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
+checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4995,13 +4984,13 @@ dependencies = [
 
 [[package]]
 name = "nybbles"
-version = "0.3.4"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8983bb634df7248924ee0c4c3a749609b5abcb082c28fffe3254b3eb3602b307"
+checksum = "11d51b0175c49668a033fe7cc69080110d9833b291566cdf332905f3ad9c68a0"
 dependencies = [
  "alloy-rlp",
- "const-hex",
  "proptest",
+ "ruint",
  "serde",
  "smallvec",
 ]
@@ -5049,25 +5038,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "op-alloy-rpc-types"
-version = "0.18.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcbf5ee458a2ad66833e7dcc28d78f33d3d4eba53f432c93d7030f5c02331861"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-network-primitives",
- "alloy-primitives",
- "alloy-rpc-types-eth",
- "alloy-serde",
- "derive_more",
- "op-alloy-consensus",
- "serde",
- "serde_json",
- "thiserror 2.0.12",
-]
-
-[[package]]
 name = "op-alloy-rpc-types-engine"
 version = "0.18.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5088,9 +5058,9 @@ dependencies = [
 
 [[package]]
 name = "op-revm"
-version = "5.0.1"
+version = "7.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0e8a3830a2be82166fbe9ead34361149ff4320743ed7ee5502ab779de221361"
+checksum = "2b97d2b54651fcd2955b454e86b2336c031e17925a127f4c44e2b63b2eeda923"
 dependencies = [
  "auto_impl",
  "once_cell",
@@ -5170,7 +5140,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5270,7 +5240,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5299,7 +5269,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5436,7 +5406,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5577,9 +5547,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.12"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4e529991f949c5e25755532370b8af5d114acae52326361d68d47af64aa842"
+checksum = "fcebb1209ee276352ef14ff8732e24cc2b02bbac986cd74a4c81bcb2f9881970"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -5794,7 +5764,7 @@ checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5891,7 +5861,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 1.0.0",
+ "webpki-roots 1.0.1",
 ]
 
 [[package]]
@@ -5903,7 +5873,7 @@ checksum = "95325155c684b1c89f7765e30bc1c42e4a6da51ca513615660cb8a62ef9a88e3"
 [[package]]
 name = "reth"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-rpc-types",
  "aquamarine",
@@ -5936,9 +5906,9 @@ dependencies = [
  "reth-rpc",
  "reth-rpc-api",
  "reth-rpc-builder",
+ "reth-rpc-convert",
  "reth-rpc-eth-types",
  "reth-rpc-server-types",
- "reth-rpc-types-compat",
  "reth-tasks",
  "reth-tokio-util",
  "reth-transaction-pool",
@@ -5949,7 +5919,7 @@ dependencies = [
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5973,7 +5943,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6002,7 +5972,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -6022,7 +5992,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -6036,7 +6006,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "ahash",
  "alloy-chains",
@@ -6094,7 +6064,7 @@ dependencies = [
  "reth-static-file-types",
  "reth-trie",
  "reth-trie-db",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde",
  "serde_json",
  "tar",
@@ -6107,7 +6077,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -6117,7 +6087,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6126,7 +6096,7 @@ dependencies = [
  "libc",
  "rand 0.8.5",
  "reth-fs-util",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde",
  "thiserror 2.0.12",
  "tikv-jemallocator",
@@ -6135,7 +6105,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6153,18 +6123,18 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "reth-config"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -6179,7 +6149,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -6192,7 +6162,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6204,7 +6174,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6228,7 +6198,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -6252,7 +6222,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -6277,7 +6247,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -6306,7 +6276,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6320,7 +6290,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -6335,7 +6305,7 @@ dependencies = [
  "reth-net-nat",
  "reth-network-peers",
  "schnellru",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde",
  "thiserror 2.0.12",
  "tokio",
@@ -6346,7 +6316,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -6361,7 +6331,7 @@ dependencies = [
  "reth-ethereum-forks",
  "reth-metrics",
  "reth-network-peers",
- "secp256k1",
+ "secp256k1 0.30.0",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -6370,7 +6340,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -6382,7 +6352,7 @@ dependencies = [
  "reth-network-peers",
  "reth-tokio-util",
  "schnellru",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde",
  "serde_with",
  "thiserror 2.0.12",
@@ -6394,7 +6364,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6424,7 +6394,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -6441,7 +6411,7 @@ dependencies = [
  "pin-project",
  "rand 0.8.5",
  "reth-network-peers",
- "secp256k1",
+ "secp256k1 0.30.0",
  "sha2 0.10.9",
  "sha3",
  "thiserror 2.0.12",
@@ -6455,7 +6425,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -6477,7 +6447,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6502,7 +6472,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-service"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "futures",
  "pin-project",
@@ -6525,7 +6495,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6572,7 +6542,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -6599,7 +6569,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6615,7 +6585,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -6630,7 +6600,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-primitives",
  "eyre",
@@ -6651,7 +6621,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -6662,7 +6632,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -6690,7 +6660,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -6711,7 +6681,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6770,7 +6740,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6786,7 +6756,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6804,7 +6774,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -6817,7 +6787,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6844,7 +6814,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6861,7 +6831,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -6871,7 +6841,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6894,7 +6864,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6913,7 +6883,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -6926,7 +6896,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6944,7 +6914,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6982,7 +6952,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6996,7 +6966,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "serde",
  "serde_json",
@@ -7006,7 +6976,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7034,7 +7004,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "bytes",
  "futures",
@@ -7054,7 +7024,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "bitflags 2.9.1",
  "byteorder",
@@ -7071,7 +7041,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "bindgen",
  "cc",
@@ -7080,7 +7050,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "futures",
  "metrics",
@@ -7092,7 +7062,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-primitives",
 ]
@@ -7100,7 +7070,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -7114,7 +7084,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7156,7 +7126,7 @@ dependencies = [
  "reth-transaction-pool",
  "rustc-hash 2.1.1",
  "schnellru",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde",
  "smallvec",
  "thiserror 2.0.12",
@@ -7169,7 +7139,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-admin",
@@ -7192,7 +7162,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7214,12 +7184,12 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "enr",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde_with",
  "thiserror 2.0.12",
  "tokio",
@@ -7229,7 +7199,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -7243,7 +7213,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "anyhow",
  "bincode",
@@ -7260,7 +7230,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -7284,7 +7254,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7338,7 +7308,7 @@ dependencies = [
  "reth-tokio-util",
  "reth-tracing",
  "reth-transaction-pool",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde_json",
  "tokio",
  "tokio-stream",
@@ -7348,7 +7318,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7376,15 +7346,15 @@ dependencies = [
  "reth-network-peers",
  "reth-primitives-traits",
  "reth-prune-types",
+ "reth-rpc-convert",
  "reth-rpc-eth-types",
  "reth-rpc-server-types",
- "reth-rpc-types-compat",
  "reth-stages-types",
  "reth-storage-api",
  "reth-storage-errors",
  "reth-tracing",
  "reth-transaction-pool",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde",
  "shellexpand",
  "strum 0.27.1",
@@ -7399,7 +7369,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-eips",
  "alloy-rpc-types-engine",
@@ -7435,7 +7405,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7459,7 +7429,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "eyre",
  "http",
@@ -7480,7 +7450,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -7491,26 +7461,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-optimism-primitives"
-version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "bytes",
- "op-alloy-consensus",
- "reth-codecs",
- "reth-primitives-traits",
- "serde",
- "serde_with",
-]
-
-[[package]]
 name = "reth-payload-builder"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types",
@@ -7530,7 +7483,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -7542,7 +7495,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7561,7 +7514,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -7571,7 +7524,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-consensus",
  "once_cell",
@@ -7584,7 +7537,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7605,7 +7558,7 @@ dependencies = [
  "revm-bytecode",
  "revm-primitives",
  "revm-state",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde",
  "serde_with",
  "thiserror 2.0.12",
@@ -7614,7 +7567,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7656,7 +7609,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7684,7 +7637,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -7697,7 +7650,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-protocol"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7716,7 +7669,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-provider"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7743,7 +7696,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -7756,7 +7709,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -7806,11 +7759,11 @@ dependencies = [
  "reth-primitives-traits",
  "reth-revm",
  "reth-rpc-api",
+ "reth-rpc-convert",
  "reth-rpc-engine-api",
  "reth-rpc-eth-api",
  "reth-rpc-eth-types",
  "reth-rpc-server-types",
- "reth-rpc-types-compat",
  "reth-storage-api",
  "reth-tasks",
  "reth-transaction-pool",
@@ -7832,7 +7785,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -7860,7 +7813,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -7896,9 +7849,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-rpc-convert"
+version = "1.4.8"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+dependencies = [
+ "alloy-consensus",
+ "alloy-json-rpc",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-rpc-types-eth",
+ "jsonrpsee-types",
+ "reth-evm",
+ "reth-primitives-traits",
+ "revm-context",
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "reth-rpc-engine-api"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7928,7 +7898,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -7956,9 +7926,9 @@ dependencies = [
  "reth-payload-builder",
  "reth-primitives-traits",
  "reth-revm",
+ "reth-rpc-convert",
  "reth-rpc-eth-types",
  "reth-rpc-server-types",
- "reth-rpc-types-compat",
  "reth-storage-api",
  "reth-tasks",
  "reth-transaction-pool",
@@ -7972,7 +7942,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7995,8 +7965,8 @@ dependencies = [
  "reth-metrics",
  "reth-primitives-traits",
  "reth-revm",
+ "reth-rpc-convert",
  "reth-rpc-server-types",
- "reth-rpc-types-compat",
  "reth-storage-api",
  "reth-tasks",
  "reth-transaction-pool",
@@ -8014,7 +7984,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -8028,7 +7998,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8042,31 +8012,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-rpc-types-compat"
-version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
-dependencies = [
- "alloy-consensus",
- "alloy-network",
- "alloy-primitives",
- "alloy-rpc-types-eth",
- "jsonrpsee-types",
- "op-alloy-consensus",
- "op-alloy-rpc-types",
- "op-revm",
- "reth-evm",
- "reth-optimism-primitives",
- "reth-primitives-traits",
- "reth-storage-api",
- "revm-context",
- "serde",
- "thiserror 2.0.12",
-]
-
-[[package]]
 name = "reth-stages"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8112,7 +8060,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8139,7 +8087,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8152,7 +8100,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -8172,7 +8120,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -8184,7 +8132,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8208,7 +8156,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8224,7 +8172,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -8242,7 +8190,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -8252,7 +8200,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "clap",
  "eyre",
@@ -8267,7 +8215,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8305,7 +8253,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8329,7 +8277,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8352,7 +8300,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -8365,7 +8313,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8390,7 +8338,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8408,16 +8356,16 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.4.8"
-source = "git+https://github.com/rezbera/reth?branch=basefee%2Fcentralize-with-rose#3abe2f4eaccc21283de85cc9880c7e0941e7581e"
+source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
 dependencies = [
  "zstd",
 ]
 
 [[package]]
 name = "revm"
-version = "24.0.1"
+version = "26.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d277408ff8d6f747665ad9e52150ab4caf8d5eaf0d787614cf84633c8337b4"
+checksum = "7b2a493c73054a0f6635bad6e840cdbef34838e6e6186974833c901dff7dd709"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -8434,9 +8382,9 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "4.1.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942fe4724cf552fd28db6b0a2ca5b79e884d40dd8288a4027ed1e9090e0c6f49"
+checksum = "b395ee2212d44fcde20e9425916fee685b5440c3f8e01fabae8b0f07a2fd7f08"
 dependencies = [
  "bitvec",
  "once_cell",
@@ -8447,9 +8395,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "5.0.1"
+version = "7.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b01aad49e1233f94cebda48a4e5cef022f7c7ed29b4edf0d202b081af23435ef"
+checksum = "7b97b69d05651509b809eb7215a6563dc64be76a941666c40aabe597ab544d38"
 dependencies = [
  "cfg-if",
  "derive-where",
@@ -8463,9 +8411,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "5.0.0"
+version = "7.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b844f48a411e62c7dde0f757bf5cce49c85b86d6fc1d3b2722c07f2bec4c3ce"
+checksum = "9f8f4f06a1c43bf8e6148509aa06a6c4d28421541944842b9b11ea1a6e53468f"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -8479,9 +8427,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "4.0.1"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad3fbe34f6bb00a9c3155723b3718b9cb9f17066ba38f9eb101b678cd3626775"
+checksum = "763eb5867a109a85f8e47f548b9d88c9143c0e443ec056742052f059fa32f4f1"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -8493,9 +8441,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "4.0.1"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b8acd36784a6d95d5b9e1b7be3ce014f1e759abb59df1fa08396b30f71adc2a"
+checksum = "cf5ecd19a5b75b862841113b9abdd864ad4b22e633810e11e6d620e8207e361d"
 dependencies = [
  "auto_impl",
  "revm-primitives",
@@ -8505,11 +8453,12 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "5.0.1"
+version = "7.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "481e8c3290ff4fa1c066592fdfeb2b172edfd14d12e6cade6f6f5588cad9359a"
+checksum = "17b61f992beaa7a5fc3f5fcf79f1093624fa1557dc42d36baa42114c2d836b59"
 dependencies = [
  "auto_impl",
+ "derive-where",
  "revm-bytecode",
  "revm-context",
  "revm-context-interface",
@@ -8523,11 +8472,12 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "5.0.1"
+version = "7.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc1167ef8937d8867888e63581d8ece729a72073d322119ef4627d813d99ecb"
+checksum = "d7e4400a109a2264f4bf290888ac6d02432b6d5d070492b9dcf134b0c7d51354"
 dependencies = [
  "auto_impl",
+ "either",
  "revm-context",
  "revm-database-interface",
  "revm-handler",
@@ -8540,9 +8490,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48db62c066383dfc2e9636c31999265d48c19fc47652a85f9b3071c2e7512158"
+checksum = "2aabdffc06bdb434d9163e2d63b6fae843559afd300ea3fbeb113b8a0d8ec728"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -8560,9 +8510,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "20.0.0"
+version = "22.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5ee65e57375c6639b0f50555e92a4f1b2434349dd32f52e2176f5c711171697"
+checksum = "a2481ef059708772cec0ce6bc4c84b796a40111612efb73b01adf1caed7ff9ac"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -8572,9 +8522,9 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "21.0.0"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9311e735123d8d53a02af2aa81877bba185be7c141be7f931bb3d2f3af449c"
+checksum = "6d581e78c8f132832bd00854fb5bf37efd95a52582003da35c25cd2cbfc63849"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -8591,15 +8541,16 @@ dependencies = [
  "p256",
  "revm-primitives",
  "ripemd",
- "secp256k1",
+ "rug",
+ "secp256k1 0.31.1",
  "sha2 0.10.9",
 ]
 
 [[package]]
 name = "revm-primitives"
-version = "19.2.0"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c1588093530ec4442461163be49c433c07a3235d1ca6f6799fef338dacc50d3"
+checksum = "52cdf897b3418f2ee05bcade64985e5faed2dbaa349b2b5f27d3d6bfd10fff2a"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -8608,9 +8559,9 @@ dependencies = [
 
 [[package]]
 name = "revm-state"
-version = "4.0.1"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0040c61c30319254b34507383ba33d85f92949933adf6525a2cede05d165e1fa"
+checksum = "8d6274928dd78f907103740b10800d3c0db6caeca391e75a159c168a1e5c78f8"
 dependencies = [
  "bitflags 2.9.1",
  "revm-bytecode",
@@ -8722,6 +8673,18 @@ name = "route-recognizer"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
+
+[[package]]
+name = "rug"
+version = "1.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4207e8d668e5b8eb574bda8322088ccd0d7782d3d03c7e8d562e82ed82bdcbc3"
+dependencies = [
+ "az",
+ "gmp-mpfr-sys",
+ "libc",
+ "libm",
+]
 
 [[package]]
 name = "ruint"
@@ -9008,8 +8971,19 @@ checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
 dependencies = [
  "bitcoin_hashes",
  "rand 0.8.5",
- "secp256k1-sys",
+ "secp256k1-sys 0.10.1",
  "serde",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c3c81b43dc2d8877c216a3fccf76677ee1ebccd429566d3e67447290d0c42b2"
+dependencies = [
+ "bitcoin_hashes",
+ "rand 0.9.1",
+ "secp256k1-sys 0.11.0",
 ]
 
 [[package]]
@@ -9017,6 +8991,15 @@ name = "secp256k1-sys"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb913707158fadaf0d8702c2db0e857de66eb003ccfdda5924b5f5ac98efb38"
 dependencies = [
  "cc",
 ]
@@ -9100,7 +9083,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -9165,7 +9148,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -9466,7 +9449,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -9479,7 +9462,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -9501,9 +9484,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9512,14 +9495,14 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c8c8f496c33dc6343dac05b4be8d9e0bca180a4caa81d7b8416b10cc2273cd"
+checksum = "b9ac494e7266fcdd2ad80bf4375d55d27a117ea5c866c26d0e97fe5b3caeeb75"
 dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -9539,7 +9522,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -9623,7 +9606,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -9634,7 +9617,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -9790,7 +9773,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -9982,7 +9965,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -10103,7 +10086,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -10419,7 +10402,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
  "wasm-bindgen-shared",
 ]
 
@@ -10454,7 +10437,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -10521,14 +10504,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
 dependencies = [
- "webpki-root-certs 1.0.0",
+ "webpki-root-certs 1.0.1",
 ]
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01a83f7e1a9f8712695c03eabe9ed3fbca0feff0152f33f12593e5a6303cb1a4"
+checksum = "86138b15b2b7d561bc4469e77027b8dd005a43dc502e9031d1f5afc8ce1f280e"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -10539,14 +10522,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.0",
+ "webpki-roots 1.0.1",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2853738d1cc4f2da3a225c18ec6c3721abb31961096e9dbf5ab35fa88b19cfdb"
+checksum = "8782dd5a41a24eed3a4f40b606249b3e236ca61adf1f25ea4d45c73de122b502"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -10687,7 +10670,7 @@ checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -10698,7 +10681,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -10709,7 +10692,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -10720,7 +10703,7 @@ checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -10731,7 +10714,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -10742,7 +10725,7 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -11225,7 +11208,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
  "synstructure",
 ]
 
@@ -11237,7 +11220,7 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
  "synstructure",
 ]
 
@@ -11258,7 +11241,7 @@ checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -11278,7 +11261,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
  "synstructure",
 ]
 
@@ -11299,7 +11282,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -11343,7 +11326,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -11354,7 +11337,7 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -11384,3 +11367,8 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[patch.unused]]
+name = "alloy-contract"
+version = "1.0.12"
+source = "git+https://github.com/alloy-rs/alloy?rev=08fa016ed950b6e65f810fc9cdef7cf38fbc63f6#08fa016ed950b6e65f810fc9cdef7cf38fbc63f6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,19 +13,19 @@ clap = { version = "4.5.39", features = ["derive"] }
 derive_more = "2.0.1"
 eyre = "0.6"
 jsonrpsee-core = "0.25.1"
-reth = { git = "https://github.com/rezbera/reth", branch = "basefee/centralize-with-rose" }
-reth-chainspec = { git = "https://github.com/rezbera/reth", branch = "basefee/centralize-with-rose" }
-reth-cli = { git = "https://github.com/rezbera/reth", branch = "basefee/centralize-with-rose" }
-reth-cli-commands = { git = "https://github.com/rezbera/reth", branch = "basefee/centralize-with-rose" }
-reth-cli-util = { git = "https://github.com/rezbera/reth", branch = "basefee/centralize-with-rose" }
-reth-db = { git = "https://github.com/rezbera/reth", branch = "basefee/centralize-with-rose" }
-reth-ethereum-cli = { git = "https://github.com/rezbera/reth", branch = "basefee/centralize-with-rose" }
-reth-evm = { git = "https://github.com/rezbera/reth", branch = "basefee/centralize-with-rose" }
-reth-evm-ethereum = { git = "https://github.com/rezbera/reth", branch = "basefee/centralize-with-rose" }
-reth-network-peers = { git = "https://github.com/rezbera/reth", branch = "basefee/centralize-with-rose" }
-reth-node-builder = { git = "https://github.com/rezbera/reth", branch = "basefee/centralize-with-rose" }
-reth-node-ethereum = { git = "https://github.com/rezbera/reth", branch = "basefee/centralize-with-rose" }
-reth-tracing = { git = "https://github.com/rezbera/reth", branch = "basefee/centralize-with-rose" }
+reth = { git = "https://github.com/berachain/reth", branch = "prague1-berachain-reth" }
+reth-chainspec = { git = "https://github.com/berachain/reth", branch = "prague1-berachain-reth" }
+reth-cli = { git = "https://github.com/berachain/reth", branch = "prague1-berachain-reth" }
+reth-cli-commands = { git = "https://github.com/berachain/reth", branch = "prague1-berachain-reth" }
+reth-cli-util = { git = "https://github.com/berachain/reth", branch = "prague1-berachain-reth" }
+reth-db = { git = "https://github.com/berachain/reth", branch = "prague1-berachain-reth" }
+reth-ethereum-cli = { git = "https://github.com/berachain/reth", branch = "prague1-berachain-reth" }
+reth-evm = { git = "https://github.com/berachain/reth", branch = "prague1-berachain-reth" }
+reth-evm-ethereum = { git = "https://github.com/berachain/reth", branch = "prague1-berachain-reth" }
+reth-network-peers = { git = "https://github.com/berachain/reth", branch = "prague1-berachain-reth" }
+reth-node-builder = { git = "https://github.com/berachain/reth", branch = "prague1-berachain-reth" }
+reth-node-ethereum = { git = "https://github.com/berachain/reth", branch = "prague1-berachain-reth" }
+reth-tracing = { git = "https://github.com/berachain/reth", branch = "prague1-berachain-reth" }
 serde = { version = "1.0", features = ["derive"], default-features = false }
 thiserror = "2.0"
 tracing = "0.1.41"
@@ -48,29 +48,30 @@ debug = "full"
 strip = "none"
 
 [patch.crates-io]
-# alloy-consensus = { git = "https://github.com/rezbera/alloy", branch ="BRIP-0002"}
-# alloy-eips = { git = "https://github.com/rezbera/alloy", branch = "BRIP-0002" }
-# alloy-genesis = { git = "https://github.com/rezbera/alloy", branch = "BRIP-0002" }
-# alloy-json-rpc = { git = "https://github.com/rezbera/alloy", branch ="BRIP-0002"}
-# alloy-network = { git = "https://github.com/rezbera/alloy", branch ="BRIP-0002"}
-# alloy-network-primitives = { git = "https://github.com/rezbera/alloy", branch ="BRIP-0002"}
-# alloy-provider = { git = "https://github.com/rezbera/alloy", branch ="BRIP-0002"}
-# alloy-pubsub = { git = "https://github.com/rezbera/alloy", branch ="BRIP-0002"}
-# alloy-rpc-client = { git = "https://github.com/rezbera/alloy", branch ="BRIP-0002"}
-# alloy-rpc-types = { git = "https://github.com/rezbera/alloy", branch ="BRIP-0002"}
-# alloy-rpc-types-admin = { git = "https://github.com/rezbera/alloy", branch ="BRIP-0002"}
-# alloy-rpc-types-anvil = { git = "https://github.com/rezbera/alloy", branch ="BRIP-0002"}
-# alloy-rpc-types-beacon = { git = "https://github.com/rezbera/alloy", branch ="BRIP-0002"}
-# alloy-rpc-types-debug = { git = "https://github.com/rezbera/alloy", branch ="BRIP-0002"}
-# alloy-rpc-types-engine = { git = "https://github.com/rezbera/alloy", branch ="BRIP-0002"}
-# alloy-rpc-types-eth = { git = "https://github.com/rezbera/alloy", branch ="BRIP-0002"}
-# alloy-rpc-types-mev = { git = "https://github.com/rezbera/alloy", branch ="BRIP-0002"}
-# alloy-rpc-types-trace = { git = "https://github.com/rezbera/alloy", branch ="BRIP-0002"}
-# alloy-rpc-types-txpool = { git = "https://github.com/rezbera/alloy", branch ="BRIP-0002"}
-# alloy-serde = { git = "https://github.com/rezbera/alloy", branch ="BRIP-0002"}
-# alloy-signer = { git = "https://github.com/rezbera/alloy", branch ="BRIP-0002"}
-# alloy-signer-local = { git = "https://github.com/rezbera/alloy", branch ="BRIP-0002"}
-# alloy-transport = { git = "https://github.com/rezbera/alloy", branch ="BRIP-0002"}
-# alloy-transport-http = { git = "https://github.com/rezbera/alloy", branch ="BRIP-0002"}
-# alloy-transport-ipc = { git = "https://github.com/rezbera/alloy", branch ="BRIP-0002"}
-# alloy-transport-ws = { git = "https://github.com/rezbera/alloy", branch ="BRIP-0002"}
+alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "08fa016ed950b6e65f810fc9cdef7cf38fbc63f6" }
+alloy-contract = { git = "https://github.com/alloy-rs/alloy", rev = "08fa016ed950b6e65f810fc9cdef7cf38fbc63f6" }
+alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "08fa016ed950b6e65f810fc9cdef7cf38fbc63f6" }
+alloy-genesis = { git = "https://github.com/alloy-rs/alloy", rev = "08fa016ed950b6e65f810fc9cdef7cf38fbc63f6" }
+alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy", rev = "08fa016ed950b6e65f810fc9cdef7cf38fbc63f6" }
+alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "08fa016ed950b6e65f810fc9cdef7cf38fbc63f6" }
+alloy-network-primitives = { git = "https://github.com/alloy-rs/alloy", rev = "08fa016ed950b6e65f810fc9cdef7cf38fbc63f6" }
+alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "08fa016ed950b6e65f810fc9cdef7cf38fbc63f6" }
+alloy-pubsub = { git = "https://github.com/alloy-rs/alloy", rev = "08fa016ed950b6e65f810fc9cdef7cf38fbc63f6" }
+alloy-rpc-client = { git = "https://github.com/alloy-rs/alloy", rev = "08fa016ed950b6e65f810fc9cdef7cf38fbc63f6" }
+alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "08fa016ed950b6e65f810fc9cdef7cf38fbc63f6" }
+alloy-rpc-types-admin = { git = "https://github.com/alloy-rs/alloy", rev = "08fa016ed950b6e65f810fc9cdef7cf38fbc63f6" }
+alloy-rpc-types-anvil = { git = "https://github.com/alloy-rs/alloy", rev = "08fa016ed950b6e65f810fc9cdef7cf38fbc63f6" }
+alloy-rpc-types-beacon = { git = "https://github.com/alloy-rs/alloy", rev = "08fa016ed950b6e65f810fc9cdef7cf38fbc63f6" }
+alloy-rpc-types-debug = { git = "https://github.com/alloy-rs/alloy", rev = "08fa016ed950b6e65f810fc9cdef7cf38fbc63f6" }
+alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", rev = "08fa016ed950b6e65f810fc9cdef7cf38fbc63f6" }
+alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", rev = "08fa016ed950b6e65f810fc9cdef7cf38fbc63f6" }
+alloy-rpc-types-mev = { git = "https://github.com/alloy-rs/alloy", rev = "08fa016ed950b6e65f810fc9cdef7cf38fbc63f6" }
+alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", rev = "08fa016ed950b6e65f810fc9cdef7cf38fbc63f6" }
+alloy-rpc-types-txpool = { git = "https://github.com/alloy-rs/alloy", rev = "08fa016ed950b6e65f810fc9cdef7cf38fbc63f6" }
+alloy-serde = { git = "https://github.com/alloy-rs/alloy", rev = "08fa016ed950b6e65f810fc9cdef7cf38fbc63f6" }
+alloy-signer = { git = "https://github.com/alloy-rs/alloy", rev = "08fa016ed950b6e65f810fc9cdef7cf38fbc63f6" }
+alloy-signer-local = { git = "https://github.com/alloy-rs/alloy", rev = "08fa016ed950b6e65f810fc9cdef7cf38fbc63f6" }
+alloy-transport = { git = "https://github.com/alloy-rs/alloy", rev = "08fa016ed950b6e65f810fc9cdef7cf38fbc63f6" }
+alloy-transport-http = { git = "https://github.com/alloy-rs/alloy", rev = "08fa016ed950b6e65f810fc9cdef7cf38fbc63f6" }
+alloy-transport-ipc = { git = "https://github.com/alloy-rs/alloy", rev = "08fa016ed950b6e65f810fc9cdef7cf38fbc63f6" }
+alloy-transport-ws = { git = "https://github.com/alloy-rs/alloy", rev = "08fa016ed950b6e65f810fc9cdef7cf38fbc63f6" }

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ pr: ## Run all checks that are run in CI for pull requests
 	@echo "2. Checking TOML formatting..."
 	dprint check
 	@echo "3. Running clippy..."
-	cargo clippy --all-targets --all-features -- -D warnings
+	cargo +nightly clippy --all-targets --all-features -- -D warnings
 	@echo "4. Running security audit..."
 	cargo deny check
 	@echo "5. Checking unused dependencies..."

--- a/src/chainspec/mod.rs
+++ b/src/chainspec/mod.rs
@@ -5,7 +5,10 @@ use crate::{
     hardforks::{BerachainHardfork, BerachainHardforks},
 };
 use alloy_consensus::BlockHeader;
-use alloy_eips::eip2124::{ForkFilter, ForkId, Head};
+use alloy_eips::{
+    calc_next_block_base_fee,
+    eip2124::{ForkFilter, ForkId, Head},
+};
 use alloy_genesis::Genesis;
 use derive_more::{Constructor, Into};
 use reth::{
@@ -87,7 +90,7 @@ impl EthChainSpec for BerachainChainSpec {
         self.inner.final_paris_total_difficulty()
     }
 
-    fn next_block_base_fee<H>(&self, parent: &H, _: u64) -> u64
+    fn next_block_base_fee<H>(&self, parent: &H, _: u64) -> Option<u64>
     where
         Self: Sized,
         H: BlockHeader,
@@ -95,17 +98,19 @@ impl EthChainSpec for BerachainChainSpec {
         // Note that we use this parent block timestamp to determine whether Prague 1 is active.
         // This means that we technically start the base_fee changes the block after the fork
         // block. This is a conscious decision to minimize fork diffs across execution clients.
-        let raw = parent
-            .next_block_base_fee(self.base_fee_params_at_timestamp(parent.timestamp()))
-            .unwrap_or_default();
+        let raw = calc_next_block_base_fee(
+            parent.gas_used(),
+            parent.gas_limit(),
+            parent.base_fee_per_gas()?,
+            self.base_fee_params_at_timestamp(parent.timestamp()),
+        );
 
         let min_base_fee = if self.is_prague1_active_at_timestamp(parent.timestamp()) {
             PRAGUE1_MIN_BASE_FEE_WEI
         } else {
             DEFAULT_MIN_BASE_FEE_WEI
         };
-
-        raw.max(min_base_fee)
+        Some(raw.max(min_base_fee))
     }
 }
 
@@ -512,7 +517,7 @@ mod tests {
 
         // Before Prague1, base fee can go below 1 gwei
         let next_base_fee = chain_spec.next_block_base_fee(&parent_header, 0);
-        assert!(next_base_fee < PRAGUE1_MIN_BASE_FEE_WEI);
+        assert!(next_base_fee.unwrap() < PRAGUE1_MIN_BASE_FEE_WEI);
 
         // Create a parent block at Prague1 activation
         let parent_header = Header {
@@ -523,6 +528,6 @@ mod tests {
 
         // After Prague1, base fee should be at least 1 gwei
         let next_base_fee = chain_spec.next_block_base_fee(&parent_header, 0);
-        assert_eq!(next_base_fee, PRAGUE1_MIN_BASE_FEE_WEI);
+        assert_eq!(next_base_fee.unwrap(), PRAGUE1_MIN_BASE_FEE_WEI);
     }
 }


### PR DESCRIPTION
## Summary
- Switch reth dependencies from rezbera/reth to berachain/reth prague1-berachain-reth branch
- Add alloy git patches to fix compatibility issues
- Update chainspec API to match new trait signatures

## Technical Details

Recent upstream reth changes activated alloy git patches and updated alloy-trie from 0.8.1 to 0.9.0, causing build failures. The berachain/reth prague1-berachain-reth branch includes these necessary patches.

**Key Changes:**
- All reth dependencies now point to `berachain/reth` `prague1-berachain-reth` branch 
- Added alloy git patches (rev `08fa016ed950b6e65f810fc9cdef7cf38fbc63f6`) to resolve `TrieAccount` trait bound errors
- Updated `next_block_base_fee` to return `Option<u64>` per new `EthChainSpec` trait
- Switch to `calc_next_block_base_fee` from `alloy-eips` for better consistency

**Patch Reasoning:**
The alloy patches are required because upstream reth commit `34fe4c7c5` activated these same patches to maintain compatibility with recent alloy changes. Without them, compilation fails with trait bound errors between `GenesisAccount` and `alloy_trie::TrieAccount`.

All tests pass and `make pr` succeeds.