### PR TITLE
feat: add custom extra_data for Berachain blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1375,6 +1375,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-genesis",
+ "alloy-primitives",
  "alloy-rpc-types",
  "clap",
  "derive_more",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT OR Apache-2.0"
 alloy-consensus = "1.0.9"
 alloy-eips = "1.0.9"
 alloy-genesis = "1.0.9"
+alloy-primitives = "1.0.9"
 alloy-rpc-types = "1.0.9"
 clap = { version = "4.5.39", features = ["derive"] }
 derive_more = "2.0.1"

--- a/src/node/evm/mod.rs
+++ b/src/node/evm/mod.rs
@@ -1,11 +1,21 @@
 //! Berachain EVM executor using standard Ethereum execution with Berachain chain spec
 
-use reth_node_builder::PayloadBuilderConfig;
+use alloy_primitives::Bytes;
 
 use crate::{chainspec::BerachainChainSpec, node::BerachainNode};
 use reth_evm::EthEvmFactory;
 use reth_node_builder::{BuilderContext, FullNodeTypes, components::ExecutorBuilder};
 use reth_node_ethereum::EthEvmConfig;
+
+/// Default extra data for Berachain blocks
+fn default_extra_data() -> String {
+    format!("bera-reth/v{}/{}", env!("CARGO_PKG_VERSION"), std::env::consts::OS)
+}
+
+/// Default extra data in bytes for Berachain blocks
+fn default_extra_data_bytes() -> Bytes {
+    Bytes::from(default_extra_data().as_bytes().to_vec())
+}
 
 /// Creates standard Ethereum EVM with Berachain chain spec
 #[derive(Debug, Default, Clone, Copy)]
@@ -20,9 +30,10 @@ where
 
     /// Builds standard Ethereum EVM config with Berachain chain spec
     async fn build_evm(self, ctx: &BuilderContext<Node>) -> eyre::Result<Self::EVM> {
+        // Always use Berachain-specific extra_data
         let evm_config =
             EthEvmConfig::new_with_evm_factory(ctx.chain_spec().clone(), EthEvmFactory::default())
-                .with_extra_data(ctx.payload_builder_config().extra_data_bytes());
+                .with_extra_data(default_extra_data_bytes());
         Ok(evm_config)
     }
 }


### PR DESCRIPTION
## Summary

Override default reth extra_data to use bera-reth branding instead of reth branding in block headers.

## Background

Reth by default sets block `extra_data` via two mechanisms:
1. **Command line flag**: `--builder.extradata` allows users to set custom extra_data
2. **Default branding**: When no custom extra_data is provided, reth uses `default_extra_data()` from `reth-node-core/src/version.rs` which generates `"reth/v{version}/{os}"`

The default extra_data configuration flows through:
- `PayloadBuilderArgs` parses CLI arguments 
- `PayloadBuilderConfig::extra_data_bytes()` provides the configured or default extra_data
- `EthEvmConfig::with_extra_data()` applies it to the EVM configuration during payload building

## Changes

This PR overrides the default behavior in `BerachainExecutorBuilder::build_evm()` to:
- Always use `"bera-reth/v{version}/{os}"` format for block extra_data
- Ignore any CLI-provided extra_data to ensure consistent Berachain branding
- Add minimal code changes by implementing custom extra_data functions

### Files Changed
- `src/node/evm/mod.rs`: Add custom extra_data functions and override in EVM config
- `Cargo.toml`: Add `alloy-primitives` dependency for `Bytes` type

## Result

All blocks produced by bera-reth will now have `extra_data` showing:
```
"bera-reth/v0.1.0/darwin"  // or your OS
```

Instead of the default reth branding:
```
"reth/v1.4.8/darwin"
```

## Test plan

- [x] Code builds successfully with `cargo build --release`
- [x] All PR checks pass (formatting, linting, tests, security audit)
- [x] Integration testing can be performed by running bera-reth and inspecting block headers via JSON-RPC