### PR TITLE
feat: update reth and alloy dependencies to latest versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,8 +110,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.0.12"
-source = "git+https://github.com/alloy-rs/alloy?rev=08fa016ed950b6e65f810fc9cdef7cf38fbc63f6#08fa016ed950b6e65f810fc9cdef7cf38fbc63f6"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b64ec76fe727969728f4396e3f410cdd825042d81d5017bfa5e58bf349071290"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -134,8 +135,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.0.12"
-source = "git+https://github.com/alloy-rs/alloy?rev=08fa016ed950b6e65f810fc9cdef7cf38fbc63f6#08fa016ed950b6e65f810fc9cdef7cf38fbc63f6"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec637158ca8070cab850524ad258a8b7cee090e1e1ce393426c4247927f0acb0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -202,8 +204,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "1.0.12"
-source = "git+https://github.com/alloy-rs/alloy?rev=08fa016ed950b6e65f810fc9cdef7cf38fbc63f6#08fa016ed950b6e65f810fc9cdef7cf38fbc63f6"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d95a9829fef493824aad09b3e124e95c5320f8f6b3b9943fd7f3b07b4d21ddd"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -243,8 +246,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "1.0.12"
-source = "git+https://github.com/alloy-rs/alloy?rev=08fa016ed950b6e65f810fc9cdef7cf38fbc63f6#08fa016ed950b6e65f810fc9cdef7cf38fbc63f6"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2a004f3ce55b81321147249d8a5e9b7da83dbb7291555ef8b61834b1a08249e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -281,8 +285,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "1.0.12"
-source = "git+https://github.com/alloy-rs/alloy?rev=08fa016ed950b6e65f810fc9cdef7cf38fbc63f6#08fa016ed950b6e65f810fc9cdef7cf38fbc63f6"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7aeb6bdadf68e4f075147141af9631e4ea8af57649b0738db8c4473f9872b5f"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -295,8 +300,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "1.0.12"
-source = "git+https://github.com/alloy-rs/alloy?rev=08fa016ed950b6e65f810fc9cdef7cf38fbc63f6#08fa016ed950b6e65f810fc9cdef7cf38fbc63f6"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5fe3fc1d6e5e5914e239f9fb7fb06a55b1bb8fe6e1985933832bd92da327a20"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -320,8 +326,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "1.0.12"
-source = "git+https://github.com/alloy-rs/alloy?rev=08fa016ed950b6e65f810fc9cdef7cf38fbc63f6#08fa016ed950b6e65f810fc9cdef7cf38fbc63f6"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "140e30026c6f1ed5a10c02b312735b1b84d07af74d1a90c87c38ad31909dd5f2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -360,8 +367,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "1.0.12"
-source = "git+https://github.com/alloy-rs/alloy?rev=08fa016ed950b6e65f810fc9cdef7cf38fbc63f6#08fa016ed950b6e65f810fc9cdef7cf38fbc63f6"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a58276c10466554bcd9dd93cd5ea349d2c6d28e29d59ad299e200b3eedbea205"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -402,8 +410,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "1.0.12"
-source = "git+https://github.com/alloy-rs/alloy?rev=08fa016ed950b6e65f810fc9cdef7cf38fbc63f6#08fa016ed950b6e65f810fc9cdef7cf38fbc63f6"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419cd1a961142f6fb8575e3dead318f07cf95bc19f1cb739ff0dbe1f7b713355"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -444,8 +453,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "1.0.12"
-source = "git+https://github.com/alloy-rs/alloy?rev=08fa016ed950b6e65f810fc9cdef7cf38fbc63f6#08fa016ed950b6e65f810fc9cdef7cf38fbc63f6"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ede96b42460d865ff3c26ce604aa927c829a7b621675d0a7bdfc8cdc9d5f7fb"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -471,8 +481,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "1.0.12"
-source = "git+https://github.com/alloy-rs/alloy?rev=08fa016ed950b6e65f810fc9cdef7cf38fbc63f6#08fa016ed950b6e65f810fc9cdef7cf38fbc63f6"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34217bac065fd6c5197ecb4bbdcf82ce28893c679d90d98e4e5a2700b7994f69"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -483,8 +494,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-admin"
-version = "1.0.12"
-source = "git+https://github.com/alloy-rs/alloy?rev=08fa016ed950b6e65f810fc9cdef7cf38fbc63f6#08fa016ed950b6e65f810fc9cdef7cf38fbc63f6"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb178fa8f0b892d4e3eebde91b216d87538e82340655ac6a6eb4c50c2a41e407"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -494,8 +506,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "1.0.12"
-source = "git+https://github.com/alloy-rs/alloy?rev=08fa016ed950b6e65f810fc9cdef7cf38fbc63f6#08fa016ed950b6e65f810fc9cdef7cf38fbc63f6"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "263a868fbe924c00f4af91532a8a890dfeb0af6199ca9641f2f9322fa86e437e"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -505,8 +518,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "1.0.12"
-source = "git+https://github.com/alloy-rs/alloy?rev=08fa016ed950b6e65f810fc9cdef7cf38fbc63f6#08fa016ed950b6e65f810fc9cdef7cf38fbc63f6"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "470d43aabf4a58794465671e5b9dad428e66dcf4f11e23e3c3510e61759d0044"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -515,8 +529,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-beacon"
-version = "1.0.12"
-source = "git+https://github.com/alloy-rs/alloy?rev=08fa016ed950b6e65f810fc9cdef7cf38fbc63f6#08fa016ed950b6e65f810fc9cdef7cf38fbc63f6"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f67abcd68143553be69c70b5e2bfffe62bb1a784228f330bd7326ab2f4e19d92"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -532,8 +547,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "1.0.12"
-source = "git+https://github.com/alloy-rs/alloy?rev=08fa016ed950b6e65f810fc9cdef7cf38fbc63f6#08fa016ed950b6e65f810fc9cdef7cf38fbc63f6"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "971864f4d2add7a7792e126e2d1a39cc251582d6932e5744b9703d846eda9beb"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -541,8 +557,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "1.0.12"
-source = "git+https://github.com/alloy-rs/alloy?rev=08fa016ed950b6e65f810fc9cdef7cf38fbc63f6#08fa016ed950b6e65f810fc9cdef7cf38fbc63f6"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a01bab0f1ecf7075fe6cf9d9fa319cbc1c5717537697ee36526d4579f1963e6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -560,8 +577,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.0.12"
-source = "git+https://github.com/alloy-rs/alloy?rev=08fa016ed950b6e65f810fc9cdef7cf38fbc63f6#08fa016ed950b6e65f810fc9cdef7cf38fbc63f6"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d912d255847cc46bfc8f698d6f3f089f021431e35b6b65837ca1b18d461f9f10"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -571,7 +589,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -579,8 +597,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-mev"
-version = "1.0.12"
-source = "git+https://github.com/alloy-rs/alloy?rev=08fa016ed950b6e65f810fc9cdef7cf38fbc63f6#08fa016ed950b6e65f810fc9cdef7cf38fbc63f6"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bfaa3dda6691cd07010b59bd5de87963ace137d32f95b434f733b7c21fe2470"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -593,8 +612,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "1.0.12"
-source = "git+https://github.com/alloy-rs/alloy?rev=08fa016ed950b6e65f810fc9cdef7cf38fbc63f6#08fa016ed950b6e65f810fc9cdef7cf38fbc63f6"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8517dc56fd52a1f88b1847cebdd36a117a64ffe3cc6c3da8cb14efb41ecbcb06"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -606,8 +626,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "1.0.12"
-source = "git+https://github.com/alloy-rs/alloy?rev=08fa016ed950b6e65f810fc9cdef7cf38fbc63f6#08fa016ed950b6e65f810fc9cdef7cf38fbc63f6"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de4448330bd57eb6b2ecb4ee2f986fe2d9e846e7fb3cb13a112e5714fb4c47b8"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -617,8 +638,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "1.0.12"
-source = "git+https://github.com/alloy-rs/alloy?rev=08fa016ed950b6e65f810fc9cdef7cf38fbc63f6#08fa016ed950b6e65f810fc9cdef7cf38fbc63f6"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e63928922253ad23b902e968cfbc31bb7f7ddd2b59c34e58b2b28ea032aff4a"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -627,8 +649,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "1.0.12"
-source = "git+https://github.com/alloy-rs/alloy?rev=08fa016ed950b6e65f810fc9cdef7cf38fbc63f6#08fa016ed950b6e65f810fc9cdef7cf38fbc63f6"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db794f239d3746fd116146acca55a1ca3362311ecc3bdbfc150aeeaa84f462ff"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -641,8 +664,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "1.0.12"
-source = "git+https://github.com/alloy-rs/alloy?rev=08fa016ed950b6e65f810fc9cdef7cf38fbc63f6#08fa016ed950b6e65f810fc9cdef7cf38fbc63f6"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8fcb2567f89f31dec894d3cd1d0c42cfcd699acd181a03e7339492b20eea302"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -726,8 +750,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "1.0.12"
-source = "git+https://github.com/alloy-rs/alloy?rev=08fa016ed950b6e65f810fc9cdef7cf38fbc63f6#08fa016ed950b6e65f810fc9cdef7cf38fbc63f6"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67353ab9f9ae5eacf31155cf395add8bcfd64d98246f296a08a2e6ead92031dc"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -748,8 +773,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "1.0.12"
-source = "git+https://github.com/alloy-rs/alloy?rev=08fa016ed950b6e65f810fc9cdef7cf38fbc63f6#08fa016ed950b6e65f810fc9cdef7cf38fbc63f6"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b18ce0732e42186d10479b7d87f96eb3991209c472f534fb775223e1e51f4f"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -762,8 +788,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "1.0.12"
-source = "git+https://github.com/alloy-rs/alloy?rev=08fa016ed950b6e65f810fc9cdef7cf38fbc63f6#08fa016ed950b6e65f810fc9cdef7cf38fbc63f6"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c43322dbaabe886f69cb9647a449ed50bf18b8bba8804fefd825a2af0cd1c7e"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -781,8 +808,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "1.0.12"
-source = "git+https://github.com/alloy-rs/alloy?rev=08fa016ed950b6e65f810fc9cdef7cf38fbc63f6#08fa016ed950b6e65f810fc9cdef7cf38fbc63f6"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13318c049f3d9187a88856b7ba0d12fda90f92225780fb119c0ac26e3fbfd5d2"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -814,8 +842,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "1.0.12"
-source = "git+https://github.com/alloy-rs/alloy?rev=08fa016ed950b6e65f810fc9cdef7cf38fbc63f6#08fa016ed950b6e65f810fc9cdef7cf38fbc63f6"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e325be6a1f80a744343d62b7229cae22b8d4b1ece6e61b8f8e71cfb7d3bcc0c8"
 dependencies = [
  "alloy-primitives",
  "darling",
@@ -2215,9 +2244,9 @@ dependencies = [
 
 [[package]]
 name = "crunchy"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
@@ -4326,9 +4355,9 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libp2p-identity"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbb68ea10844211a59ce46230909fd0ea040e8a192454d4cc2ee0d53e12280eb"
+checksum = "3104e13b51e4711ff5738caa1fb54467c8604c2e94d607e27745bcf709068774"
 dependencies = [
  "asn1_der",
  "bs58",
@@ -4356,9 +4385,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+checksum = "1580801010e535496706ba011c15f8532df6b42297d2e471fec38ceadd8c0638"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
@@ -5023,9 +5052,9 @@ checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "op-alloy-consensus"
-version = "0.18.6"
+version = "0.18.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5448a4ef9ef1ee241a67fe533ae3563716bbcd719acbd0544ad1ac9f03cfde6"
+checksum = "a335f4cbd98a5d7ce0551b296971872e0eddac8802ff9b417f9e9a26ea476ddc"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5040,9 +5069,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-rpc-types-engine"
-version = "0.18.6"
+version = "0.18.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712c2b1be5c3414f29800d1b29cd16f0049b847687143adb19814de587ecb3f6"
+checksum = "bcbce08900e92a17b490d8e24dd18f299a58b3da8b202ed38992d3f56fa42d84"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5873,8 +5902,8 @@ checksum = "95325155c684b1c89f7765e30bc1c42e4a6da51ca513615660cb8a62ef9a88e3"
 
 [[package]]
 name = "reth"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-rpc-types",
  "aquamarine",
@@ -5919,8 +5948,8 @@ dependencies = [
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5943,8 +5972,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chain-state"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5972,8 +6001,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -5992,8 +6021,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -6006,8 +6035,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-commands"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "ahash",
  "alloy-chains",
@@ -6077,8 +6106,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-runner"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -6087,8 +6116,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6105,8 +6134,8 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6123,8 +6152,8 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -6134,8 +6163,8 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -6149,8 +6178,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -6162,8 +6191,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6174,8 +6203,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6198,8 +6227,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -6222,8 +6251,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -6247,8 +6276,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -6276,8 +6305,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6290,8 +6319,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -6316,8 +6345,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -6340,8 +6369,8 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -6364,8 +6393,8 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6394,8 +6423,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -6425,8 +6454,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-local"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -6447,8 +6476,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6472,8 +6501,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-service"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "futures",
  "pin-project",
@@ -6495,8 +6524,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-tree"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6542,8 +6571,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-util"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -6569,8 +6598,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6585,8 +6614,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era-downloader"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -6600,15 +6629,18 @@ dependencies = [
 
 [[package]]
 name = "reth-era-utils"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
+ "alloy-consensus",
  "alloy-primitives",
+ "alloy-rlp",
  "eyre",
  "futures-util",
  "reth-db-api",
  "reth-era",
  "reth-era-downloader",
+ "reth-ethereum-primitives",
  "reth-etl",
  "reth-fs-util",
  "reth-primitives-traits",
@@ -6621,8 +6653,8 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -6632,8 +6664,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -6660,8 +6692,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -6681,8 +6713,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-cli"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6740,8 +6772,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6756,8 +6788,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6774,8 +6806,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -6787,8 +6819,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6814,8 +6846,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6831,8 +6863,8 @@ dependencies = [
 
 [[package]]
 name = "reth-etl"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -6841,8 +6873,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6864,8 +6896,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6883,8 +6915,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -6896,8 +6928,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6914,8 +6946,8 @@ dependencies = [
 
 [[package]]
 name = "reth-exex"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6952,8 +6984,8 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-types"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6966,8 +6998,8 @@ dependencies = [
 
 [[package]]
 name = "reth-fs-util"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "serde",
  "serde_json",
@@ -6976,8 +7008,8 @@ dependencies = [
 
 [[package]]
 name = "reth-invalid-block-hooks"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7004,8 +7036,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ipc"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "bytes",
  "futures",
@@ -7024,8 +7056,8 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "bitflags 2.9.1",
  "byteorder",
@@ -7041,8 +7073,8 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "bindgen",
  "cc",
@@ -7050,8 +7082,8 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "futures",
  "metrics",
@@ -7062,16 +7094,16 @@ dependencies = [
 
 [[package]]
 name = "reth-net-banlist"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "reth-net-nat"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -7084,8 +7116,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7139,8 +7171,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-admin",
@@ -7162,8 +7194,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-p2p"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7184,8 +7216,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7199,8 +7231,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -7213,8 +7245,8 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "anyhow",
  "bincode",
@@ -7230,8 +7262,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -7254,8 +7286,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-builder"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7318,8 +7350,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7369,8 +7401,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethereum"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-eips",
  "alloy-rpc-types-engine",
@@ -7405,8 +7437,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-events"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7429,8 +7461,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-metrics"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "eyre",
  "http",
@@ -7450,8 +7482,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-types"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -7463,8 +7495,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types",
@@ -7483,8 +7515,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder-primitives"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -7495,8 +7527,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7514,8 +7546,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -7524,8 +7556,8 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-consensus",
  "once_cell",
@@ -7537,8 +7569,8 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7567,8 +7599,8 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7609,8 +7641,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7637,8 +7669,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -7650,8 +7682,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ress-protocol"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7669,8 +7701,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ress-provider"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7696,8 +7728,8 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -7709,8 +7741,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -7785,8 +7817,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -7813,8 +7845,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-builder"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -7851,8 +7883,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-convert"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-consensus",
  "alloy-json-rpc",
@@ -7868,8 +7900,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-engine-api"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7898,8 +7930,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -7942,8 +7974,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7984,8 +8016,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-layer"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -7998,8 +8030,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8014,8 +8046,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8060,8 +8092,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-api"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8087,8 +8119,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8100,8 +8132,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -8120,8 +8152,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -8132,8 +8164,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8156,8 +8188,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8172,8 +8204,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tasks"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -8190,8 +8222,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -8200,8 +8232,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "clap",
  "eyre",
@@ -8215,8 +8247,8 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8253,8 +8285,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8277,8 +8309,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8300,8 +8332,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-db"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -8313,8 +8345,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-parallel"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8338,8 +8370,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8356,8 +8388,8 @@ dependencies = [
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "1.4.8"
-source = "git+https://github.com/berachain/reth?branch=prague1-berachain-reth#ad8fec466156245afb1fc6cbd1afed6dcbfc8b7b"
+version = "1.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7#07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7"
 dependencies = [
  "zstd",
 ]
@@ -11163,9 +11195,9 @@ dependencies = [
 
 [[package]]
 name = "xattr"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d65cbf2f12c15564212d48f4e3dfb87923d25d611f2aed18f4cb23f0413d89e"
+checksum = "af3a19837351dc82ba89f8a125e22a3c475f05aba604acc023d62b2739ae2909"
 dependencies = [
  "libc",
  "rustix 1.0.7",
@@ -11368,8 +11400,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "alloy-contract"
-version = "1.0.12"
-source = "git+https://github.com/alloy-rs/alloy?rev=08fa016ed950b6e65f810fc9cdef7cf38fbc63f6#08fa016ed950b6e65f810fc9cdef7cf38fbc63f6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,11 +5,11 @@ edition = "2024"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-alloy-consensus = "1.0.9"
-alloy-eips = "1.0.9"
-alloy-genesis = "1.0.9"
-alloy-primitives = "1.0.9"
-alloy-rpc-types = "1.0.9"
+alloy-consensus = "1.0.13"
+alloy-eips = "1.0.13"
+alloy-genesis = "1.0.13"
+alloy-primitives = "1.2.1"
+alloy-rpc-types = "1.0.13"
 clap = { version = "4.5.39", features = ["derive"] }
 derive_more = "2.0.1"
 eyre = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,19 +14,19 @@ clap = { version = "4.5.39", features = ["derive"] }
 derive_more = "2.0.1"
 eyre = "0.6"
 jsonrpsee-core = "0.25.1"
-reth = { git = "https://github.com/berachain/reth", branch = "prague1-berachain-reth" }
-reth-chainspec = { git = "https://github.com/berachain/reth", branch = "prague1-berachain-reth" }
-reth-cli = { git = "https://github.com/berachain/reth", branch = "prague1-berachain-reth" }
-reth-cli-commands = { git = "https://github.com/berachain/reth", branch = "prague1-berachain-reth" }
-reth-cli-util = { git = "https://github.com/berachain/reth", branch = "prague1-berachain-reth" }
-reth-db = { git = "https://github.com/berachain/reth", branch = "prague1-berachain-reth" }
-reth-ethereum-cli = { git = "https://github.com/berachain/reth", branch = "prague1-berachain-reth" }
-reth-evm = { git = "https://github.com/berachain/reth", branch = "prague1-berachain-reth" }
-reth-evm-ethereum = { git = "https://github.com/berachain/reth", branch = "prague1-berachain-reth" }
-reth-network-peers = { git = "https://github.com/berachain/reth", branch = "prague1-berachain-reth" }
-reth-node-builder = { git = "https://github.com/berachain/reth", branch = "prague1-berachain-reth" }
-reth-node-ethereum = { git = "https://github.com/berachain/reth", branch = "prague1-berachain-reth" }
-reth-tracing = { git = "https://github.com/berachain/reth", branch = "prague1-berachain-reth" }
+reth = { git = "https://github.com/paradigmxyz/reth", rev = "07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7" }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7" }
 serde = { version = "1.0", features = ["derive"], default-features = false }
 thiserror = "2.0"
 tracing = "0.1.41"
@@ -47,32 +47,3 @@ incremental = false
 inherits = "release"
 debug = "full"
 strip = "none"
-
-[patch.crates-io]
-alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "08fa016ed950b6e65f810fc9cdef7cf38fbc63f6" }
-alloy-contract = { git = "https://github.com/alloy-rs/alloy", rev = "08fa016ed950b6e65f810fc9cdef7cf38fbc63f6" }
-alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "08fa016ed950b6e65f810fc9cdef7cf38fbc63f6" }
-alloy-genesis = { git = "https://github.com/alloy-rs/alloy", rev = "08fa016ed950b6e65f810fc9cdef7cf38fbc63f6" }
-alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy", rev = "08fa016ed950b6e65f810fc9cdef7cf38fbc63f6" }
-alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "08fa016ed950b6e65f810fc9cdef7cf38fbc63f6" }
-alloy-network-primitives = { git = "https://github.com/alloy-rs/alloy", rev = "08fa016ed950b6e65f810fc9cdef7cf38fbc63f6" }
-alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "08fa016ed950b6e65f810fc9cdef7cf38fbc63f6" }
-alloy-pubsub = { git = "https://github.com/alloy-rs/alloy", rev = "08fa016ed950b6e65f810fc9cdef7cf38fbc63f6" }
-alloy-rpc-client = { git = "https://github.com/alloy-rs/alloy", rev = "08fa016ed950b6e65f810fc9cdef7cf38fbc63f6" }
-alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "08fa016ed950b6e65f810fc9cdef7cf38fbc63f6" }
-alloy-rpc-types-admin = { git = "https://github.com/alloy-rs/alloy", rev = "08fa016ed950b6e65f810fc9cdef7cf38fbc63f6" }
-alloy-rpc-types-anvil = { git = "https://github.com/alloy-rs/alloy", rev = "08fa016ed950b6e65f810fc9cdef7cf38fbc63f6" }
-alloy-rpc-types-beacon = { git = "https://github.com/alloy-rs/alloy", rev = "08fa016ed950b6e65f810fc9cdef7cf38fbc63f6" }
-alloy-rpc-types-debug = { git = "https://github.com/alloy-rs/alloy", rev = "08fa016ed950b6e65f810fc9cdef7cf38fbc63f6" }
-alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", rev = "08fa016ed950b6e65f810fc9cdef7cf38fbc63f6" }
-alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", rev = "08fa016ed950b6e65f810fc9cdef7cf38fbc63f6" }
-alloy-rpc-types-mev = { git = "https://github.com/alloy-rs/alloy", rev = "08fa016ed950b6e65f810fc9cdef7cf38fbc63f6" }
-alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", rev = "08fa016ed950b6e65f810fc9cdef7cf38fbc63f6" }
-alloy-rpc-types-txpool = { git = "https://github.com/alloy-rs/alloy", rev = "08fa016ed950b6e65f810fc9cdef7cf38fbc63f6" }
-alloy-serde = { git = "https://github.com/alloy-rs/alloy", rev = "08fa016ed950b6e65f810fc9cdef7cf38fbc63f6" }
-alloy-signer = { git = "https://github.com/alloy-rs/alloy", rev = "08fa016ed950b6e65f810fc9cdef7cf38fbc63f6" }
-alloy-signer-local = { git = "https://github.com/alloy-rs/alloy", rev = "08fa016ed950b6e65f810fc9cdef7cf38fbc63f6" }
-alloy-transport = { git = "https://github.com/alloy-rs/alloy", rev = "08fa016ed950b6e65f810fc9cdef7cf38fbc63f6" }
-alloy-transport-http = { git = "https://github.com/alloy-rs/alloy", rev = "08fa016ed950b6e65f810fc9cdef7cf38fbc63f6" }
-alloy-transport-ipc = { git = "https://github.com/alloy-rs/alloy", rev = "08fa016ed950b6e65f810fc9cdef7cf38fbc63f6" }
-alloy-transport-ws = { git = "https://github.com/alloy-rs/alloy", rev = "08fa016ed950b6e65f810fc9cdef7cf38fbc63f6" }


### PR DESCRIPTION
## Summary
- Updated all reth dependencies from berachain/reth fork to upstream paradigmxyz/reth at commit 07b19553a14fe9c2e6c36a7c3b8b793bbc9c50a7
- Updated alloy dependencies to their latest versions:
  - alloy-consensus: 1.0.9 → 1.0.13
  - alloy-eips: 1.0.9 → 1.0.13
  - alloy-genesis: 1.0.9 → 1.0.13
  - alloy-primitives: 1.0.9 → 1.2.1
  - alloy-rpc-types: 1.0.9 → 1.0.13
- Removed alloy patches that are no longer needed
- Verified build and tests pass with updated dependencies

## Test plan
- [x] Build completes successfully with `cargo build --release`
- [x] All quality checks pass with `make pr`
- [x] All tests pass
- [x] Compatible with latest alloy versions