### PR TITLE
fix: handle EIP-4844 and EIP-7702 transaction types in compact encoding

### DIFF
--- a/src/transaction/txtype.rs
+++ b/src/transaction/txtype.rs
@@ -105,4 +105,85 @@ mod tests {
         let (decoded, _) = BerachainTxType::from_compact(&buf, identifier);
         assert_eq!(tx_type, decoded);
     }
+
+    /// Test backwards compatibility: Ethereum TxType -> compact -> BerachainTxType
+    /// This ensures existing Ethereum transaction data can be read by Berachain
+    #[test]
+    fn test_backwards_compatibility_ethereum_to_berachain() {
+        let ethereum_types = vec![
+            TxType::Legacy,
+            TxType::Eip2930,
+            TxType::Eip1559,
+            TxType::Eip4844,
+            TxType::Eip7702,
+        ];
+
+        for eth_type in ethereum_types {
+            // Compact using standard Ethereum TxType
+            let mut buf = Vec::new();
+            let identifier = eth_type.to_compact(&mut buf);
+
+            // Decompress using BerachainTxType
+            let (berachain_type, _) = BerachainTxType::from_compact(&buf, identifier);
+
+            // Should convert to BerachainTxType::Ethereum variant
+            match berachain_type {
+                BerachainTxType::Ethereum(decoded_eth_type) => {
+                    assert_eq!(
+                        decoded_eth_type, eth_type,
+                        "Ethereum type {eth_type:?} should round-trip correctly"
+                    );
+                }
+                BerachainTxType::Berachain => {
+                    panic!(
+                        "Ethereum type {eth_type:?} should not decode as Berachain POL transaction"
+                    );
+                }
+            }
+        }
+    }
+
+    /// Test that BerachainTxType can decompress data originally compressed by Ethereum TxType
+    /// for specific transaction types that use extended identifiers
+    #[test]
+    fn test_backwards_compatibility_extended_identifiers() {
+        // Test EIP-4844 (blob transactions)
+        let eip4844_type = TxType::Eip4844;
+        let mut buf = Vec::new();
+        let identifier = eip4844_type.to_compact(&mut buf);
+
+        let (decoded, _) = BerachainTxType::from_compact(&buf, identifier);
+        assert_eq!(decoded, BerachainTxType::Ethereum(TxType::Eip4844));
+
+        // Test EIP-7702 (set code transactions)
+        let eip7702_type = TxType::Eip7702;
+        let mut buf = Vec::new();
+        let identifier = eip7702_type.to_compact(&mut buf);
+
+        let (decoded, _) = BerachainTxType::from_compact(&buf, identifier);
+        assert_eq!(decoded, BerachainTxType::Ethereum(TxType::Eip7702));
+    }
+
+    /// Test that standard Ethereum types (0-2) use direct identifiers
+    /// and don't interfere with Berachain's extended identifier usage
+    #[test]
+    fn test_backwards_compatibility_direct_identifiers() {
+        // These should use direct identifiers, not extended
+        let direct_types = vec![
+            (TxType::Legacy, BerachainTxType::Ethereum(TxType::Legacy)),
+            (TxType::Eip2930, BerachainTxType::Ethereum(TxType::Eip2930)),
+            (TxType::Eip1559, BerachainTxType::Ethereum(TxType::Eip1559)),
+        ];
+
+        for (eth_type, expected_berachain_type) in direct_types {
+            let mut buf = Vec::new();
+            let identifier = eth_type.to_compact(&mut buf);
+
+            // Direct identifiers should not write to buffer
+            assert!(buf.is_empty(), "Direct identifier types should not write to buffer");
+
+            let (decoded, _) = BerachainTxType::from_compact(&buf, identifier);
+            assert_eq!(decoded, expected_berachain_type);
+        }
+    }
 }

--- a/src/transaction/txtype.rs
+++ b/src/transaction/txtype.rs
@@ -36,6 +36,8 @@ impl Compact for BerachainTxType {
                 let tx_type_byte = buf.get_u8();
                 match tx_type_byte {
                     POL_TX_TYPE => Self::Berachain,
+                    3 => Self::Ethereum(TxType::Eip4844), // EIP-4844 blob transactions
+                    4 => Self::Ethereum(TxType::Eip7702), // EIP-7702 set code transactions
                     _ => panic!("Unsupported BerachainTxType extended identifier: {tx_type_byte}"),
                 }
             }
@@ -63,5 +65,44 @@ impl Decompress for BerachainTxType {
     fn decompress(value: &[u8]) -> Result<Self, DatabaseError> {
         let (tx, _) = reth_codecs::Compact::from_compact(value, value.len());
         Ok(tx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_consensus::TxType;
+
+    #[test]
+    fn test_eip4844_compact_roundtrip() {
+        let tx_type = BerachainTxType::Ethereum(TxType::Eip4844);
+
+        let mut buf = Vec::new();
+        let identifier = tx_type.to_compact(&mut buf);
+
+        let (decoded, _) = BerachainTxType::from_compact(&buf, identifier);
+        assert_eq!(tx_type, decoded);
+    }
+
+    #[test]
+    fn test_eip7702_compact_roundtrip() {
+        let tx_type = BerachainTxType::Ethereum(TxType::Eip7702);
+
+        let mut buf = Vec::new();
+        let identifier = tx_type.to_compact(&mut buf);
+
+        let (decoded, _) = BerachainTxType::from_compact(&buf, identifier);
+        assert_eq!(tx_type, decoded);
+    }
+
+    #[test]
+    fn test_berachain_pol_compact_roundtrip() {
+        let tx_type = BerachainTxType::Berachain;
+
+        let mut buf = Vec::new();
+        let identifier = tx_type.to_compact(&mut buf);
+
+        let (decoded, _) = BerachainTxType::from_compact(&buf, identifier);
+        assert_eq!(tx_type, decoded);
     }
 }

--- a/src/transaction/txtype.rs
+++ b/src/transaction/txtype.rs
@@ -2,6 +2,7 @@
 
 use crate::transaction::{BerachainTxType, POL_TX_TYPE};
 use alloy_consensus::TxType;
+use alloy_eips::eip2718::{EIP4844_TX_TYPE_ID, EIP7702_TX_TYPE_ID};
 use bytes::{Buf, BufMut};
 use reth::providers::errors::db::DatabaseError;
 use reth_codecs::{Compact, txtype::COMPACT_EXTENDED_IDENTIFIER_FLAG};
@@ -22,9 +23,6 @@ impl Compact for BerachainTxType {
         }
     }
 
-    // For backwards compatibility purposes only 2 bits of the type are encoded in the identifier
-    // parameter. In the case of a [`COMPACT_EXTENDED_IDENTIFIER_FLAG`], the full transaction type
-    // is read from the buffer as a single byte.
     fn from_compact(mut buf: &[u8], identifier: usize) -> (Self, &[u8]) {
         use reth_codecs::txtype::*;
 
@@ -33,12 +31,14 @@ impl Compact for BerachainTxType {
             COMPACT_IDENTIFIER_EIP2930 => Self::Ethereum(TxType::Eip2930),
             COMPACT_IDENTIFIER_EIP1559 => Self::Ethereum(TxType::Eip1559),
             COMPACT_EXTENDED_IDENTIFIER_FLAG => {
-                let tx_type_byte = buf.get_u8();
-                match tx_type_byte {
+                let extended_identifier = buf.get_u8();
+                match extended_identifier {
                     POL_TX_TYPE => Self::Berachain,
-                    3 => Self::Ethereum(TxType::Eip4844), // EIP-4844 blob transactions
-                    4 => Self::Ethereum(TxType::Eip7702), // EIP-7702 set code transactions
-                    _ => panic!("Unsupported BerachainTxType extended identifier: {tx_type_byte}"),
+                    EIP4844_TX_TYPE_ID => Self::Ethereum(TxType::Eip4844),
+                    EIP7702_TX_TYPE_ID => Self::Ethereum(TxType::Eip7702),
+                    _ => panic!(
+                        "Unsupported BerachainTxType extended identifier: {extended_identifier}"
+                    ),
                 }
             }
             _ => panic!("Unknown identifier for BerachainTxType: {identifier}"),


### PR DESCRIPTION
## Summary
- Fixes panic `"Unsupported BerachainTxType extended identifier: 3"` during transaction processing
- Adds missing support for EIP-4844 (blob) and EIP-7702 (set code) transaction types in compact encoding
- Ensures complete backwards compatibility with existing Ethereum transaction data

## Test plan
- [x] Added comprehensive backwards compatibility tests
- [x] Verified roundtrip encoding/decoding for all transaction types
- [x] Tested Ethereum TxType → compact → BerachainTxType conversion
- [x] All 55 tests pass including new backwards compatibility coverage