### PR TITLE
chore: update reth to commit 58235419bb855728d9f2afbc8bd59cf8690e8804

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,9 +110,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3b746060277f3d7f9c36903bb39b593a741cb7afcb0044164c28f0e9b673f0"
+checksum = "1b6093bc69509849435a2d68237a2e9fea79d27390c8e62f1e4012c460aabad8"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -135,9 +135,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf98679329fa708fa809ea596db6d974da892b068ad45e48ac1956f582edf946"
+checksum = "8d1cfed4fefd13b5620cb81cdb6ba397866ff0de514c1b24806e6e79cdff5570"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -149,9 +149,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b95b3deca680efc7e9cba781f1a1db352fa1ea50e6384a514944dcf4419e652"
+checksum = "d9e8a436f0aad7df8bb47f144095fba61202265d9f5f09a70b0e3227881a668e"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -204,9 +204,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f562a81278a3ed83290e68361f2d1c75d018ae3b8589a314faf9303883e18ec9"
+checksum = "5937e2d544e9b71000942d875cbc57965b32859a666ea543cc57aae5a06d602d"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -246,9 +246,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc41384e9ab8c9b2fb387c52774d9d432656a28edcda1c2d4083e96051524518"
+checksum = "c51b4c13e02a8104170a4de02ccf006d7c233e6c10ab290ee16e7041e6ac221d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -274,9 +274,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15516116086325c157c18261d768a20677f0f699348000ed391d4ad0dcb82530"
+checksum = "459f98c6843f208856f338bfb25e65325467f7aff35dfeb0484d0a76e059134b"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -286,9 +286,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12c454fcfcd5d26ed3b8cae5933cbee9da5f0b05df19b46d4bd4446d1f082565"
+checksum = "b590caa6b6d8bc10e6e7a7696c59b1e550e89f27f50d1ee13071150d3a3e3f66"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -301,9 +301,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d6d39eabe5c7b3d8f23ac47b0b683b99faa4359797114636c66e0743103d05"
+checksum = "36fe5af1fca03277daa56ad4ce5f6d623d3f4c2273ea30b9ee8674d18cefc1fa"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -327,9 +327,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3704fa8b7ba9ba3f378d99b3d628c8bc8c2fc431b709947930f154e22a8368b6"
+checksum = "793df1e3457573877fbde8872e4906638fde565ee2d3bd16d04aad17d43dbf0e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -340,9 +340,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6177ed26655d4e84e00b65cb494d4e0b8830e7cae7ef5d63087d445a2600fb55"
+checksum = "3cfebde8c581a5d37b678d0a48a32decb51efd7a63a08ce2517ddec26db705c8"
 dependencies = [
  "alloy-rlp",
  "bytes",
@@ -368,9 +368,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08800e8cbe70c19e2eb7cf3d7ff4b28bdd9b3933f8e1c8136c7d910617ba03bf"
+checksum = "d59879a772ebdcde9dc4eb38b2535d32e8503d3175687cc09e763a625c5fcf32"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -411,9 +411,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae68457a2c2ead6bd7d7acb5bf5f1623324b1962d4f8e7b0250657a3c3ab0a0b"
+checksum = "fbdfb2899b54b7cb0063fa8e61938320f9be6b81b681be69c203abf130a87baa"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -454,9 +454,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162301b5a57d4d8f000bf30f4dcb82f9f468f3e5e846eeb8598dd39e7886932c"
+checksum = "7f060e3bb9f319eb01867a2d6d1ff9e0114e8877f5ca8f5db447724136106cae"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -480,9 +480,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cd8ca94ae7e2b32cc3895d9981f3772aab0b4756aa60e9ed0bcfee50f0e1328"
+checksum = "d47b637369245d2dafef84b223b1ff5ea59e6cd3a98d2d3516e32788a0b216df"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -493,9 +493,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-admin"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7bff682e76f3f72e9ddc75e54a1bd1db5ce53cbdf2cce2d63a3a981437f78f5"
+checksum = "db29bf8f7c961533b017f383122cab6517c8da95712cf832e23c60415d520a58"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -505,9 +505,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f3ff6a778ebda3deaed9af17930d678611afe1effa895c4260b61009c314f82"
+checksum = "c0b1f499acb3fc729615147bc113b8b798b17379f19d43058a687edc5792c102"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -517,9 +517,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "076b47e834b367d8618c52dd0a0d6a711ddf66154636df394805300af4923b8a"
+checksum = "1e26b4dd90b33bd158975307fb9cf5fafa737a0e33cbb772a8648bf8be13c104"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -528,9 +528,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-beacon"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f39da9b760e78fc3f347fba4da257aa6328fb33f73682b26cc0a6874798f7d"
+checksum = "9196cbbf4b82a3cc0c471a8e68ccb30102170d930948ac940d2bceadc1b1346b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -546,9 +546,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94a2a86ad7b7d718c15e79d0779bd255561b6b22968dc5ed2e7c0fbc43bb55fe"
+checksum = "71841e6fc8e221892035a74f7d5b279c0a2bf27a7e1c93e7476c64ce9056624e"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -556,9 +556,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ba838417c42e8f1fe5eb4f4bbfacb7b5d4b9e615b8d2e831b921e04bf0bed62"
+checksum = "f2f9cbf5f781b9ee39cfdddea078fdef6015424f4c8282ef0e5416d15ca352c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -576,9 +576,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c2f847e635ec0be819d06e2ada4bcc4e4204026a83c4bfd78ae8d550e027ae7"
+checksum = "46586ec3c278639fc0e129f0eb73dbfa3d57f683c44b2ff5e066fab7ba63fa1f"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -597,9 +597,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-mev"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb1c9b23cedf70aeb99ea9f16b78cdf902f524e227922fb340e3eb899ebe96dc"
+checksum = "79b6e80b501842c3f5803dd5752ae41b61f43bf6d2e1b8d29999d3312d67a8a5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -612,9 +612,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fc58180302a94c934d455eeedb3ecb99cdc93da1dbddcdbbdb79dd6fe618b2a"
+checksum = "bc9a2184493c374ca1dbba9569d37215c23e489970f8c3994f731cb3ed6b0b7d"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -626,9 +626,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9f089d78bb94148e0fcfda087d4ce5fd35a7002847b5e90610c0fcb140f7b4"
+checksum = "a3aaf142f4f6c0bdd06839c422179bae135024407d731e6f365380f88cd4730e"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -638,9 +638,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae699248d02ade9db493bbdae61822277dc14ae0f82a5a4153203b60e34422a6"
+checksum = "1e1722bc30feef87cc0fa824e43c9013f9639cc6c037be7be28a31361c788be2"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -649,9 +649,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cf7d793c813515e2b627b19a15693960b3ed06670f9f66759396d06ebe5747b"
+checksum = "d3674beb29e68fbbc7be302b611cf35fe07b736e308012a280861df5a2361395"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -664,9 +664,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51a424bc5a11df0d898ce0fd15906b88ebe2a6e4f17a514b51bc93946bb756bd"
+checksum = "ad7094c39cd41b03ed642145b0bd37251e31a9cf2ed19e1ce761f089867356a6"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -680,9 +680,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a14f21d053aea4c6630687c2f4ad614bed4c81e14737a9b904798b24f30ea849"
+checksum = "aedac07a10d4c2027817a43cc1f038313fc53c7ac866f7363239971fd01f9f18"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
@@ -694,9 +694,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34d99282e7c9ef14eb62727981a985a01869e586d1dec729d3bb33679094c100"
+checksum = "24f9a598f010f048d8b8226492b6401104f5a5c1273c2869b72af29b48bb4ba9"
 dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
@@ -712,9 +712,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eda029f955b78e493360ee1d7bd11e1ab9f2a220a5715449babc79d6d0a01105"
+checksum = "f494adf9d60e49aa6ce26dfd42c7417aa6d4343cf2ae621f20e4d92a5ad07d85"
 dependencies = [
  "const-hex",
  "dunce",
@@ -728,9 +728,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10db1bd7baa35bc8d4a1b07efbf734e73e5ba09f2580fb8cee3483a36087ceb2"
+checksum = "52db32fbd35a9c0c0e538b58b81ebbae08a51be029e7ad60e08b60481c2ec6c3"
 dependencies = [
  "serde",
  "winnow",
@@ -738,9 +738,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58377025a47d8b8426b3e4846a251f2c1991033b27f517aade368146f6ab1dfe"
+checksum = "a285b46e3e0c177887028278f04cc8262b76fd3b8e0e20e93cea0a58c35f5ac5"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -750,9 +750,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f317d20f047b3de4d9728c556e2e9a92c9a507702d2016424cd8be13a74ca5e"
+checksum = "f89bec2f59a41c0e259b6fe92f78dfc49862c17d10f938db9c33150d5a7f42b6"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -773,9 +773,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff084ac7b1f318c87b579d221f11b748341d68b9ddaa4ffca5e62ed2b8cfefb4"
+checksum = "0d3615ec64d775fec840f4e9d5c8e1f739eb1854d8d28db093fb3d4805e0cb53"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -788,9 +788,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edb099cdad8ed2e6a80811cdf9bbf715ebf4e34c981b4a6e2d1f9daacbf8b218"
+checksum = "374db72669d8ee09063b9aa1a316e812d5cdfce7fc9a99a3eceaa0e5512300d2"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -808,9 +808,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e915e1250dc129ad48d264573ccd08e4716fdda564a772fd217875b8459aff9"
+checksum = "f5dbaa6851875d59c8803088f4b6ec72eaeddf7667547ae8995c1a19fbca6303"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -842,9 +842,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1154c8187a5ff985c95a8b2daa2fedcf778b17d7668e5e50e556c4ff9c881154"
+checksum = "9f916ff6d52f219c44a9684aea764ce2c7e1d53bd4a724c9b127863aeacc30bb"
 dependencies = [
  "alloy-primitives",
  "darling 0.20.11",
@@ -2670,7 +2670,7 @@ dependencies = [
  "parking_lot",
  "rand 0.8.5",
  "smallvec",
- "socket2",
+ "socket2 0.5.10",
  "tokio",
  "tracing",
  "uint 0.10.0",
@@ -3598,9 +3598,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66d5bd4c6f02bf0542fad85d626775bab9258cf795a4256dcaf3161114d1df"
+checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
 dependencies = [
  "base64",
  "bytes",
@@ -3614,7 +3614,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.0",
  "tokio",
  "tower-service",
  "tracing",
@@ -4027,9 +4027,9 @@ dependencies = [
 
 [[package]]
 name = "io-uring"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
+checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
 dependencies = [
  "bitflags 2.9.1",
  "cfg-if",
@@ -4042,7 +4042,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
 dependencies = [
- "socket2",
+ "socket2 0.5.10",
  "widestring",
  "windows-sys 0.48.0",
  "winreg",
@@ -5125,9 +5125,9 @@ checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "op-alloy-consensus"
-version = "0.18.12"
+version = "0.18.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eda4af86c3185b06f8d70986a591c087f054c5217cc7ce53cd0ec36dc42d7425"
+checksum = "d3c719b26da6d9cac18c3a35634d6ab27a74a304ed9b403b43749c22e57a389f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5142,9 +5142,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-rpc-types-engine"
-version = "0.18.12"
+version = "0.18.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a420102c1b857a4ba373fcaf674d5c0499fd3705ddce95be9a69f3561c337b3"
+checksum = "50cf45d43a3d548fdc39d9bfab6ba13cc06b3214ef4b9c36d3efbf3faea1b9f1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5630,7 +5630,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2",
+ "socket2 0.5.10",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -5667,7 +5667,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -5985,8 +5985,8 @@ checksum = "95325155c684b1c89f7765e30bc1c42e4a6da51ca513615660cb8a62ef9a88e3"
 
 [[package]]
 name = "reth"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-rpc-types",
  "aquamarine",
@@ -6031,8 +6031,8 @@ dependencies = [
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6055,8 +6055,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chain-state"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6084,8 +6084,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -6104,8 +6104,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -6118,8 +6118,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-commands"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "ahash",
  "alloy-chains",
@@ -6191,8 +6191,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-runner"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -6201,8 +6201,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6219,8 +6219,8 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6237,8 +6237,8 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -6248,8 +6248,8 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -6263,8 +6263,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -6276,8 +6276,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6288,8 +6288,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6313,8 +6313,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -6337,8 +6337,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -6362,8 +6362,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -6391,8 +6391,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6405,8 +6405,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -6431,8 +6431,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -6455,8 +6455,8 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -6479,8 +6479,8 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6509,8 +6509,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -6540,8 +6540,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-local"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -6562,8 +6562,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6587,8 +6587,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-service"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "futures",
  "pin-project",
@@ -6610,8 +6610,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-tree"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6658,8 +6658,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-util"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -6685,8 +6685,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6701,8 +6701,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era-downloader"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -6716,8 +6716,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era-utils"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -6740,8 +6740,8 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -6751,8 +6751,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -6779,8 +6779,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -6800,8 +6800,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-cli"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-consensus",
  "clap",
@@ -6822,8 +6822,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6838,8 +6838,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6856,8 +6856,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -6869,8 +6869,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6896,8 +6896,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6913,8 +6913,8 @@ dependencies = [
 
 [[package]]
 name = "reth-etl"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -6923,8 +6923,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6946,8 +6946,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6965,8 +6965,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -6978,8 +6978,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6996,8 +6996,8 @@ dependencies = [
 
 [[package]]
 name = "reth-exex"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7034,8 +7034,8 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-types"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7048,8 +7048,8 @@ dependencies = [
 
 [[package]]
 name = "reth-fs-util"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "serde",
  "serde_json",
@@ -7058,8 +7058,8 @@ dependencies = [
 
 [[package]]
 name = "reth-invalid-block-hooks"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7086,8 +7086,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ipc"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "bytes",
  "futures",
@@ -7106,8 +7106,8 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "bitflags 2.9.1",
  "byteorder",
@@ -7123,8 +7123,8 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "bindgen",
  "cc",
@@ -7132,8 +7132,8 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "futures",
  "metrics",
@@ -7144,16 +7144,16 @@ dependencies = [
 
 [[package]]
 name = "reth-net-banlist"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "reth-net-nat"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -7166,8 +7166,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7221,8 +7221,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7246,8 +7246,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-p2p"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7268,8 +7268,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7283,8 +7283,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -7297,8 +7297,8 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -7314,8 +7314,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -7338,8 +7338,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-builder"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7403,8 +7403,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7455,8 +7455,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethereum"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -7464,7 +7464,6 @@ dependencies = [
  "alloy-rpc-types-eth",
  "eyre",
  "reth-chainspec",
- "reth-consensus",
  "reth-engine-local",
  "reth-engine-primitives",
  "reth-ethereum-consensus",
@@ -7494,8 +7493,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethstats"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7518,8 +7517,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-events"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7542,8 +7541,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-metrics"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "eyre",
  "http",
@@ -7563,8 +7562,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-types"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -7576,8 +7575,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types",
@@ -7596,8 +7595,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder-primitives"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -7608,8 +7607,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7627,8 +7626,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -7637,8 +7636,8 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-consensus",
  "once_cell",
@@ -7650,8 +7649,8 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7680,8 +7679,8 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7722,8 +7721,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7750,8 +7749,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -7763,8 +7762,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ress-protocol"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7782,8 +7781,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ress-provider"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7809,8 +7808,8 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -7822,8 +7821,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -7851,6 +7850,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "itertools 0.14.0",
  "jsonrpsee",
  "jsonrpsee-types",
  "jsonwebtoken",
@@ -7897,8 +7897,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -7925,8 +7925,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-builder"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -7963,8 +7963,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-convert"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-consensus",
  "alloy-json-rpc",
@@ -7982,8 +7982,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-engine-api"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8012,8 +8012,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -8039,7 +8039,6 @@ dependencies = [
  "reth-evm",
  "reth-network-api",
  "reth-node-api",
- "reth-payload-builder",
  "reth-primitives-traits",
  "reth-revm",
  "reth-rpc-convert",
@@ -8057,8 +8056,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8101,8 +8100,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-layer"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -8115,8 +8114,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8131,8 +8130,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8177,8 +8176,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-api"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8204,8 +8203,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8217,8 +8216,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -8237,8 +8236,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -8249,8 +8248,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8273,8 +8272,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8289,8 +8288,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tasks"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -8307,8 +8306,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -8317,8 +8316,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "clap",
  "eyre",
@@ -8332,8 +8331,8 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8370,8 +8369,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8394,8 +8393,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8417,8 +8416,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-db"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -8430,8 +8429,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-parallel"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8455,8 +8454,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8473,8 +8472,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse-parallel"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8489,8 +8488,8 @@ dependencies = [
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "1.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8f26b95643c151ec7fd6498264ada0974c7db3f1#8f26b95643c151ec7fd6498264ada0974c7db3f1"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=58235419bb855728d9f2afbc8bd59cf8690e8804#58235419bb855728d9f2afbc8bd59cf8690e8804"
 dependencies = [
  "zstd",
 ]
@@ -8625,9 +8624,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.26.5"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7b99a2332cf8eed9e9a22fffbf76dfadc99d2c45de6ae6431a1eb9f657dd97a"
+checksum = "aad27cab355b0aa905d0744f3222e716b40ad48b32276ac4b0a615f2c3364c97"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -9509,6 +9508,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "soketto"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9631,9 +9640,9 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ac494e7266fcdd2ad80bf4375d55d27a117ea5c866c26d0e97fe5b3caeeb75"
+checksum = "a7a985ff4ffd7373e10e0fb048110fb11a162e5a4c47f92ddb8787a6f766b769"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -9950,7 +9959,7 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
- "socket2",
+ "socket2 0.5.10",
  "tokio-macros",
  "windows-sys 0.52.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,37 +33,37 @@ jsonrpsee-types = "0.25.1"
 
 async-trait = "0.1.88"
 modular-bitfield = "0.11.2"
-reth = { git = "https://github.com/paradigmxyz/reth", rev = "8f26b95643c151ec7fd6498264ada0974c7db3f1" }
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8f26b95643c151ec7fd6498264ada0974c7db3f1" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "8f26b95643c151ec7fd6498264ada0974c7db3f1" }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "8f26b95643c151ec7fd6498264ada0974c7db3f1" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "8f26b95643c151ec7fd6498264ada0974c7db3f1" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "8f26b95643c151ec7fd6498264ada0974c7db3f1" }
-reth-codecs = { git = "https://github.com/paradigmxyz/reth", rev = "8f26b95643c151ec7fd6498264ada0974c7db3f1" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "8f26b95643c151ec7fd6498264ada0974c7db3f1" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "8f26b95643c151ec7fd6498264ada0974c7db3f1" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "8f26b95643c151ec7fd6498264ada0974c7db3f1" }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8f26b95643c151ec7fd6498264ada0974c7db3f1" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "8f26b95643c151ec7fd6498264ada0974c7db3f1" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8f26b95643c151ec7fd6498264ada0974c7db3f1" }
-reth-ethereum-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8f26b95643c151ec7fd6498264ada0974c7db3f1" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8f26b95643c151ec7fd6498264ada0974c7db3f1" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "8f26b95643c151ec7fd6498264ada0974c7db3f1" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8f26b95643c151ec7fd6498264ada0974c7db3f1" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "8f26b95643c151ec7fd6498264ada0974c7db3f1" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "8f26b95643c151ec7fd6498264ada0974c7db3f1" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8f26b95643c151ec7fd6498264ada0974c7db3f1" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "8f26b95643c151ec7fd6498264ada0974c7db3f1" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8f26b95643c151ec7fd6498264ada0974c7db3f1" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8f26b95643c151ec7fd6498264ada0974c7db3f1" }
-reth-payload-validator = { git = "https://github.com/paradigmxyz/reth", rev = "8f26b95643c151ec7fd6498264ada0974c7db3f1" }
-reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", rev = "8f26b95643c151ec7fd6498264ada0974c7db3f1" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "8f26b95643c151ec7fd6498264ada0974c7db3f1" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "8f26b95643c151ec7fd6498264ada0974c7db3f1" }
-reth-rpc-engine-api = { git = "https://github.com/paradigmxyz/reth", rev = "8f26b95643c151ec7fd6498264ada0974c7db3f1" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "8f26b95643c151ec7fd6498264ada0974c7db3f1" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "8f26b95643c151ec7fd6498264ada0974c7db3f1" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "8f26b95643c151ec7fd6498264ada0974c7db3f1" }
+reth = { git = "https://github.com/paradigmxyz/reth", rev = "58235419bb855728d9f2afbc8bd59cf8690e8804" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "58235419bb855728d9f2afbc8bd59cf8690e8804" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "58235419bb855728d9f2afbc8bd59cf8690e8804" }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "58235419bb855728d9f2afbc8bd59cf8690e8804" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "58235419bb855728d9f2afbc8bd59cf8690e8804" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "58235419bb855728d9f2afbc8bd59cf8690e8804" }
+reth-codecs = { git = "https://github.com/paradigmxyz/reth", rev = "58235419bb855728d9f2afbc8bd59cf8690e8804" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "58235419bb855728d9f2afbc8bd59cf8690e8804" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "58235419bb855728d9f2afbc8bd59cf8690e8804" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "58235419bb855728d9f2afbc8bd59cf8690e8804" }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "58235419bb855728d9f2afbc8bd59cf8690e8804" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "58235419bb855728d9f2afbc8bd59cf8690e8804" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "58235419bb855728d9f2afbc8bd59cf8690e8804" }
+reth-ethereum-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "58235419bb855728d9f2afbc8bd59cf8690e8804" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "58235419bb855728d9f2afbc8bd59cf8690e8804" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "58235419bb855728d9f2afbc8bd59cf8690e8804" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "58235419bb855728d9f2afbc8bd59cf8690e8804" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "58235419bb855728d9f2afbc8bd59cf8690e8804" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "58235419bb855728d9f2afbc8bd59cf8690e8804" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "58235419bb855728d9f2afbc8bd59cf8690e8804" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "58235419bb855728d9f2afbc8bd59cf8690e8804" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "58235419bb855728d9f2afbc8bd59cf8690e8804" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "58235419bb855728d9f2afbc8bd59cf8690e8804" }
+reth-payload-validator = { git = "https://github.com/paradigmxyz/reth", rev = "58235419bb855728d9f2afbc8bd59cf8690e8804" }
+reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", rev = "58235419bb855728d9f2afbc8bd59cf8690e8804" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "58235419bb855728d9f2afbc8bd59cf8690e8804" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "58235419bb855728d9f2afbc8bd59cf8690e8804" }
+reth-rpc-engine-api = { git = "https://github.com/paradigmxyz/reth", rev = "58235419bb855728d9f2afbc8bd59cf8690e8804" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "58235419bb855728d9f2afbc8bd59cf8690e8804" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "58235419bb855728d9f2afbc8bd59cf8690e8804" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "58235419bb855728d9f2afbc8bd59cf8690e8804" }
 serde = { version = "1.0", features = ["derive"], default-features = false }
 test-fuzz = "7"
 thiserror = "2.0"

--- a/src/rpc/api.rs
+++ b/src/rpc/api.rs
@@ -13,9 +13,7 @@ use alloy_rpc_types_eth::{Transaction as RpcTransaction, TransactionRequest};
 use core::fmt;
 use derive_more::Deref;
 use reth::{
-    providers::{
-        BlockReader, NodePrimitivesProvider, ProviderHeader, ProviderTx, TransactionsProvider,
-    },
+    providers::{ProviderHeader, ProviderTx},
     rpc::compat::{RpcConvert, RpcTypes},
     tasks::{
         TaskSpawner,
@@ -23,9 +21,7 @@ use reth::{
     },
     transaction_pool::{PoolTransaction, TransactionPool},
 };
-use reth_chainspec::EthChainSpec;
-use reth_evm::{ConfigureEvm, TxEnvFor};
-use reth_primitives_traits::NodePrimitives;
+use reth_evm::TxEnvFor;
 use reth_rpc::eth::DevSigner;
 use reth_rpc_convert::SignableTxRequest;
 use reth_rpc_eth_api::{
@@ -455,7 +451,7 @@ where
 {
     #[inline]
     fn signers(&self) -> &SignersForRpc<Self::Provider, Self::NetworkTypes> {
-        self.inner.signers()
+        EthTransactions::signers(&self.inner)
     }
 
     /// Decodes and recovers the transaction and submits it to the pool.

--- a/src/rpc/api.rs
+++ b/src/rpc/api.rs
@@ -3,7 +3,7 @@ use crate::{
     rpc::receipt::BerachainReceiptEnvelope,
     transaction::{BerachainTxEnvelope, BerachainTxType, POL_TX_TYPE},
 };
-use alloy_consensus::{Transaction, crypto::RecoveryError};
+use alloy_consensus::Transaction;
 use alloy_eips::eip2930::AccessList;
 use alloy_network::{
     BuildResult, Network, NetworkWallet, TransactionBuilder, TransactionBuilderError,
@@ -13,12 +13,8 @@ use alloy_rpc_types_eth::{Transaction as RpcTransaction, TransactionRequest};
 use core::fmt;
 use derive_more::Deref;
 use reth::{
-    chainspec::EthereumHardforks,
-    network::NetworkInfo,
     providers::{
-        BlockNumReader, BlockReader, BlockReaderIdExt, NodePrimitivesProvider, ProviderBlock,
-        ProviderError, ProviderHeader, ProviderReceipt, ProviderTx, StageCheckpointReader,
-        StateProviderFactory, TransactionsProvider,
+        BlockReader, NodePrimitivesProvider, ProviderHeader, ProviderTx, TransactionsProvider,
     },
     rpc::compat::{RpcConvert, RpcTypes},
     tasks::{
@@ -27,13 +23,13 @@ use reth::{
     },
     transaction_pool::{PoolTransaction, TransactionPool},
 };
-use reth_chainspec::{ChainSpecProvider, EthChainSpec};
+use reth_chainspec::EthChainSpec;
 use reth_evm::{ConfigureEvm, TxEnvFor};
 use reth_primitives_traits::NodePrimitives;
 use reth_rpc::eth::DevSigner;
 use reth_rpc_convert::SignableTxRequest;
 use reth_rpc_eth_api::{
-    EthApiTypes, FromEthApiError, FullEthApiTypes, RpcNodeCore, RpcNodeCoreExt,
+    EthApiTypes, RpcNodeCore, RpcNodeCoreExt,
     helpers::{
         AddDevSigners, Call, EthApiSpec, EthBlocks, EthCall, EthFees, EthState, EthTransactions,
         LoadBlock, LoadFee, LoadPendingBlock, LoadReceipt, LoadState, LoadTransaction,
@@ -47,7 +43,7 @@ use reth_rpc_eth_types::{
     EthApiError, EthStateCache, FeeHistoryCache, GasPriceOracle, PendingBlock, error::FromEvmError,
     utils::recover_raw_transaction,
 };
-use reth_transaction_pool::TransactionOrigin;
+use reth_transaction_pool::{AddedTransactionOutcome, TransactionOrigin};
 
 impl fmt::Display for BerachainTxType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -337,23 +333,15 @@ impl Network for BerachainNetwork {
 }
 
 #[derive(Deref)]
-pub struct BerachainApi<
-    Provider: BlockReader,
-    Pool,
-    Network,
-    EvmConfig: ConfigureEvm,
-    Rpc: RpcConvert,
-> {
+pub struct BerachainApi<N: RpcNodeCore, Rpc: RpcConvert> {
     /// All nested fields bundled together.
     #[deref]
-    pub(super) inner: reth_rpc::EthApi<Provider, Pool, Network, EvmConfig, Rpc>,
+    pub(super) inner: reth_rpc::EthApi<N, Rpc>,
 }
 
-impl<Provider, Pool, Network, EvmConfig, Rpc> Clone
-    for BerachainApi<Provider, Pool, Network, EvmConfig, Rpc>
+impl<N, Rpc> Clone for BerachainApi<N, Rpc>
 where
-    Provider: BlockReader,
-    EvmConfig: ConfigureEvm,
+    N: RpcNodeCore,
     Rpc: RpcConvert,
 {
     fn clone(&self) -> Self {
@@ -361,17 +349,14 @@ where
     }
 }
 
-impl<Provider, Pool, Network, EvmConfig, Rpc> EthApiTypes
-    for BerachainApi<Provider, Pool, Network, EvmConfig, Rpc>
+impl<N, Rpc> EthApiTypes for BerachainApi<N, Rpc>
 where
-    Self: Send + Sync,
-    Provider: BlockReader,
-    EvmConfig: ConfigureEvm,
+    N: RpcNodeCore,
     Rpc: RpcConvert,
 {
     type Error = EthApiError;
 
-    type NetworkTypes = BerachainNetwork;
+    type NetworkTypes = Rpc::Network;
     type RpcConvert = Rpc;
 
     fn tx_resp_builder(&self) -> &Self::RpcConvert {
@@ -379,21 +364,16 @@ where
     }
 }
 
-impl<Provider, Pool, Network, EvmConfig, Rpc> RpcNodeCore
-    for BerachainApi<Provider, Pool, Network, EvmConfig, Rpc>
+impl<N, Rpc> RpcNodeCore for BerachainApi<N, Rpc>
 where
-    Provider: BlockReader + NodePrimitivesProvider + Clone + Unpin,
-    Pool: Send + Sync + Clone + Unpin,
-    Network: Send + Sync + Clone,
-    EvmConfig: ConfigureEvm,
+    N: RpcNodeCore,
     Rpc: RpcConvert,
 {
-    type Primitives = Provider::Primitives;
-    type Provider = Provider;
-    type Pool = Pool;
-    type Evm = EvmConfig;
-    type Network = Network;
-    type PayloadBuilder = ();
+    type Primitives = N::Primitives;
+    type Provider = N::Provider;
+    type Pool = N::Pool;
+    type Evm = N::Evm;
+    type Network = N::Network;
 
     fn pool(&self) -> &Self::Pool {
         self.inner.pool()
@@ -407,35 +387,25 @@ where
         self.inner.network()
     }
 
-    fn payload_builder(&self) -> &Self::PayloadBuilder {
-        &()
-    }
-
     fn provider(&self) -> &Self::Provider {
         self.inner.provider()
     }
 }
 
-impl<Provider, Pool, Network, EvmConfig, Rpc> RpcNodeCoreExt
-    for BerachainApi<Provider, Pool, Network, EvmConfig, Rpc>
+impl<N, Rpc> RpcNodeCoreExt for BerachainApi<N, Rpc>
 where
-    Provider: BlockReader + NodePrimitivesProvider + Clone + Unpin,
-    Pool: Send + Sync + Clone + Unpin,
-    Network: Send + Sync + Clone,
-    EvmConfig: ConfigureEvm,
+    N: RpcNodeCore,
     Rpc: RpcConvert,
 {
     #[inline]
-    fn cache(&self) -> &EthStateCache<ProviderBlock<Provider>, ProviderReceipt<Provider>> {
+    fn cache(&self) -> &EthStateCache<N::Primitives> {
         self.inner.cache()
     }
 }
 
-impl<Provider, Pool, Network, EvmConfig, Rpc> std::fmt::Debug
-    for BerachainApi<Provider, Pool, Network, EvmConfig, Rpc>
+impl<N, Rpc> std::fmt::Debug for BerachainApi<N, Rpc>
 where
-    Provider: BlockReader,
-    EvmConfig: ConfigureEvm,
+    N: RpcNodeCore,
     Rpc: RpcConvert,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -443,12 +413,9 @@ where
     }
 }
 
-impl<Provider, Pool, Network, EvmConfig, Rpc> SpawnBlocking
-    for BerachainApi<Provider, Pool, Network, EvmConfig, Rpc>
+impl<N, Rpc> SpawnBlocking for BerachainApi<N, Rpc>
 where
-    Self: EthApiTypes<NetworkTypes = Rpc::Network> + Clone + Send + Sync + 'static,
-    Provider: BlockReader,
-    EvmConfig: ConfigureEvm,
+    N: RpcNodeCore,
     Rpc: RpcConvert,
 {
     #[inline]
@@ -467,30 +434,27 @@ where
     }
 }
 
-impl<Provider, Pool, Network, EvmConfig, Rpc> AddDevSigners
-    for BerachainApi<Provider, Pool, Network, EvmConfig, Rpc>
+impl<N, Rpc> AddDevSigners for BerachainApi<N, Rpc>
 where
-    Provider: BlockReader,
-    EvmConfig: ConfigureEvm,
-    Rpc: RpcConvert<Network: RpcTypes<TransactionRequest: SignableTxRequest<ProviderTx<Provider>>>>,
+    N: RpcNodeCore,
+    EthApiError: FromEvmError<N::Evm>,
+    Rpc: RpcConvert<
+        Network: RpcTypes<TransactionRequest: SignableTxRequest<ProviderTx<N::Provider>>>,
+    >,
 {
     fn with_dev_accounts(&self) {
         *self.inner.signers().write() = DevSigner::random_signers(20)
     }
 }
 
-impl<Provider, Pool, Network, EvmConfig, Rpc> EthTransactions
-    for BerachainApi<Provider, Pool, Network, EvmConfig, Rpc>
+impl<N, Rpc> EthTransactions for BerachainApi<N, Rpc>
 where
-    Self: LoadTransaction<Provider: BlockReaderIdExt> + EthApiTypes<NetworkTypes = Rpc::Network>,
-    Provider: BlockReader<Transaction = ProviderTx<Self::Provider>>,
-    EvmConfig: ConfigureEvm,
-    Rpc: RpcConvert,
+    N: RpcNodeCore,
+    EthApiError: FromEvmError<N::Evm>,
+    Rpc: RpcConvert<Primitives = N::Primitives, Error = EthApiError>,
 {
     #[inline]
     fn signers(&self) -> &SignersForRpc<Self::Provider, Self::NetworkTypes> {
-        // SAFETY: This is safe because BerachainNetwork and Rpc have the same TransactionRequest
-        // type and both implement RpcTypes. The signatures are compatible.
         self.inner.signers()
     }
 
@@ -506,66 +470,35 @@ where
         let pool_transaction = <Self::Pool as TransactionPool>::Transaction::from_pooled(recovered);
 
         // submit the transaction to the pool with a `Local` origin
-        let hash = self
-            .pool()
-            .add_transaction(TransactionOrigin::Local, pool_transaction)
-            .await
-            .map_err(Self::Error::from_eth_err)?;
+        let AddedTransactionOutcome { hash, .. } =
+            self.pool().add_transaction(TransactionOrigin::Local, pool_transaction).await?;
 
         Ok(hash)
     }
 }
 
-impl<Provider, Pool, Network, EvmConfig, Rpc> LoadTransaction
-    for BerachainApi<Provider, Pool, Network, EvmConfig, Rpc>
+impl<N, Rpc> LoadTransaction for BerachainApi<N, Rpc>
 where
-    Self: SpawnBlocking
-        + FullEthApiTypes
-        + RpcNodeCoreExt<Provider: TransactionsProvider, Pool: TransactionPool>
-        + EthApiTypes<NetworkTypes = Rpc::Network>,
-    Provider: BlockReader,
-    EvmConfig: ConfigureEvm,
-    Rpc: RpcConvert,
+    N: RpcNodeCore,
+    EthApiError: FromEvmError<N::Evm>,
+    Rpc: RpcConvert<Primitives = N::Primitives, Error = EthApiError>,
 {
 }
 
-impl<Provider, Pool, Network, EvmConfig, Rpc> LoadReceipt
-    for BerachainApi<Provider, Pool, Network, EvmConfig, Rpc>
+impl<N, Rpc> LoadReceipt for BerachainApi<N, Rpc>
 where
-    Self: RpcNodeCoreExt<
-            Primitives: NodePrimitives<
-                SignedTx = ProviderTx<Self::Provider>,
-                Receipt = ProviderReceipt<Self::Provider>,
-            >,
-        > + EthApiTypes<
-            NetworkTypes = Rpc::Network,
-            RpcConvert: RpcConvert<
-                Network = Rpc::Network,
-                Primitives = Self::Primitives,
-                Error = Self::Error,
-            >,
-            Error: From<RecoveryError>,
-        >,
-    Provider: BlockReader + ChainSpecProvider,
-    EvmConfig: ConfigureEvm,
-    Rpc: RpcConvert,
+    N: RpcNodeCore,
+    EthApiError: FromEvmError<N::Evm>,
+    Rpc: RpcConvert<Primitives = N::Primitives, Error = EthApiError>,
 {
 }
 
-impl<Provider, Pool, Network, EvmConfig, Rpc> EthApiSpec
-    for BerachainApi<Provider, Pool, Network, EvmConfig, Rpc>
+impl<N, Rpc> EthApiSpec for BerachainApi<N, Rpc>
 where
-    Self: RpcNodeCore<
-            Provider: ChainSpecProvider<ChainSpec: EthereumHardforks>
-                          + BlockNumReader
-                          + StageCheckpointReader,
-            Network: NetworkInfo,
-        >,
-    Provider: BlockReader,
-    EvmConfig: ConfigureEvm,
-    Rpc: RpcConvert,
+    N: RpcNodeCore,
+    Rpc: RpcConvert<Primitives = N::Primitives>,
 {
-    type Transaction = ProviderTx<Provider>;
+    type Transaction = ProviderTx<N::Provider>;
     type Rpc = Rpc::Network;
 
     fn starting_block(&self) -> U256 {
@@ -577,90 +510,35 @@ where
     }
 }
 
-impl<Provider, Pool, Network, EvmConfig, Rpc> EthBlocks
-    for BerachainApi<Provider, Pool, Network, EvmConfig, Rpc>
+impl<N, Rpc> EthBlocks for BerachainApi<N, Rpc>
 where
-    Self: LoadBlock<
-            Error = EthApiError,
-            NetworkTypes = Rpc::Network,
-            RpcConvert: RpcConvert<
-                Primitives = Self::Primitives,
-                Error = Self::Error,
-                Network = Rpc::Network,
-            >,
-        >,
-    Provider: BlockReader + ChainSpecProvider,
-    EvmConfig: ConfigureEvm,
-    Rpc: RpcConvert,
+    N: RpcNodeCore,
+    EthApiError: FromEvmError<N::Evm>,
+    Rpc: RpcConvert<Primitives = N::Primitives, Error = EthApiError>,
 {
 }
 
-impl<Provider, Pool, Network, EvmConfig, Rpc> LoadBlock
-    for BerachainApi<Provider, Pool, Network, EvmConfig, Rpc>
+impl<N, Rpc> LoadBlock for BerachainApi<N, Rpc>
 where
-    Self: LoadPendingBlock
-        + SpawnBlocking
-        + RpcNodeCoreExt<
-            Pool: TransactionPool<
-                Transaction: PoolTransaction<Consensus = ProviderTx<Self::Provider>>,
-            >,
-            Primitives: NodePrimitives<SignedTx = ProviderTx<Self::Provider>>,
-            Evm = EvmConfig,
-        >,
-    Provider: BlockReader,
-    EvmConfig: ConfigureEvm,
-    Rpc: RpcConvert,
+    Self: LoadPendingBlock,
+    N: RpcNodeCore,
+    Rpc: RpcConvert<Primitives = N::Primitives, Error = EthApiError>,
 {
 }
 
-impl<Provider, Pool, Network, EvmConfig, Rpc> EthCall
-    for BerachainApi<Provider, Pool, Network, EvmConfig, Rpc>
+impl<N, Rpc> EthCall for BerachainApi<N, Rpc>
 where
-    Self: EstimateCall<NetworkTypes = Rpc::Network>
-        + LoadPendingBlock<NetworkTypes = Rpc::Network>
-        + FullEthApiTypes<NetworkTypes = Rpc::Network>
-        + RpcNodeCoreExt<
-            Pool: TransactionPool<
-                Transaction: PoolTransaction<Consensus = ProviderTx<Self::Provider>>,
-            >,
-            Primitives: NodePrimitives<SignedTx = ProviderTx<Self::Provider>>,
-            Evm = EvmConfig,
-        >,
-    EvmConfig: ConfigureEvm<Primitives = <Self as RpcNodeCore>::Primitives>,
-    Provider: BlockReader,
-    Rpc: RpcConvert,
+    N: RpcNodeCore,
+    EthApiError: FromEvmError<N::Evm>,
+    Rpc: RpcConvert<Primitives = N::Primitives, Error = EthApiError, TxEnv = TxEnvFor<N::Evm>>,
 {
 }
 
-impl<Provider, Pool, Network, EvmConfig, Rpc> EstimateCall
-    for BerachainApi<Provider, Pool, Network, EvmConfig, Rpc>
+impl<N, Rpc> Call for BerachainApi<N, Rpc>
 where
-    Self: Call<NetworkTypes = Rpc::Network>,
-    Provider: BlockReader,
-    EvmConfig: ConfigureEvm,
-    Rpc: RpcConvert,
-{
-}
-
-impl<Provider, Pool, Network, EvmConfig, Rpc> Call
-    for BerachainApi<Provider, Pool, Network, EvmConfig, Rpc>
-where
-    Self: LoadState<
-            Evm: ConfigureEvm<
-                Primitives: NodePrimitives<
-                    BlockHeader = ProviderHeader<Self::Provider>,
-                    SignedTx = ProviderTx<Self::Provider>,
-                >,
-            >,
-            RpcConvert: RpcConvert<TxEnv = TxEnvFor<Self::Evm>, Network = Rpc::Network>,
-            NetworkTypes = Rpc::Network,
-            Error: FromEvmError<Self::Evm>
-                       + From<<Self::RpcConvert as RpcConvert>::Error>
-                       + From<ProviderError>,
-        > + SpawnBlocking,
-    Provider: BlockReader,
-    EvmConfig: ConfigureEvm,
-    Rpc: RpcConvert,
+    N: RpcNodeCore,
+    EthApiError: FromEvmError<N::Evm>,
+    Rpc: RpcConvert<Primitives = N::Primitives, Error = EthApiError, TxEnv = TxEnvFor<N::Evm>>,
 {
     #[inline]
     fn call_gas_limit(&self) -> u64 {
@@ -673,76 +551,52 @@ where
     }
 }
 
-impl<Provider, Pool, Network, EvmConfig, Rpc> EthFees
-    for BerachainApi<Provider, Pool, Network, EvmConfig, Rpc>
+impl<N, Rpc> EstimateCall for BerachainApi<N, Rpc>
 where
-    Self: LoadFee<
-        Provider: ChainSpecProvider<
-            ChainSpec: EthChainSpec<Header = ProviderHeader<Self::Provider>>,
-        >,
-    >,
-    Provider: BlockReader,
-    EvmConfig: ConfigureEvm,
-    Rpc: RpcConvert,
+    N: RpcNodeCore,
+    EthApiError: FromEvmError<N::Evm>,
+    Rpc: RpcConvert<Primitives = N::Primitives, Error = EthApiError, TxEnv = TxEnvFor<N::Evm>>,
 {
 }
 
-impl<Provider, Pool, Network, EvmConfig, Rpc> EthState
-    for BerachainApi<Provider, Pool, Network, EvmConfig, Rpc>
+impl<N, Rpc> EthFees for BerachainApi<N, Rpc>
 where
-    Self: LoadState + SpawnBlocking,
-    Provider: BlockReader,
-    EvmConfig: ConfigureEvm,
-    Rpc: RpcConvert,
+    N: RpcNodeCore,
+    EthApiError: FromEvmError<N::Evm>,
+    Rpc: RpcConvert<Primitives = N::Primitives, Error = EthApiError>,
+{
+}
+
+impl<N, Rpc> EthState for BerachainApi<N, Rpc>
+where
+    N: RpcNodeCore,
+    Rpc: RpcConvert<Primitives = N::Primitives>,
 {
     fn max_proof_window(&self) -> u64 {
         self.inner.eth_proof_window()
     }
 }
 
-impl<Provider, Pool, Network, EvmConfig, Rpc> Trace
-    for BerachainApi<Provider, Pool, Network, EvmConfig, Rpc>
+impl<N, Rpc> Trace for BerachainApi<N, Rpc>
 where
-    Self: LoadState<
-            Provider: BlockReader,
-            Evm: ConfigureEvm<
-                Primitives: NodePrimitives<
-                    BlockHeader = ProviderHeader<Self::Provider>,
-                    SignedTx = ProviderTx<Self::Provider>,
-                >,
-            >,
-            Error: FromEvmError<Self::Evm>,
-        >,
-    Provider: BlockReader,
-    EvmConfig: ConfigureEvm,
-    Rpc: RpcConvert,
+    N: RpcNodeCore,
+    EthApiError: FromEvmError<N::Evm>,
+    Rpc: RpcConvert<Primitives = N::Primitives>,
 {
 }
 
-impl<Provider, Pool, Network, EvmConfig, Rpc> LoadState
-    for BerachainApi<Provider, Pool, Network, EvmConfig, Rpc>
+impl<N, Rpc> LoadState for BerachainApi<N, Rpc>
 where
-    Self: RpcNodeCoreExt<
-            Provider: BlockReader
-                          + StateProviderFactory
-                          + ChainSpecProvider<ChainSpec: EthereumHardforks>,
-            Pool: TransactionPool,
-        > + EthApiTypes<NetworkTypes = Rpc::Network>,
-    Provider: BlockReader,
-    EvmConfig: ConfigureEvm,
-    Rpc: RpcConvert,
+    N: RpcNodeCore,
+    Rpc: RpcConvert<Primitives = N::Primitives>,
 {
 }
 
-impl<Provider, Pool, Network, EvmConfig, Rpc> LoadFee
-    for BerachainApi<Provider, Pool, Network, EvmConfig, Rpc>
+impl<N, Rpc> LoadFee for BerachainApi<N, Rpc>
 where
-    Self: LoadBlock<Provider = Provider>,
-    Provider: BlockReaderIdExt
-        + ChainSpecProvider<ChainSpec: EthChainSpec + EthereumHardforks>
-        + StateProviderFactory,
-    EvmConfig: ConfigureEvm,
-    Rpc: RpcConvert,
+    N: RpcNodeCore,
+    EthApiError: FromEvmError<N::Evm>,
+    Rpc: RpcConvert<Primitives = N::Primitives, Error = EthApiError>,
 {
     #[inline]
     fn gas_oracle(&self) -> &GasPriceOracle<Self::Provider> {
@@ -750,45 +604,19 @@ where
     }
 
     #[inline]
-    fn fee_history_cache(&self) -> &FeeHistoryCache<ProviderHeader<Provider>> {
+    fn fee_history_cache(&self) -> &FeeHistoryCache<ProviderHeader<N::Provider>> {
         self.inner.fee_history_cache()
     }
 }
 
-impl<Provider, Pool, Network, EvmConfig, Rpc> LoadPendingBlock
-    for BerachainApi<Provider, Pool, Network, EvmConfig, Rpc>
+impl<N, Rpc> LoadPendingBlock for BerachainApi<N, Rpc>
 where
-    Self: SpawnBlocking<
-            NetworkTypes = Rpc::Network,
-            Error: FromEvmError<Self::Evm>,
-            RpcConvert: RpcConvert<Network = Rpc::Network>,
-        > + RpcNodeCore<
-            Provider: BlockReaderIdExt<Receipt = Provider::Receipt, Block = Provider::Block>
-                          + ChainSpecProvider<ChainSpec: EthChainSpec + EthereumHardforks>
-                          + StateProviderFactory,
-            Pool: TransactionPool<
-                Transaction: PoolTransaction<Consensus = ProviderTx<Self::Provider>>,
-            >,
-            Evm = EvmConfig,
-            Primitives: NodePrimitives<
-                BlockHeader = ProviderHeader<Self::Provider>,
-                SignedTx = ProviderTx<Self::Provider>,
-                Receipt = ProviderReceipt<Self::Provider>,
-                Block = ProviderBlock<Self::Provider>,
-            >,
-        >,
-    Provider: BlockReader,
-    EvmConfig: ConfigureEvm<Primitives = Self::Primitives>,
-    Rpc: RpcConvert<
-        Network: RpcTypes<Header = alloy_rpc_types_eth::Header<ProviderHeader<Self::Provider>>>,
-    >,
+    N: RpcNodeCore,
+    EthApiError: FromEvmError<N::Evm>,
+    Rpc: RpcConvert<Primitives = N::Primitives>,
 {
     #[inline]
-    fn pending_block(
-        &self,
-    ) -> &tokio::sync::Mutex<
-        Option<PendingBlock<ProviderBlock<Self::Provider>, ProviderReceipt<Self::Provider>>>,
-    > {
+    fn pending_block(&self) -> &tokio::sync::Mutex<Option<PendingBlock<Self::Primitives>>> {
         self.inner.pending_block()
     }
 

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -57,22 +57,17 @@ where
             BerachainEthReceiptConverter::new(ctx.components.provider().clone().chain_spec()),
         );
 
-        let api = reth_rpc::EthApiBuilder::new(
-            ctx.components.provider().clone(),
-            ctx.components.pool().clone(),
-            ctx.components.network().clone(),
-            ctx.components.evm_config().clone(),
-        )
-        .with_rpc_converter(tx_resp_builder.clone())
-        .eth_cache(ctx.cache)
-        .task_spawner(ctx.components.task_executor().clone())
-        .gas_cap(ctx.config.rpc_gas_cap.into())
-        .max_simulate_blocks(ctx.config.rpc_max_simulate_blocks)
-        .eth_proof_window(ctx.config.eth_proof_window)
-        .fee_history_cache_config(ctx.config.fee_history_cache)
-        .proof_permits(ctx.config.proof_permits)
-        .gas_oracle_config(ctx.config.gas_oracle)
-        .build();
+        let api = reth_rpc::EthApiBuilder::new_with_components(ctx.components.clone())
+            .with_rpc_converter(tx_resp_builder.clone())
+            .eth_cache(ctx.cache)
+            .task_spawner(ctx.components.task_executor().clone())
+            .gas_cap(ctx.config.rpc_gas_cap.into())
+            .max_simulate_blocks(ctx.config.rpc_max_simulate_blocks)
+            .eth_proof_window(ctx.config.eth_proof_window)
+            .fee_history_cache_config(ctx.config.fee_history_cache)
+            .proof_permits(ctx.config.proof_permits)
+            .gas_oracle_config(ctx.config.gas_oracle)
+            .build();
 
         Ok(BerachainApi { inner: api })
     }

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -50,18 +50,11 @@ where
         >,
     EthApiError: FromEvmError<N::Evm>,
 {
-    type EthApi = BerachainApi<
-        <N as FullNodeTypes>::Provider,
-        <N as FullNodeComponents>::Pool,
-        <N as FullNodeComponents>::Network,
-        <N as FullNodeComponents>::Evm,
-        BerachainEthRpcConverterFor<N>,
-    >;
+    type EthApi = BerachainApi<N, BerachainEthRpcConverterFor<N>>;
 
     async fn build_eth_api(self, ctx: EthApiCtx<'_, N>) -> eyre::Result<Self::EthApi> {
         let tx_resp_builder = BerachainEthRpcConverterFor::<N>::new(
             BerachainEthReceiptConverter::new(ctx.components.provider().clone().chain_spec()),
-            (),
         );
 
         let api = reth_rpc::EthApiBuilder::new(

--- a/src/rpc/receipt.rs
+++ b/src/rpc/receipt.rs
@@ -179,7 +179,7 @@ impl<ChainSpec> BerachainEthReceiptConverter<ChainSpec> {
 
 impl<ChainSpec> ReceiptConverter<BerachainPrimitives> for BerachainEthReceiptConverter<ChainSpec>
 where
-    ChainSpec: EthChainSpec,
+    ChainSpec: EthChainSpec + 'static,
 {
     type RpcReceipt = TransactionReceipt<BerachainReceiptEnvelope>;
     type Error = EthApiError;


### PR DESCRIPTION
## Summary
- Update all reth dependencies to commit 58235419bb855728d9f2afbc8bd59cf8690e8804 (v1.6.0)
- Fix API compatibility issues with new reth version
- Update EthApiBuilder usage to use new_with_components pattern
- Resolve signers method disambiguation in EthTransactions trait

## Changes
- Updated Cargo.toml with new reth commit hash across all dependencies
- Modified RPC API implementation to work with updated reth interfaces
- Cleaned up unused imports

## Test plan
- [x] cargo check passes
- [x] Dependencies updated successfully via cargo update