### PR TITLE
fix: use the correct gas limit for the PoL Tx

### DIFF
--- a/src/transaction/pol.rs
+++ b/src/transaction/pol.rs
@@ -6,10 +6,7 @@ use crate::{
 use alloy_primitives::{Bytes, Sealed, U256};
 use alloy_sol_macro::sol;
 use alloy_sol_types::SolCall;
-use reth::{
-    consensus::ConsensusError,
-    revm::{handler::SYSTEM_ADDRESS, primitives::eip7825},
-};
+use reth::{consensus::ConsensusError, revm::handler::SYSTEM_ADDRESS};
 use reth_chainspec::EthChainSpec;
 use reth_evm::block::{BlockExecutionError, InternalBlockExecutionError};
 use std::sync::Arc;

--- a/src/transaction/pol.rs
+++ b/src/transaction/pol.rs
@@ -14,6 +14,8 @@ use reth_chainspec::EthChainSpec;
 use reth_evm::block::{BlockExecutionError, InternalBlockExecutionError};
 use std::sync::Arc;
 
+pub const POL_TX_GAS_LIMIT: u64 = 30_000_000;
+
 pub fn create_pol_transaction(
     chain_spec: Arc<BerachainChainSpec>,
     prev_proposer_pubkey: BlsPublicKey,
@@ -45,9 +47,9 @@ pub fn create_pol_transaction(
         to: chain_spec.pol_contract(),
         input: Bytes::from(calldata),
         nonce,
-        gas_limit: eip7825::TX_GAS_LIMIT_CAP, // this is the env value used in revm for system calls
-        gas_price: base_fee.into(),           /* gas price is set to the base fee for RPC
-                                               * compatability reasons */
+        gas_limit: POL_TX_GAS_LIMIT, // this is the env value used in revm for system calls
+        gas_price: base_fee.into(),  /* gas price is set to the base fee for RPC
+                                      * compatability reasons */
     };
 
     Ok(BerachainTxEnvelope::Berachain(Sealed::new(pol_tx)))


### PR DESCRIPTION
We used a variable in revm for the PoL Tx gas limit. This was updated and we inherited the wrong gas limit. https://github.com/bluealloy/revm/pull/2753

Further e2e tests in subsequent prs will cover this regression vector