### PR TITLE
fix: reduce noisy POL transaction log to DEBUG level

### DIFF
--- a/src/node/evm/assembler.rs
+++ b/src/node/evm/assembler.rs
@@ -19,7 +19,6 @@ use reth_evm::{
     execute::{BlockAssembler, BlockAssemblerInput},
 };
 use std::sync::Arc;
-use tracing::info;
 
 #[derive(Clone, Debug)]
 pub struct BerachainBlockAssembler {
@@ -59,8 +58,6 @@ where
             state_root,
             ..
         } = input;
-
-        info!(target: "block receipts", ?receipts, "block assembler");
 
         let timestamp = evm_env.block_env.timestamp.saturating_to();
 

--- a/src/node/evm/executor.rs
+++ b/src/node/evm/executor.rs
@@ -113,7 +113,7 @@ impl<'a, Evm> BerachainBlockExecutor<'a, Evm> {
             calldata.clone(),
         ) {
             Ok(result_and_state) => {
-                tracing::info!(target: "executor", ?result_and_state, "POL transaction executed successfully");
+                tracing::debug!(target: "executor", ?result_and_state, "POL transaction executed successfully");
 
                 // Use the already-created POL envelope for receipt generation
 


### PR DESCRIPTION
## Summary
- Changed INFO level log to DEBUG for block assembler receipts to reduce console noise during block assembly

## Test plan
- [x] Build passes
- [x] Log level change verified in assembler.rs:63