### PR TITLE
fix: use gas_price for POL transaction effective gas price

### DIFF
--- a/src/transaction/mod.rs
+++ b/src/transaction/mod.rs
@@ -97,7 +97,7 @@ impl Transaction for PoLTx {
     }
 
     fn effective_gas_price(&self, _base_fee: Option<u64>) -> u128 {
-        0
+        self.gas_price
     }
 
     fn is_dynamic_fee(&self) -> bool {


### PR DESCRIPTION
## Summary
- Changes POL transaction effective_gas_price() to return self.gas_price instead of 0
- Aligns with the effective gas price implementation used in bera-geth

## Test plan
- [x] All tests pass
- [x] make pr passes