### PR TITLE
ci: enable proper cross-compilation for release targets

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,18 +1,18 @@
 [build]
 pre-build = [
-    # Use HTTPS for package sources
-    "apt-get update && apt-get install --assume-yes --no-install-recommends ca-certificates",
-    "find /etc/apt/ -type f \\( -name '*.list' -o -name '*.sources' \\) -exec sed -i 's|http://|https://|g' {} +",
+  # Use HTTPS for package sources
+  "apt-get update && apt-get install --assume-yes --no-install-recommends ca-certificates",
+  "find /etc/apt/ -type f \\( -name '*.list' -o -name '*.sources' \\) -exec sed -i 's|http://|https://|g' {} +",
 
-    # Configure APT retries and timeouts to handle network issues
-    "echo 'Acquire::Retries \"3\";' > /etc/apt/apt.conf.d/80-retries",
-    "echo 'Acquire::http::Timeout \"60\";' >> /etc/apt/apt.conf.d/80-retries",
-    "echo 'Acquire::ftp::Timeout \"60\";' >> /etc/apt/apt.conf.d/80-retries",
+  # Configure APT retries and timeouts to handle network issues
+  "echo 'Acquire::Retries \"3\";' > /etc/apt/apt.conf.d/80-retries",
+  "echo 'Acquire::http::Timeout \"60\";' >> /etc/apt/apt.conf.d/80-retries",
+  "echo 'Acquire::ftp::Timeout \"60\";' >> /etc/apt/apt.conf.d/80-retries",
 
-    # rust-bindgen dependencies: llvm-dev libclang-dev (>= 10) clang (>= 10)
-    # See: https://github.com/cross-rs/cross/wiki/FAQ#using-clang--bindgen for
-    # recommended clang versions for the given cross and bindgen version.
-    "apt-get update && apt-get install --assume-yes --no-install-recommends llvm-dev libclang-dev clang",
+  # rust-bindgen dependencies: llvm-dev libclang-dev (>= 10) clang (>= 10)
+  # See: https://github.com/cross-rs/cross/wiki/FAQ#using-clang--bindgen for
+  # recommended clang versions for the given cross and bindgen version.
+  "apt-get update && apt-get install --assume-yes --no-install-recommends llvm-dev libclang-dev clang",
 ]
 
 [build.env]

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,19 @@
+[build]
+pre-build = [
+    # Use HTTPS for package sources
+    "apt-get update && apt-get install --assume-yes --no-install-recommends ca-certificates",
+    "find /etc/apt/ -type f \\( -name '*.list' -o -name '*.sources' \\) -exec sed -i 's|http://|https://|g' {} +",
+
+    # Configure APT retries and timeouts to handle network issues
+    "echo 'Acquire::Retries \"3\";' > /etc/apt/apt.conf.d/80-retries",
+    "echo 'Acquire::http::Timeout \"60\";' >> /etc/apt/apt.conf.d/80-retries",
+    "echo 'Acquire::ftp::Timeout \"60\";' >> /etc/apt/apt.conf.d/80-retries",
+
+    # rust-bindgen dependencies: llvm-dev libclang-dev (>= 10) clang (>= 10)
+    # See: https://github.com/cross-rs/cross/wiki/FAQ#using-clang--bindgen for
+    # recommended clang versions for the given cross and bindgen version.
+    "apt-get update && apt-get install --assume-yes --no-install-recommends llvm-dev libclang-dev clang",
+]
+
+[build.env]
+passthrough = ["JEMALLOC_SYS_WITH_LG_PAGE"]

--- a/Makefile
+++ b/Makefile
@@ -90,11 +90,11 @@ build-maxperf: ## Build bera-reth with maxperf profile
 # Cross-compilation targets for CI/CD
 .PHONY: build-x86_64-unknown-linux-gnu
 build-x86_64-unknown-linux-gnu: ## Build bera-reth for x86_64-unknown-linux-gnu
-	cargo build --target x86_64-unknown-linux-gnu --features "$(FEATURES)" --profile "$(PROFILE)"
+	cross build --target x86_64-unknown-linux-gnu --features "$(FEATURES)" --profile "$(PROFILE)"
 
 .PHONY: build-aarch64-unknown-linux-gnu
 build-aarch64-unknown-linux-gnu: ## Build bera-reth for aarch64-unknown-linux-gnu
-	cargo build --target aarch64-unknown-linux-gnu --features "$(FEATURES)" --profile "$(PROFILE)"
+	cross build --target aarch64-unknown-linux-gnu --features "$(FEATURES)" --profile "$(PROFILE)"
 
 ###############################################################################
 ###                               Development                               ###


### PR DESCRIPTION
- Update Makefile to use 'cross' instead of 'cargo' for cross-compilation
- Add Cross.toml configuration with proper build dependencies
- Fixes aarch64-unknown-linux-gnu build failures in CI/CD workflow

The previous setup failed because cross-compilation requires specialized toolchains and Docker images that 'cross' provides. This change aligns with upstream Reth patterns and enables successful multi-architecture builds.