### PR TITLE
chore: bump version to v1.0.0-rc.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bera-reth"
-version = "0.1.0"
+version = "1.0.0-rc.8"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 


### PR DESCRIPTION
## Summary

Bumps the crate version to v1.0.0-rc.8 in preparation for the next release candidate.

## Changes

- Updated `Cargo.toml` version from `0.1.0` to `1.0.0-rc.8`

## Testing

- Version will be validated by the release workflow when tag is created
- RC tag will automatically be marked as prerelease due to `-rc` suffix

## Next Steps

After merge:
1. Create and push git tag: `git tag v1.0.0-rc.8 && git push origin v1.0.0-rc.8`
2. Monitor release workflow in Actions
3. Review and publish the generated release

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>