### PR TITLE
feat: add macOS support to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,14 @@ jobs:
             os: ubuntu-24.04
             profile: maxperf
             allow_fail: false
+          - target: x86_64-apple-darwin
+            os: macos-13
+            profile: maxperf
+            allow_fail: false
+          - target: aarch64-apple-darwin
+            os: macos-14
+            profile: maxperf
+            allow_fail: false
     steps:
       - uses: actions/checkout@v4
       - uses: rui314/setup-mold@v1
@@ -88,7 +96,11 @@ jobs:
         with:
           cache-on-failure: true
 
-
+      - name: Apple M1 setup
+        if: matrix.configs.target == 'aarch64-apple-darwin'
+        run: |
+          echo "SDKROOT=$(xcrun -sdk macosx --show-sdk-path)" >> $GITHUB_ENV
+          echo "MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx --show-sdk-platform-version)" >> $GITHUB_ENV
 
       - name: Build Bera-Reth
         run: make PROFILE=${{ matrix.configs.profile }} build-${{ matrix.configs.target }}
@@ -210,6 +222,8 @@ jobs:
           |:---:|:---:|:---:|:---|
           | <img src="https://www.svgrepo.com/download/473700/linux.svg" width="50"/> | x86_64 | [bera-reth-${{ env.VERSION }}-x86_64-unknown-linux-gnu.tar.gz](https://github.com/${{ env.REPO_NAME }}/releases/download/${{ env.VERSION }}/bera-reth-${{ env.VERSION }}-x86_64-unknown-linux-gnu.tar.gz) | [PGP Signature](https://github.com/${{ env.REPO_NAME }}/releases/download/${{ env.VERSION }}/bera-reth-${{ env.VERSION }}-x86_64-unknown-linux-gnu.tar.gz.asc) |
           | <img src="https://www.svgrepo.com/download/473700/linux.svg" width="50"/> | aarch64 | [bera-reth-${{ env.VERSION }}-aarch64-unknown-linux-gnu.tar.gz](https://github.com/${{ env.REPO_NAME }}/releases/download/${{ env.VERSION }}/bera-reth-${{ env.VERSION }}-aarch64-unknown-linux-gnu.tar.gz) | [PGP Signature](https://github.com/${{ env.REPO_NAME }}/releases/download/${{ env.VERSION }}/bera-reth-${{ env.VERSION }}-aarch64-unknown-linux-gnu.tar.gz.asc) |
+          | <img src="https://www.svgrepo.com/download/511330/apple-173.svg" width="50"/> | x86_64 | [bera-reth-${{ env.VERSION }}-x86_64-apple-darwin.tar.gz](https://github.com/${{ env.REPO_NAME }}/releases/download/${{ env.VERSION }}/bera-reth-${{ env.VERSION }}-x86_64-apple-darwin.tar.gz) | [PGP Signature](https://github.com/${{ env.REPO_NAME }}/releases/download/${{ env.VERSION }}/bera-reth-${{ env.VERSION }}-x86_64-apple-darwin.tar.gz.asc) |
+          | <img src="https://www.svgrepo.com/download/511330/apple-173.svg" width="50"/> | aarch64 | [bera-reth-${{ env.VERSION }}-aarch64-apple-darwin.tar.gz](https://github.com/${{ env.REPO_NAME }}/releases/download/${{ env.VERSION }}/bera-reth-${{ env.VERSION }}-aarch64-apple-darwin.tar.gz) | [PGP Signature](https://github.com/${{ env.REPO_NAME }}/releases/download/${{ env.VERSION }}/bera-reth-${{ env.VERSION }}-aarch64-apple-darwin.tar.gz.asc) |
           | <img src="https://www.svgrepo.com/download/473589/docker.svg" width="50"/> | Docker | [${{ env.IMAGE_NAME }}](${{ env.DOCKER_IMAGE_NAME_URL }}) | - |
           ENDBODY
           )

--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,14 @@ build-x86_64-unknown-linux-gnu: ## Build bera-reth for x86_64-unknown-linux-gnu
 build-aarch64-unknown-linux-gnu: ## Build bera-reth for aarch64-unknown-linux-gnu
 	cross build --target aarch64-unknown-linux-gnu --features "$(FEATURES)" --profile "$(PROFILE)"
 
+.PHONY: build-x86_64-apple-darwin
+build-x86_64-apple-darwin: ## Build bera-reth for x86_64-apple-darwin (macOS Intel)
+	cargo build --target x86_64-apple-darwin --features "$(FEATURES)" --profile "$(PROFILE)"
+
+.PHONY: build-aarch64-apple-darwin
+build-aarch64-apple-darwin: ## Build bera-reth for aarch64-apple-darwin (macOS Apple Silicon)
+	cargo build --target aarch64-apple-darwin --features "$(FEATURES)" --profile "$(PROFILE)"
+
 ###############################################################################
 ###                               Development                               ###
 ###############################################################################


### PR DESCRIPTION
- Add x86_64-apple-darwin and aarch64-apple-darwin build targets
- Add Apple M1 setup step for aarch64-apple-darwin builds
- Add macOS build targets to Makefile using native cargo (not cross)
- Update release template to include macOS binaries with Apple icons
- Follows Reth's approach for macOS compilation