### PR TITLE
fix: add Berachain-specific capabilities to engine API exchange

### DIFF
--- a/src/engine/rpc.rs
+++ b/src/engine/rpc.rs
@@ -49,6 +49,9 @@ pub struct BerachainEngineApiBuilder<EV> {
     engine_validator_builder: EV,
 }
 
+pub const BERACHAIN_ADDITIONAL_CAPABILITIES: &[&str] =
+    &["engine_newPayloadV4P11", "engine_forkchoiceUpdatedV3P11", "engine_getPayloadV4P11"];
+
 impl<N, EV> EngineApiBuilder<N> for BerachainEngineApiBuilder<EV>
 where
     N: FullNodeComponents<
@@ -613,7 +616,11 @@ where
     }
 
     async fn exchange_capabilities(&self, _capabilities: Vec<String>) -> RpcResult<Vec<String>> {
-        Ok(self.inner.capabilities().list())
+        let mut capabilities = self.inner.capabilities().clone();
+        for cap in BERACHAIN_ADDITIONAL_CAPABILITIES {
+            capabilities.add_capability(*cap);
+        }
+        Ok(capabilities.list())
     }
 
     async fn get_blobs_v1(

--- a/src/engine/rpc.rs
+++ b/src/engine/rpc.rs
@@ -617,9 +617,7 @@ where
 
     async fn exchange_capabilities(&self, _capabilities: Vec<String>) -> RpcResult<Vec<String>> {
         let mut capabilities = self.inner.capabilities().clone();
-        for cap in BERACHAIN_ADDITIONAL_CAPABILITIES {
-            capabilities.add_capability(*cap);
-        }
+        BERACHAIN_ADDITIONAL_CAPABILITIES.iter().for_each(|&cap| capabilities.add_capability(cap));
         Ok(capabilities.list())
     }
 


### PR DESCRIPTION
## Summary
Fixes the exchange_capabilities method in the engine API to properly advertise Berachain-specific Prague1 fork extensions (engine_newPayloadV4P11, engine_forkchoiceUpdatedV3P11, engine_getPayloadV4P11). Previously, these capabilities were implemented but not advertised during capability negotiation, causing beacon-kit to log warnings about unsupported capabilities during startup. The implementation clones the base capabilities, adds the Berachain extensions, and returns the enhanced capability list to ensure proper integration with beacon-kit.
