### PR TITLE
fix: use correct consensus in CLI components builder

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,10 @@ use clap::Parser;
 use reth::{CliRunner, beacon_consensus::EthBeaconConsensus};
 use std::sync::Arc;
 // Removed RessArgs since ress subprotocol is disabled
-use bera_reth::{chainspec::BerachainChainSpec, node::evm::config::BerachainEvmConfig};
+use bera_reth::{
+    chainspec::BerachainChainSpec, consensus::BerachainBeaconConsensus,
+    node::evm::config::BerachainEvmConfig,
+};
 use reth_cli_commands::node::NoArgs;
 use reth_ethereum_cli::Cli;
 use reth_evm::EthEvmFactory;
@@ -29,7 +32,7 @@ fn main() {
     let cli_components_builder = |spec: Arc<BerachainChainSpec>| {
         (
             BerachainEvmConfig::new_with_evm_factory(spec.clone(), EthEvmFactory::default()),
-            EthBeaconConsensus::new(spec),
+            BerachainBeaconConsensus::new(spec),
         )
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ static ALLOC: reth_cli_util::allocator::Allocator = reth_cli_util::allocator::ne
 
 use bera_reth::{chainspec::BerachainChainSpecParser, node::BerachainNode};
 use clap::Parser;
-use reth::{CliRunner, beacon_consensus::EthBeaconConsensus};
+use reth::CliRunner;
 use std::sync::Arc;
 // Removed RessArgs since ress subprotocol is disabled
 use bera_reth::{


### PR DESCRIPTION
The CLI requires components to be passed in for code paths beyond building the node itself. 

In reth, usages can be started from here https://github.com/paradigmxyz/reth/blob/6923e051ee84fe9d7afd550e2852b0151c847785/crates/cli/commands/src/common.rs#L270-L272

Fixes correctness of CLI commands:
- `import`
- `re-execute`
- `stage`