### PR TITLE
chore: upgrade reth dependency to 48941e6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,9 +235,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.15.0"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28de0dd1bbb0634ef7c3715e8e60176b77b82f8b6b15b2e35fe64cf6640f6550"
+checksum = "4042e855163839443cba91147fb7737c4aba02df4767cb322b0e8cea5a77642c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -269,9 +269,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-hardforks"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819a3620fe125e0fff365363315ee5e24c23169173b19747dfd6deba33db8990"
+checksum = "3165210652f71dfc094b051602bafd691f506c54050a174b1cba18fb5ef706a3"
 dependencies = [
  "alloy-chains",
  "alloy-eip2124",
@@ -1379,9 +1379,9 @@ checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
 
 [[package]]
 name = "backon"
-version = "1.5.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "302eaff5357a264a2c42f127ecb8bac761cf99749fc3dc95677e2743991f99e7"
+checksum = "592277618714fbcecda9a02ba7a8781f319d26532a88553bbacc77ba5d2b3a8d"
 dependencies = [
  "fastrand",
  "tokio",
@@ -1477,7 +1477,6 @@ dependencies = [
  "reth-e2e-test-utils",
  "reth-engine-local",
  "reth-engine-primitives",
- "reth-engine-tree",
  "reth-ethereum-cli",
  "reth-ethereum-engine-primitives",
  "reth-ethereum-payload-builder",
@@ -2056,9 +2055,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.41"
+version = "4.5.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
+checksum = "ed87a9d530bb41a67537289bafcac159cb3ee28460e0a4571123d2a778a6a882"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -2066,9 +2065,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.41"
+version = "4.5.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
+checksum = "64f4f3f3c77c94aff3c7e9aac9a2ca1974a5adf392a8bb751e827d6d127ab966"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2747,7 +2746,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users 0.5.0",
+ "redox_users 0.5.2",
  "windows-sys 0.60.2",
 ]
 
@@ -2820,9 +2819,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ecdsa"
@@ -3821,7 +3820,7 @@ dependencies = [
  "potential_utf",
  "yoke 0.8.0",
  "zerofrom",
- "zerovec 0.11.2",
+ "zerovec 0.11.3",
 ]
 
 [[package]]
@@ -3834,7 +3833,7 @@ dependencies = [
  "litemap 0.8.0",
  "tinystr 0.8.1",
  "writeable 0.6.1",
- "zerovec 0.11.2",
+ "zerovec 0.11.3",
 ]
 
 [[package]]
@@ -3900,7 +3899,7 @@ dependencies = [
  "icu_properties 2.0.1",
  "icu_provider 2.0.0",
  "smallvec",
- "zerovec 0.11.2",
+ "zerovec 0.11.3",
 ]
 
 [[package]]
@@ -3943,7 +3942,7 @@ dependencies = [
  "icu_provider 2.0.0",
  "potential_utf",
  "zerotrie",
- "zerovec 0.11.2",
+ "zerovec 0.11.3",
 ]
 
 [[package]]
@@ -3989,7 +3988,7 @@ dependencies = [
  "yoke 0.8.0",
  "zerofrom",
  "zerotrie",
- "zerovec 0.11.2",
+ "zerovec 0.11.3",
 ]
 
 [[package]]
@@ -4573,7 +4572,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.2",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -4614,9 +4613,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.6"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4488594b9328dee448adb906d8b126d9b7deb7cf5c22161ee591610bb1be83c0"
+checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
@@ -5094,9 +5093,9 @@ dependencies = [
 
 [[package]]
 name = "notify"
-version = "8.1.0"
+version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3163f59cd3fa0e9ef8c32f242966a7b9994fd7378366099593e0e73077cd8c97"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
  "bitflags 2.9.1",
  "fsevent-sys",
@@ -5299,9 +5298,9 @@ checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "op-alloy-consensus"
-version = "0.18.13"
+version = "0.18.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3c719b26da6d9cac18c3a35634d6ab27a74a304ed9b403b43749c22e57a389f"
+checksum = "0c88d2940558fd69f8f07b3cbd7bb3c02fc7d31159c1a7ba9deede50e7881024"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5317,9 +5316,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-rpc-types-engine"
-version = "0.18.13"
+version = "0.18.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cf45d43a3d548fdc39d9bfab6ba13cc06b3214ef4b9c36d3efbf3faea1b9f1"
+checksum = "b2b4f977b51e9e177e69a4d241ab7c4b439df9a3a5a998c000ae01be724de271"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5666,7 +5665,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
 dependencies = [
- "zerovec 0.11.2",
+ "zerovec 0.11.3",
 ]
 
 [[package]]
@@ -6085,9 +6084,9 @@ checksum = "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175"
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.15"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8af0dde094006011e6a740d4879319439489813bd0bcdc7d821beaeeff48ec"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags 2.9.1",
 ]
@@ -6105,9 +6104,9 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.16",
  "libredox",
@@ -6243,7 +6242,7 @@ checksum = "95325155c684b1c89f7765e30bc1c42e4a6da51ca513615660cb8a62ef9a88e3"
 [[package]]
 name = "reth"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-rpc-types",
  "aquamarine",
@@ -6289,7 +6288,7 @@ dependencies = [
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6313,7 +6312,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6344,7 +6343,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -6364,7 +6363,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -6378,7 +6377,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "ahash",
  "alloy-chains",
@@ -6451,7 +6450,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -6461,7 +6460,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6479,7 +6478,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6499,7 +6498,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -6510,7 +6509,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -6525,7 +6524,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -6538,7 +6537,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6550,7 +6549,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6575,7 +6574,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -6601,7 +6600,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -6629,7 +6628,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -6658,7 +6657,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6673,7 +6672,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -6699,7 +6698,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -6723,7 +6722,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -6747,7 +6746,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6782,7 +6781,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6844,7 +6843,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -6875,7 +6874,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -6897,7 +6896,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6922,7 +6921,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-service"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "futures",
  "pin-project",
@@ -6945,7 +6944,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6955,7 +6954,6 @@ dependencies = [
  "alloy-rpc-types-engine",
  "derive_more",
  "futures",
- "itertools 0.14.0",
  "metrics",
  "mini-moka",
  "parking_lot",
@@ -6998,7 +6996,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -7008,6 +7006,7 @@ dependencies = [
  "pin-project",
  "reth-chainspec",
  "reth-engine-primitives",
+ "reth-engine-tree",
  "reth-errors",
  "reth-evm",
  "reth-fs-util",
@@ -7025,7 +7024,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7041,7 +7040,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -7056,7 +7055,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7080,7 +7079,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -7091,7 +7090,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -7119,7 +7118,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7140,9 +7139,8 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
- "alloy-consensus",
  "clap",
  "eyre",
  "reth-chainspec",
@@ -7162,7 +7160,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7178,7 +7176,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7196,7 +7194,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -7209,7 +7207,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7236,7 +7234,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7254,7 +7252,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -7264,7 +7262,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7287,7 +7285,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7306,7 +7304,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -7319,7 +7317,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7337,7 +7335,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7375,7 +7373,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7389,7 +7387,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "serde",
  "serde_json",
@@ -7399,7 +7397,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7427,7 +7425,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "bytes",
  "futures",
@@ -7447,7 +7445,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "bitflags 2.9.1",
  "byteorder",
@@ -7464,7 +7462,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "bindgen",
  "cc",
@@ -7473,7 +7471,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "futures",
  "metrics",
@@ -7485,7 +7483,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-primitives",
 ]
@@ -7493,7 +7491,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -7507,7 +7505,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7562,7 +7560,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7587,7 +7585,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7610,7 +7608,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7625,7 +7623,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -7639,7 +7637,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -7656,7 +7654,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -7680,7 +7678,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7706,6 +7704,7 @@ dependencies = [
  "reth-db-common",
  "reth-downloaders",
  "reth-engine-local",
+ "reth-engine-primitives",
  "reth-engine-service",
  "reth-engine-tree",
  "reth-engine-util",
@@ -7722,6 +7721,7 @@ dependencies = [
  "reth-node-events",
  "reth-node-metrics",
  "reth-payload-builder",
+ "reth-primitives-traits",
  "reth-provider",
  "reth-prune",
  "reth-rpc",
@@ -7746,7 +7746,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7798,7 +7798,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -7808,7 +7808,6 @@ dependencies = [
  "reth-chainspec",
  "reth-engine-local",
  "reth-engine-primitives",
- "reth-engine-tree",
  "reth-ethereum-consensus",
  "reth-ethereum-engine-primitives",
  "reth-ethereum-payload-builder",
@@ -7837,7 +7836,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7861,7 +7860,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7885,7 +7884,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "eyre",
  "http",
@@ -7906,7 +7905,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -7919,7 +7918,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-primitives"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7938,7 +7937,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7959,7 +7958,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -7971,7 +7970,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7990,7 +7989,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8000,7 +7999,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-consensus",
  "once_cell",
@@ -8013,7 +8012,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8046,7 +8045,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8091,7 +8090,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8119,7 +8118,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -8133,7 +8132,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-protocol"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8152,7 +8151,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-provider"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8179,7 +8178,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -8192,7 +8191,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -8268,7 +8267,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -8296,7 +8295,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -8334,7 +8333,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-consensus",
  "alloy-json-rpc",
@@ -8353,7 +8352,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8365,7 +8364,6 @@ dependencies = [
  "parking_lot",
  "reth-chainspec",
  "reth-engine-primitives",
- "reth-engine-tree",
  "reth-metrics",
  "reth-payload-builder",
  "reth-payload-builder-primitives",
@@ -8384,7 +8382,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -8428,7 +8426,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8472,7 +8470,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -8486,7 +8484,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8502,7 +8500,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8552,7 +8550,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8579,7 +8577,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -8593,7 +8591,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -8613,7 +8611,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -8625,7 +8623,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8649,7 +8647,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8665,7 +8663,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -8683,7 +8681,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8699,7 +8697,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -8709,7 +8707,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "clap",
  "eyre",
@@ -8724,7 +8722,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8763,7 +8761,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8788,7 +8786,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8814,7 +8812,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -8827,7 +8825,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8852,13 +8850,14 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-trie",
  "auto_impl",
  "metrics",
+ "rayon",
  "reth-execution-errors",
  "reth-metrics",
  "reth-primitives-traits",
@@ -8870,13 +8869,15 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse-parallel"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-trie",
+ "metrics",
  "rayon",
  "reth-execution-errors",
+ "reth-metrics",
  "reth-trie-common",
  "reth-trie-sparse",
  "smallvec",
@@ -8886,7 +8887,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=876e964#876e964cbcbd85ade6fdec40bb35f08690332854"
+source = "git+https://github.com/paradigmxyz/reth?rev=48941e6#48941e6db50f0c8654a391d167b465827f36dc8d"
 dependencies = [
  "zstd",
 ]
@@ -9248,9 +9249,9 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11256b5fe8c68f56ac6f39ef0720e592f33d2367a4782740d9c9142e889c7fb4"
+checksum = "9ecb38f82477f20c5c3d62ef52d7c4e536e38ea9b73fb570a20c5cae0e14bcf6"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -9282,9 +9283,9 @@ checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustc-hash"
@@ -9353,9 +9354,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.29"
+version = "0.23.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1"
+checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
 dependencies = [
  "log",
  "once_cell",
@@ -9683,9 +9684,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.141"
+version = "1.0.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
+checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
 dependencies = [
  "indexmap 2.10.0",
  "itoa",
@@ -9859,9 +9860,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.5"
+version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc",
 ]
@@ -10366,7 +10367,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
 dependencies = [
  "displaydoc",
- "zerovec 0.11.2",
+ "zerovec 0.11.3",
 ]
 
 [[package]]
@@ -10386,9 +10387,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.46.1"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
  "bytes",
@@ -10399,9 +10400,9 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "tokio-macros",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10466,9 +10467,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.15"
+version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
+checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
 dependencies = [
  "bytes",
  "futures-core",
@@ -11513,7 +11514,7 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.2",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -11564,10 +11565,11 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.2"
+version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",
@@ -11990,9 +11992,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
+checksum = "bdbb9122ea75b11bf96e7492afb723e8a7fbe12c67417aa95e7e3d18144d37cd"
 dependencies = [
  "yoke 0.8.0",
  "zerofrom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,38 +30,37 @@ jsonrpsee-proc-macros = "0.25.1"
 
 async-trait = "0.1.88"
 modular-bitfield = "0.11.2"
-reth = { git = "https://github.com/paradigmxyz/reth", rev = "876e964" }
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "876e964" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "876e964" }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "876e964" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "876e964" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "876e964" }
-reth-codecs = { git = "https://github.com/paradigmxyz/reth", rev = "876e964" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "876e964" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "876e964" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "876e964" }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "876e964" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "876e964" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "876e964" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "876e964" }
-reth-ethereum-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "876e964" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "876e964" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "876e964" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "876e964" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "876e964" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "876e964" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "876e964" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "876e964" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "876e964" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "876e964" }
-reth-payload-validator = { git = "https://github.com/paradigmxyz/reth", rev = "876e964" }
-reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", rev = "876e964" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "876e964" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "876e964" }
-reth-rpc-engine-api = { git = "https://github.com/paradigmxyz/reth", rev = "876e964" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "876e964" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "876e964" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "876e964" }
+reth = { git = "https://github.com/paradigmxyz/reth", rev = "48941e6" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "48941e6" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "48941e6" }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "48941e6" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "48941e6" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "48941e6" }
+reth-codecs = { git = "https://github.com/paradigmxyz/reth", rev = "48941e6" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "48941e6" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "48941e6" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "48941e6" }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "48941e6" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "48941e6" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "48941e6" }
+reth-ethereum-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "48941e6" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "48941e6" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "48941e6" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "48941e6" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "48941e6" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "48941e6" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "48941e6" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "48941e6" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "48941e6" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "48941e6" }
+reth-payload-validator = { git = "https://github.com/paradigmxyz/reth", rev = "48941e6" }
+reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", rev = "48941e6" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "48941e6" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "48941e6" }
+reth-rpc-engine-api = { git = "https://github.com/paradigmxyz/reth", rev = "48941e6" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "48941e6" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "48941e6" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "48941e6" }
 serde = { version = "1.0", features = ["derive"], default-features = false }
 thiserror = "2.0"
 tokio = "1.46.0"
@@ -71,8 +70,8 @@ tracing = "0.1.41"
 alloy-provider = "1.0.17"
 alloy-rpc-client = "1.0.17"
 eyre = "0.6.12"
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "876e964" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "876e964" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "48941e6" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "48941e6" }
 serde_json = "1.0"
 test-fuzz = "7"
 

--- a/src/consensus/mod.rs
+++ b/src/consensus/mod.rs
@@ -33,7 +33,6 @@ where
 
 #[derive(Debug, Clone)]
 pub struct BerachainBeaconConsensus {
-    /// Inner Ethereum beacon consensus implementation
     inner: EthBeaconConsensus<BerachainChainSpec>,
     chain_spec: Arc<BerachainChainSpec>,
 }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -161,7 +161,7 @@ impl BerachainExecutionPayloadSidecar {
     }
 
     /// Returns the EIP-7685 requests if available
-    pub fn requests(&self) -> Option<&alloy_eips::eip7685::Requests> {
+    pub fn requests(&self) -> Option<&Requests> {
         self.inner.requests()
     }
 
@@ -244,7 +244,7 @@ impl From<ExecutionPayloadInputV2> for BerachainExecutionData {
     }
 }
 
-/// Validates that proposer pubkey is present after Prague1 and absent before Prague1
+/// Validates that the proposer pubkey is present after Prague1 and absent before Prague1
 pub fn validate_proposer_pubkey_prague1<ChainSpec: BerachainHardforks>(
     chain_spec: &ChainSpec,
     timestamp: u64,

--- a/src/engine/payload.rs
+++ b/src/engine/payload.rs
@@ -26,10 +26,6 @@ use reth_primitives_traits::{NodePrimitives, SealedBlock};
 use std::{convert::Infallible, sync::Arc};
 
 /// Berachain-specific payload attributes
-///
-/// This structure wraps Ethereum payload attributes and provides extension
-/// points for Berachain-specific functionality. Currently it delegates to
-/// Ethereum attributes but can be extended with additional fields as needed.
 #[derive(Clone, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct BerachainPayloadAttributes {
     #[serde(flatten)]
@@ -58,10 +54,6 @@ impl BerachainPayloadAttributes {
 }
 
 /// Berachain payload builder attributes
-///
-/// Internal representation of payload attributes used during the payload building process.
-/// This structure maintains compatibility with Ethereum while providing extension points
-/// for Berachain-specific payload building logic.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct BerachainPayloadBuilderAttributes {
     /// Id of the payload
@@ -80,6 +72,7 @@ pub struct BerachainPayloadBuilderAttributes {
     pub withdrawals: Withdrawals,
     /// Root of the parent beacon block
     pub parent_beacon_block_root: Option<B256>,
+    /// Previous proposer public key
     pub prev_proposer_pubkey: Option<BlsPublicKey>,
 }
 

--- a/src/engine/rpc.rs
+++ b/src/engine/rpc.rs
@@ -35,11 +35,7 @@ use reth_transaction_pool::TransactionPool;
 use std::sync::Arc;
 use tracing::{debug, trace};
 
-/// Builder for basic [`EngineApi`] implementation.
-///
-/// This provides a basic default implementation for opstack and ethereum engine API via
-/// [`EngineTypes`] and uses the general purpose [`EngineApi`] implementation as the builder's
-/// output.
+/// Builder for [`BerachainEngineApi`] implementation.
 #[derive(Debug, Default)]
 pub struct BerachainEngineApiBuilder<EV> {
     engine_validator_builder: EV,

--- a/src/engine/rpc.rs
+++ b/src/engine/rpc.rs
@@ -25,10 +25,9 @@ use reth::{
     providers::{BlockReader, HeaderProvider, StateProviderFactory},
     rpc::api::IntoEngineApiRpcModule,
 };
-use reth_engine_primitives::EngineTypes;
-use reth_engine_tree::tree::EngineValidator;
+use reth_engine_primitives::{EngineApiValidator, EngineTypes};
 use reth_node_api::{AddOnsContext, FullNodeComponents};
-use reth_node_builder::rpc::{EngineApiBuilder, EngineValidatorBuilder};
+use reth_node_builder::rpc::{EngineApiBuilder, PayloadValidatorBuilder};
 use reth_node_core::version::{CARGO_PKG_VERSION, CLIENT_CODE, NAME_CLIENT, VERGEN_GIT_SHA};
 use reth_payload_primitives::{EngineObjectValidationError, PayloadAttributes, PayloadTypes};
 use reth_rpc_engine_api::{EngineApi, EngineApiError, EngineCapabilities};
@@ -60,7 +59,8 @@ where
             > + EngineTypes,
         >,
     >,
-    EV: EngineValidatorBuilder<N>,
+    EV: PayloadValidatorBuilder<N>,
+    EV::Validator: EngineApiValidator<<N::Types as NodeTypes>::Payload>,
 {
     type EngineApi = BerachainEngineApi<
         N::Provider,
@@ -383,7 +383,7 @@ where
             PayloadAttributes = BerachainPayloadAttributes,
         >,
     Pool: TransactionPool + 'static,
-    Validator: EngineValidator<EngineT>,
+    Validator: EngineApiValidator<EngineT>,
     ChainSpec: EthereumHardforks + BerachainHardforks + Send + Sync + 'static,
 {
     async fn new_payload_v1(&self, payload: ExecutionPayloadV1) -> RpcResult<PayloadStatus> {

--- a/src/engine/validator.rs
+++ b/src/engine/validator.rs
@@ -17,7 +17,7 @@ use reth_node_api::{AddOnsContext, FullNodeComponents, NodeTypes};
 use reth_node_builder::rpc::PayloadValidatorBuilder;
 use reth_payload_primitives::{
     EngineApiMessageVersion, EngineObjectValidationError, NewPayloadError, PayloadOrAttributes,
-    PayloadTypes, validate_version_specific_fields,
+    PayloadTypes, validate_execution_requests, validate_version_specific_fields,
 };
 use reth_payload_validator::{cancun, prague, shanghai};
 use reth_primitives_traits::{Block, RecoveredBlock, SealedBlock};
@@ -158,6 +158,13 @@ where
         version: EngineApiMessageVersion,
         payload_or_attrs: PayloadOrAttributes<'_, Types::ExecutionData, Types::PayloadAttributes>,
     ) -> Result<(), EngineObjectValidationError> {
+        // Validate execution requests if present in the payload
+        if let PayloadOrAttributes::ExecutionPayload(payload) = &payload_or_attrs &&
+            let Some(requests) = payload.sidecar.requests()
+        {
+            validate_execution_requests(requests)?;
+        }
+
         validate_version_specific_fields(self.chain_spec(), version, payload_or_attrs)
     }
 

--- a/src/engine/validator.rs
+++ b/src/engine/validator.rs
@@ -11,14 +11,13 @@ use crate::{
     transaction::BerachainTxEnvelope,
 };
 use reth::chainspec::EthereumHardforks;
-use reth_engine_primitives::PayloadValidator;
-use reth_engine_tree::tree::EngineValidator;
+use reth_engine_primitives::{EngineApiValidator, PayloadValidator};
 use reth_ethereum_payload_builder::EthereumExecutionPayloadValidator;
-use reth_node_api::{AddOnsContext, FullNodeComponents, NodeTypes, PayloadTypes};
-use reth_node_builder::rpc::EngineValidatorBuilder;
+use reth_node_api::{AddOnsContext, FullNodeComponents, NodeTypes};
+use reth_node_builder::rpc::PayloadValidatorBuilder;
 use reth_payload_primitives::{
     EngineApiMessageVersion, EngineObjectValidationError, NewPayloadError, PayloadOrAttributes,
-    validate_execution_requests, validate_version_specific_fields,
+    PayloadTypes, validate_version_specific_fields,
 };
 use reth_payload_validator::{cancun, prague, shanghai};
 use reth_primitives_traits::{Block, RecoveredBlock, SealedBlock};
@@ -109,9 +108,8 @@ impl BerachainEngineValidator {
     }
 }
 
-impl PayloadValidator for BerachainEngineValidator {
+impl PayloadValidator<BerachainEngineTypes> for BerachainEngineValidator {
     type Block = BerachainBlock;
-    type ExecutionData = BerachainExecutionData;
 
     fn ensure_well_formed_payload(
         &self,
@@ -142,7 +140,7 @@ impl PayloadValidator for BerachainEngineValidator {
     }
 }
 
-impl<Types> EngineValidator<Types> for BerachainEngineValidator
+impl<Types> EngineApiValidator<Types> for BerachainEngineValidator
 where
     Types: PayloadTypes<
             PayloadAttributes = BerachainPayloadAttributes,
@@ -152,33 +150,20 @@ where
     fn validate_version_specific_fields(
         &self,
         version: EngineApiMessageVersion,
-        payload_or_attrs: PayloadOrAttributes<'_, Self::ExecutionData, BerachainPayloadAttributes>,
+        payload_or_attrs: PayloadOrAttributes<'_, Types::ExecutionData, Types::PayloadAttributes>,
     ) -> Result<(), EngineObjectValidationError> {
-        // Extract execution requests from the payload if present
-        let execution_requests =
-            if let PayloadOrAttributes::ExecutionPayload(payload) = &payload_or_attrs {
-                payload.sidecar.requests()
-            } else {
-                None
-            };
-
-        // Validate execution requests if present
-        if let Some(requests) = execution_requests {
-            validate_execution_requests(requests)?;
-        }
-
         validate_version_specific_fields(self.chain_spec(), version, payload_or_attrs)
     }
 
     fn ensure_well_formed_attributes(
         &self,
         version: EngineApiMessageVersion,
-        attributes: &BerachainPayloadAttributes,
+        attributes: &Types::PayloadAttributes,
     ) -> Result<(), EngineObjectValidationError> {
         validate_version_specific_fields(
             self.chain_spec(),
             version,
-            PayloadOrAttributes::<Self::ExecutionData, BerachainPayloadAttributes>::PayloadAttributes(
+            PayloadOrAttributes::<Types::ExecutionData, Types::PayloadAttributes>::PayloadAttributes(
                 attributes,
             ),
         )
@@ -191,14 +176,15 @@ pub struct BerachainEngineValidatorBuilder {
     _phantom: PhantomData<BerachainChainSpec>,
 }
 
-impl<Node, Types> EngineValidatorBuilder<Node> for BerachainEngineValidatorBuilder
+impl<Node> PayloadValidatorBuilder<Node> for BerachainEngineValidatorBuilder
 where
-    Types: NodeTypes<
+    Node: FullNodeComponents<
+        Types: NodeTypes<
             ChainSpec = BerachainChainSpec,
             Payload = BerachainEngineTypes,
             Primitives = BerachainPrimitives,
         >,
-    Node: FullNodeComponents<Types = Types>,
+    >,
 {
     type Validator = BerachainEngineValidator;
 

--- a/src/engine/validator.rs
+++ b/src/engine/validator.rs
@@ -26,14 +26,12 @@ use std::{marker::PhantomData, sync::Arc};
 #[derive(Debug, Clone)]
 pub struct BerachainEngineValidator {
     inner: EthereumExecutionPayloadValidator<BerachainChainSpec>,
-    /// The inner chainspec is private, so we need this.
-    chain_spec: Arc<BerachainChainSpec>,
 }
 
 impl BerachainEngineValidator {
     /// Instantiates a new validator.
     pub fn new(chain_spec: Arc<BerachainChainSpec>) -> Self {
-        Self { inner: EthereumExecutionPayloadValidator::new(chain_spec.clone()), chain_spec }
+        Self { inner: EthereumExecutionPayloadValidator::new(chain_spec.clone()) }
     }
 
     /// Returns the chain spec used by the validator.
@@ -89,25 +87,25 @@ impl BerachainEngineValidator {
     ) -> Result<(), NewPayloadError> {
         shanghai::ensure_well_formed_fields(
             sealed_block.body(),
-            self.chain_spec.is_shanghai_active_at_timestamp(sealed_block.timestamp),
+            self.chain_spec().is_shanghai_active_at_timestamp(sealed_block.timestamp),
         )?;
 
         cancun::ensure_well_formed_fields(
             sealed_block,
             sidecar.inner.cancun(),
-            self.chain_spec.is_cancun_active_at_timestamp(sealed_block.timestamp),
+            self.chain_spec().is_cancun_active_at_timestamp(sealed_block.timestamp),
         )?;
 
         prague::ensure_well_formed_fields(
             sealed_block.body(),
             sidecar.inner.prague(),
-            self.chain_spec.is_prague_active_at_timestamp(sealed_block.timestamp),
+            self.chain_spec().is_prague_active_at_timestamp(sealed_block.timestamp),
         )?;
 
         prague1::ensure_well_formed_fields(
             sealed_block,
             sidecar.parent_proposer_pub_key,
-            self.chain_spec.is_prague1_active_at_timestamp(sealed_block.timestamp),
+            self.chain_spec().is_prague1_active_at_timestamp(sealed_block.timestamp),
         )?;
 
         Ok(())

--- a/src/engine/validator.rs
+++ b/src/engine/validator.rs
@@ -54,15 +54,21 @@ impl BerachainEngineValidator {
             .map_err(|e| NewPayloadError::Other(e.into()))?;
 
         // Convert header from standard to BerachainHeader
-        let mut berachain_header = BerachainHeader::from(standard_block.header.clone());
-
-        berachain_header.prev_proposer_pubkey = sidecar.parent_proposer_pub_key;
+        let berachain_header = BerachainHeader::from_header_with_proposer(
+            standard_block.header.clone(),
+            sidecar.parent_proposer_pub_key,
+        );
 
         // Create BerachainBlock with converted header and body
         // Ommers are empty on Berachain anyway as we don't have uncle blocks due to different
         // consensus mechanism.
-        let berachain_ommers: Vec<BerachainHeader> =
-            standard_block.body.ommers.iter().map(|h| BerachainHeader::from(h.clone())).collect();
+        let berachain_ommers: Vec<BerachainHeader> = standard_block
+            .body
+            .ommers
+            .iter()
+            .map(|h| BerachainHeader::from_header_with_proposer(h.clone(), None))
+            .collect();
+
         let berachain_body: alloy_consensus::BlockBody<BerachainTxEnvelope, BerachainHeader> =
             alloy_consensus::BlockBody {
                 transactions: standard_block.body.transactions.clone(),

--- a/src/genesis/mod.rs
+++ b/src/genesis/mod.rs
@@ -64,32 +64,12 @@ impl Default for BerachainGenesisConfig {
     fn default() -> Self {
         Self {
             prague1: BerachainForkConfig {
-                time: 0,                             // Activate immediately at genesis
-                base_fee_change_denominator: 48,     // Berachain standard value
-                minimum_base_fee_wei: 1_000_000_000, // 1 gwei
+                time: 0,                              // Activate immediately at genesis
+                base_fee_change_denominator: 48,      // Berachain standard value
+                minimum_base_fee_wei: 10_000_000_000, // 10 gwei
                 pol_distributor_address: default_pol_contract_address(),
             },
         }
-    }
-}
-
-impl BerachainForkConfig {
-    /// Creates validated config. Returns error if denominator is 0.
-    pub fn new(
-        time: u64,
-        base_fee_change_denominator: u128,
-        minimum_base_fee_wei: u64,
-        pol_distributor_address: Address,
-    ) -> Result<Self, BerachainConfigError> {
-        if base_fee_change_denominator == 0 {
-            return Err(BerachainConfigError::InvalidDenominator);
-        }
-        Ok(Self {
-            time,
-            base_fee_change_denominator,
-            minimum_base_fee_wei,
-            pol_distributor_address,
-        })
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,19 +3,18 @@
 #[global_allocator]
 static ALLOC: reth_cli_util::allocator::Allocator = reth_cli_util::allocator::new_allocator();
 
-use bera_reth::{chainspec::BerachainChainSpecParser, node::BerachainNode};
+use bera_reth::{
+    chainspec::{BerachainChainSpec, BerachainChainSpecParser},
+    consensus::BerachainBeaconConsensus,
+    node::{BerachainNode, evm::config::BerachainEvmConfig},
+};
 use clap::Parser;
 use reth::CliRunner;
-use std::sync::Arc;
-// Removed RessArgs since ress subprotocol is disabled
-use bera_reth::{
-    chainspec::BerachainChainSpec, consensus::BerachainBeaconConsensus,
-    node::evm::config::BerachainEvmConfig,
-};
 use reth_cli_commands::node::NoArgs;
 use reth_ethereum_cli::Cli;
 use reth_evm::EthEvmFactory;
 use reth_node_builder::NodeHandle;
+use std::sync::Arc;
 use tracing::info;
 
 /// Main entry point. Sets up runtime, signal handlers, and launches Berachain node.

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -7,7 +7,7 @@ use crate::{
     consensus::BerachainConsensusBuilder,
     engine::{
         BerachainEngineTypes, builder::BerachainPayloadServiceBuilder,
-        rpc::BerachainEngineApiBuilder, validator::BerachainEngineValidatorBuilder,
+        validator::BerachainEngineValidatorBuilder,
     },
     node::evm::BerachainExecutorBuilder,
     pool::BerachainPoolBuilder,
@@ -123,8 +123,6 @@ where
 
     fn add_ons(&self) -> Self::AddOns {
         BerachainAddOns::default()
-            .with_engine_validator(BerachainEngineValidatorBuilder::default())
-            .with_engine_api(BerachainEngineApiBuilder::<BerachainEngineValidatorBuilder>::default())
     }
 }
 

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -38,7 +38,6 @@ use std::sync::Arc;
 #[non_exhaustive]
 pub struct BerachainNode;
 
-// Same as ETH Except we use BerachainChainSpec
 impl NodeTypes for BerachainNode {
     type Primitives = BerachainPrimitives;
     type ChainSpec = BerachainChainSpec;
@@ -58,36 +57,6 @@ impl<N> Node<N> for BerachainNode
 where
     N: FullNodeTypes<Types = Self>,
 {
-    /// Reth SDK ComponentsBuilder defining the core node architecture.
-    ///
-    /// Each component handles a specific domain of blockchain node operations:
-    ///
-    /// - **EthereumPoolBuilder**: Transaction pool management and validation
-    ///   - Maintains mempool of pending transactions
-    ///   - Validates transactions according to chain rules
-    ///   - Provides transactions for block building
-    ///
-    /// - **`BasicPayloadServiceBuilder<BerachainPayloadServiceBuilder>`**: Block building and
-    ///   payload creation
-    ///   - Triggered by Engine API `forkchoice_updated` calls from consensus layer
-    ///   - Assembles transactions from pool into block payloads
-    ///   - Handles payload building jobs and manages build timeouts
-    ///   - Uses BerachainPayloadBuilder for Berachain-specific block construction
-    ///
-    /// - **EthereumNetworkBuilder**: P2P networking and peer management
-    ///   - Handles block/transaction propagation via devp2p
-    ///   - Manages peer connections and discovery
-    ///   - Synchronizes blockchain state with network peers
-    ///
-    /// - **BerachainExecutorBuilder**: EVM execution environment
-    ///   - Creates standard Ethereum EVM with Berachain chain specification
-    ///   - Executes transactions and manages state transitions
-    ///   - Handles hardfork logic including Prague1 minimum base fee
-    ///
-    /// - **EthereumConsensusBuilder**: Block validation and consensus rules
-    ///   - Validates block headers, transactions, and state transitions
-    ///   - Enforces Ethereum consensus rules with Berachain extensions
-    ///   - Manages fork choice and canonical chain determination
     type ComponentsBuilder = ComponentsBuilder<
         N,
         BerachainPoolBuilder,
@@ -97,14 +66,6 @@ where
         BerachainConsensusBuilder,
     >;
 
-    /// Reth SDK AddOns providing RPC and Engine API interfaces.
-    ///
-    /// - **EthApiBuilder**: Standard Ethereum JSON-RPC API implementation
-    /// - **BerachainEngineValidatorBuilder**: Validates Engine API requests with Berachain rules
-    /// - **BasicEngineApiBuilder**: Handles consensus layer communication via Engine API
-    ///   - Processes `forkchoice_updated` to trigger payload building
-    ///   - Handles `new_payload` for block execution and validation
-    ///   - Manages consensus-execution layer synchronization
     type AddOns = BerachainAddOns<
         NodeAdapter<N, <Self::ComponentsBuilder as NodeComponentsBuilder<N>>::Components>,
         BerachainEthApiBuilder,

--- a/src/pool/transaction.rs
+++ b/src/pool/transaction.rs
@@ -16,7 +16,7 @@ use reth_primitives_traits::{InMemorySize, SignedTransaction};
 use reth_transaction_pool::{EthBlobTransactionSidecar, EthPoolTransaction, PoolTransaction};
 use std::sync::Arc;
 
-/// The default `PoolTransaction` for the Pool for Ethereum.
+/// The default `BerachainPooledTransaction` for the Pool for Berachain.
 ///
 /// This type wraps a consensus transaction with additional cached data that's
 /// frequently accessed by the pool for transaction ordering and validation:
@@ -121,14 +121,14 @@ impl Transaction for BerachainPooledTransaction {
     }
 }
 
-/// A type alias for `PooledTransaction` that's also generic over blob sidecar.
+/// A type alias that's also generic over blob sidecar.
 pub type BerachainPooledTransactionVariant =
     EthereumTxEnvelope<TxEip4844WithSidecar<BlobTransactionSidecarVariant>>;
 
 impl BerachainPooledTransaction {
     /// Create new instance of [Self].
     ///
-    /// Caution: In case of blob transactions, this does marks the blob sidecar as
+    /// Caution: In case of blob transactions, this marks the blob sidecar as
     /// [`EthBlobTransactionSidecar::Missing`]
     pub fn new(
         transaction: Recovered<EthereumTxEnvelope<TxEip4844>>,

--- a/src/primitives/header.rs
+++ b/src/primitives/header.rs
@@ -4,6 +4,7 @@ use alloy_primitives::{
 };
 use alloy_rlp::{Decodable, Encodable, length_of_length};
 use bytes::BufMut;
+use reth_cli_commands::common::CliHeader;
 use reth_codecs::Compact;
 use reth_db_api::table::{Compress, Decompress};
 use reth_primitives_traits::{BlockHeader, InMemorySize, serde_bincode_compat::RlpBincode};
@@ -13,7 +14,6 @@ use serde::{Deserialize, Serialize};
 pub type BlsPublicKey = FixedBytes<48>;
 
 /// Berachain block header with additional fields for consensus
-/// TODO: All of the implementations here need to be properly tested.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BerachainHeader {
@@ -93,7 +93,7 @@ pub struct BerachainHeader {
 }
 
 /// Implementation of CliHeader trait for CLI operations
-impl reth_cli_commands::common::CliHeader for BerachainHeader {
+impl CliHeader for BerachainHeader {
     fn set_number(&mut self, number: u64) {
         self.number = number;
     }

--- a/src/primitives/header.rs
+++ b/src/primitives/header.rs
@@ -92,6 +92,13 @@ pub struct BerachainHeader {
     pub extra_data: Bytes,
 }
 
+/// Implementation of CliHeader trait for CLI operations
+impl reth_cli_commands::common::CliHeader for BerachainHeader {
+    fn set_number(&mut self, number: u64) {
+        self.number = number;
+    }
+}
+
 impl BerachainHeader {
     fn header_payload_length(&self) -> usize {
         let mut length = 0;

--- a/src/primitives/header.rs
+++ b/src/primitives/header.rs
@@ -442,31 +442,35 @@ impl From<&Header> for BerachainHeader {
     }
 }
 
-impl From<Header> for BerachainHeader {
-    fn from(value: Header) -> Self {
-        BerachainHeader {
-            parent_hash: value.parent_hash,
-            ommers_hash: value.ommers_hash,
-            beneficiary: value.beneficiary,
-            state_root: value.state_root,
-            transactions_root: value.transactions_root,
-            receipts_root: value.receipts_root,
-            withdrawals_root: value.withdrawals_root,
-            logs_bloom: value.logs_bloom,
-            difficulty: value.difficulty,
-            number: value.number,
-            gas_limit: value.gas_limit,
-            gas_used: value.gas_used,
-            timestamp: value.timestamp,
-            mix_hash: value.mix_hash,
-            nonce: value.nonce,
-            base_fee_per_gas: value.base_fee_per_gas,
-            blob_gas_used: value.blob_gas_used,
-            excess_blob_gas: value.excess_blob_gas,
-            parent_beacon_block_root: value.parent_beacon_block_root,
-            requests_hash: value.requests_hash,
-            prev_proposer_pubkey: None,
-            extra_data: value.extra_data,
+impl BerachainHeader {
+    /// Creates a BerachainHeader from a standard Header with optional previous proposer public key
+    pub fn from_header_with_proposer(
+        header: Header,
+        prev_proposer_pubkey: Option<BlsPublicKey>,
+    ) -> Self {
+        Self {
+            parent_hash: header.parent_hash,
+            ommers_hash: header.ommers_hash,
+            beneficiary: header.beneficiary,
+            state_root: header.state_root,
+            transactions_root: header.transactions_root,
+            receipts_root: header.receipts_root,
+            withdrawals_root: header.withdrawals_root,
+            logs_bloom: header.logs_bloom,
+            difficulty: header.difficulty,
+            number: header.number,
+            gas_limit: header.gas_limit,
+            gas_used: header.gas_used,
+            timestamp: header.timestamp,
+            mix_hash: header.mix_hash,
+            nonce: header.nonce,
+            base_fee_per_gas: header.base_fee_per_gas,
+            blob_gas_used: header.blob_gas_used,
+            excess_blob_gas: header.excess_blob_gas,
+            parent_beacon_block_root: header.parent_beacon_block_root,
+            requests_hash: header.requests_hash,
+            prev_proposer_pubkey,
+            extra_data: header.extra_data,
         }
     }
 }

--- a/src/primitives/mod.rs
+++ b/src/primitives/mod.rs
@@ -14,9 +14,9 @@ pub type BerachainBlock = alloy_consensus::Block<BerachainTxEnvelope, BerachainH
 pub type BerachainBlockBody = alloy_consensus::BlockBody<BerachainTxEnvelope, BerachainHeader>;
 
 impl NodePrimitives for BerachainPrimitives {
-    type Block = BerachainBlock; // Uses your transaction type
-    type BlockHeader = BerachainHeader; // Custom Berachain header with prev_proposer_pubkey
-    type BlockBody = BerachainBlockBody; // Uses your transaction type
-    type SignedTx = BerachainTxEnvelope; // Your custom transaction envelope
-    type Receipt = reth_ethereum_primitives::Receipt<BerachainTxType>; // Berachain receipts with transaction type
+    type Block = BerachainBlock;
+    type BlockHeader = BerachainHeader;
+    type BlockBody = BerachainBlockBody;
+    type SignedTx = BerachainTxEnvelope;
+    type Receipt = reth_ethereum_primitives::Receipt<BerachainTxType>;
 }

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -2,7 +2,10 @@ pub mod api;
 pub mod receipt;
 
 use crate::{
-    engine::{BerachainExecutionData, rpc::BerachainEngineApiBuilder},
+    engine::{
+        BerachainExecutionData, rpc::BerachainEngineApiBuilder,
+        validator::BerachainEngineValidatorBuilder,
+    },
     node::evm::config::BerachainNextBlockEnvAttributes,
     primitives::BerachainPrimitives,
     rpc::{
@@ -14,14 +17,15 @@ use reth::{
     api::{FullNodeComponents, HeaderTy, PrimitivesTy},
     chainspec::EthereumHardforks,
     revm::context::TxEnv,
-    rpc::{api::eth::FromEvmError, server_types::eth::EthApiError},
+    rpc::{api::eth::FromEvmError, builder::Identity, server_types::eth::EthApiError},
 };
 use reth_chainspec::{ChainSpecProvider, EthChainSpec};
 use reth_evm::{ConfigureEvm, EvmFactory, EvmFactoryFor, TxEnvFor};
-use reth_node_api::{AddOnsContext, FullNodeTypes, NodeAddOns, NodeTypes};
+use reth_node_api::{FullNodeTypes, NodeAddOns, NodeTypes};
 use reth_node_builder::rpc::{
-    EngineApiBuilder, EngineValidatorAddOn, EngineValidatorBuilder, EthApiBuilder, EthApiCtx,
-    RethRpcAddOns, RpcAddOns, RpcHandle,
+    BasicEngineValidatorBuilder, EngineApiBuilder, EngineValidatorAddOn, EngineValidatorBuilder,
+    EthApiBuilder, EthApiCtx, PayloadValidatorBuilder, RethRpcAddOns, RethRpcMiddleware, RpcAddOns,
+    RpcHandle,
 };
 use reth_rpc_convert::{RpcConvert, RpcConverter};
 use reth_rpc_eth_api::helpers::pending_block::BuildPendingEnv;
@@ -78,18 +82,15 @@ where
 pub struct BerachainAddOns<
     N: FullNodeComponents,
     EthB: EthApiBuilder<N>,
-    EV,
-    EB = BerachainEngineApiBuilder<EV>,
+    PVB,
+    EB = BerachainEngineApiBuilder<PVB>,
+    EVB = BasicEngineValidatorBuilder<PVB>,
+    RpcMiddleware = Identity,
 > {
-    inner: RpcAddOns<N, EthB, EV, EB>,
+    inner: RpcAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware>,
 }
 
-impl<N> Default
-    for BerachainAddOns<
-        N,
-        BerachainEthApiBuilder,
-        crate::engine::validator::BerachainEngineValidatorBuilder,
-    >
+impl<N> Default for BerachainAddOns<N, BerachainEthApiBuilder, BerachainEngineValidatorBuilder>
 where
     N: FullNodeComponents,
     BerachainEthApiBuilder: EthApiBuilder<N>,
@@ -98,21 +99,25 @@ where
         Self {
             inner: RpcAddOns::new(
                 BerachainEthApiBuilder,
-                crate::engine::validator::BerachainEngineValidatorBuilder::default(),
-                BerachainEngineApiBuilder::default(),
+                BerachainEngineValidatorBuilder::default(),
+                BerachainEngineApiBuilder::<BerachainEngineValidatorBuilder>::default(),
+                BasicEngineValidatorBuilder::new(BerachainEngineValidatorBuilder::default()),
                 Default::default(),
             ),
         }
     }
 }
 
-impl<N, EthB, EV, EB> BerachainAddOns<N, EthB, EV, EB>
+impl<N, EthB, PVB, EB, EVB, RpcMiddleware> BerachainAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware>
 where
     N: FullNodeComponents,
     EthB: EthApiBuilder<N>,
 {
     /// Replace the engine API builder.
-    pub fn with_engine_api<T>(self, engine_api_builder: T) -> BerachainAddOns<N, EthB, EV, T>
+    pub fn with_engine_api<T>(
+        self,
+        engine_api_builder: T,
+    ) -> BerachainAddOns<N, EthB, PVB, T, EVB, RpcMiddleware>
     where
         T: Send,
     {
@@ -120,20 +125,18 @@ where
         BerachainAddOns { inner: inner.with_engine_api(engine_api_builder) }
     }
 
-    /// Replace the engine validator builder.
-    pub fn with_engine_validator<T>(
+    /// Replace the payload validator builder.
+    pub fn with_payload_validator<V, T>(
         self,
-        engine_validator_builder: T,
-    ) -> BerachainAddOns<N, EthB, T, EB>
-    where
-        T: Send,
-    {
+        payload_validator_builder: T,
+    ) -> BerachainAddOns<N, EthB, T, EB, EVB, RpcMiddleware> {
         let Self { inner } = self;
-        BerachainAddOns { inner: inner.with_engine_validator(engine_validator_builder) }
+        BerachainAddOns { inner: inner.with_payload_validator(payload_validator_builder) }
     }
 }
 
-impl<N, EthB, EV, EB> NodeAddOns<N> for BerachainAddOns<N, EthB, EV, EB>
+impl<N, EthB, PVB, EB, EVB, RpcMiddleware> NodeAddOns<N>
+    for BerachainAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware>
 where
     N: FullNodeComponents<
             Types: NodeTypes<
@@ -143,11 +146,14 @@ where
                     ExecutionData = BerachainExecutionData,
                 >,
             >,
+            Provider: reth_chainspec::ChainSpecProvider<ChainSpec: EthereumHardforks>,
             Evm: ConfigureEvm<NextBlockEnvCtx = BerachainNextBlockEnvAttributes>,
         >,
     EthB: EthApiBuilder<N>,
-    EV: EngineValidatorBuilder<N>,
+    PVB: PayloadValidatorBuilder<N>,
     EB: EngineApiBuilder<N>,
+    EVB: EngineValidatorBuilder<N>,
+    RpcMiddleware: RethRpcMiddleware,
     EthApiError: FromEvmError<N::Evm>,
     EvmFactoryFor<N::Evm>: EvmFactory<Tx = TxEnv>,
 {
@@ -161,7 +167,7 @@ where
     }
 }
 
-impl<N, EthB, EV, EB> RethRpcAddOns<N> for BerachainAddOns<N, EthB, EV, EB>
+impl<N, EthB, PVB, EB, EVB> RethRpcAddOns<N> for BerachainAddOns<N, EthB, PVB, EB, EVB>
 where
     N: FullNodeComponents<
             Types: NodeTypes<
@@ -174,8 +180,9 @@ where
             Evm: ConfigureEvm<NextBlockEnvCtx = BerachainNextBlockEnvAttributes>,
         >,
     EthB: EthApiBuilder<N>,
-    EV: EngineValidatorBuilder<N>,
+    PVB: PayloadValidatorBuilder<N>,
     EB: EngineApiBuilder<N>,
+    EVB: EngineValidatorBuilder<N>,
     EthApiError: FromEvmError<N::Evm>,
     EvmFactoryFor<N::Evm>: EvmFactory<Tx = TxEnv>,
 {
@@ -186,7 +193,7 @@ where
     }
 }
 
-impl<N, EthB, EV, EB> EngineValidatorAddOn<N> for BerachainAddOns<N, EthB, EV, EB>
+impl<N, EthB, PVB, EB, EVB> EngineValidatorAddOn<N> for BerachainAddOns<N, EthB, PVB, EB, EVB>
 where
     N: FullNodeComponents<
             Types: NodeTypes<
@@ -199,14 +206,15 @@ where
             Evm: ConfigureEvm<NextBlockEnvCtx = BerachainNextBlockEnvAttributes>,
         >,
     EthB: EthApiBuilder<N>,
-    EV: EngineValidatorBuilder<N>,
+    PVB: Send,
     EB: EngineApiBuilder<N>,
+    EVB: EngineValidatorBuilder<N>,
     EthApiError: FromEvmError<N::Evm>,
     EvmFactoryFor<N::Evm>: EvmFactory<Tx = TxEnv>,
 {
-    type Validator = EV::Validator;
+    type ValidatorBuilder = EVB;
 
-    async fn engine_validator(&self, ctx: &AddOnsContext<'_, N>) -> eyre::Result<Self::Validator> {
-        self.inner.engine_validator(ctx).await
+    fn engine_validator_builder(&self) -> Self::ValidatorBuilder {
+        self.inner.engine_validator_builder()
     }
 }

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -146,16 +146,16 @@ where
                     ExecutionData = BerachainExecutionData,
                 >,
             >,
-            Provider: reth_chainspec::ChainSpecProvider<ChainSpec: EthereumHardforks>,
+            Provider: ChainSpecProvider<ChainSpec: EthereumHardforks>,
             Evm: ConfigureEvm<NextBlockEnvCtx = BerachainNextBlockEnvAttributes>,
         >,
     EthB: EthApiBuilder<N>,
     PVB: PayloadValidatorBuilder<N>,
     EB: EngineApiBuilder<N>,
     EVB: EngineValidatorBuilder<N>,
-    RpcMiddleware: RethRpcMiddleware,
     EthApiError: FromEvmError<N::Evm>,
     EvmFactoryFor<N::Evm>: EvmFactory<Tx = TxEnv>,
+    RpcMiddleware: RethRpcMiddleware,
 {
     type Handle = RpcHandle<N, EthB::EthApi>;
 


### PR DESCRIPTION
prompt

```
I am trying to upgrade my bera-reth, reth dependency to the latest reth version. I have started the changes, but i'm runnign into issues. I need to you to study all the commits between my last reth version and the current and then figure out the changes that need to be done to bera-reth to stay compatible without compiler issues. Spin up as many subagents as you need. I've tried started the changes but its tricky. Ultrathink.
You don't need to research the tags. Look at my staged changes to see the diff in reth commits. I'm technically still in the same reth version but trying to bump. Remember that I also have reth locally at ./reth
```

closes #65 
