### PR TITLE
fix: chainspec genesis parsing nits and add more startup logging for prague1

### DIFF
--- a/src/chainspec/mod.rs
+++ b/src/chainspec/mod.rs
@@ -82,7 +82,24 @@ impl EthChainSpec for BerachainChainSpec {
     }
 
     fn display_hardforks(&self) -> Box<dyn Display> {
-        Box::new(self.inner.display_hardforks())
+        let inner_display = self.inner.display_hardforks().to_string();
+
+        // Only show Prague1 configuration if it's configured as a timestamp-based fork
+        let prague1_details = match self.fork(BerachainHardfork::Prague1) {
+            ForkCondition::Timestamp(time) => {
+                let base_fee_params = self.base_fee_params_at_timestamp(time);
+                format!(
+                    "\nBerachain Prague1 configuration: {{time={}, base_fee_denominator={}, min_base_fee={} gwei, pol_distributor={}}}",
+                    time,
+                    base_fee_params.max_change_denominator,
+                    self.prague1_minimum_base_fee / 1_000_000_000,
+                    self.pol_contract_address
+                )
+            }
+            _ => "\nPrague1 Misconfigured".to_string(),
+        };
+
+        Box::new(format!("{}{}", inner_display, prague1_details))
     }
 
     fn genesis_header(&self) -> &Self::Header {
@@ -295,7 +312,7 @@ impl From<Genesis> for BerachainChainSpec {
         ));
 
         let paris_block_and_final_difficulty =
-            Some((0, genesis.config.terminal_total_difficulty.unwrap_or_default()));
+            Some((0, genesis.config.terminal_total_difficulty.unwrap()));
 
         // Extract blob parameters directly from blob_schedule
         let blob_params = genesis.config.blob_schedule_blob_params();

--- a/src/chainspec/mod.rs
+++ b/src/chainspec/mod.rs
@@ -87,7 +87,6 @@ impl EthChainSpec for BerachainChainSpec {
     fn display_hardforks(&self) -> Box<dyn Display> {
         let inner_display = self.inner.display_hardforks().to_string();
 
-        // Only show Prague1 configuration if it's configured as a timestamp-based fork
         let prague1_details = match self.fork(BerachainHardfork::Prague1) {
             ForkCondition::Timestamp(time) => {
                 let base_fee_params = self.base_fee_params_at_timestamp(time);
@@ -102,7 +101,7 @@ impl EthChainSpec for BerachainChainSpec {
             _ => "\nPrague1 Misconfigured".to_string(),
         };
 
-        Box::new(format!("{}{}", inner_display, prague1_details))
+        Box::new(format!("{inner_display}{prague1_details}"))
     }
 
     fn genesis_header(&self) -> &Self::Header {

--- a/src/chainspec/mod.rs
+++ b/src/chainspec/mod.rs
@@ -21,7 +21,10 @@ use reth::{
     primitives::SealedHeader,
     revm::primitives::{Address, B256, U256, b256},
 };
-use reth_chainspec::{ChainSpec, DepositContract, EthChainSpec, Hardforks, make_genesis_header};
+use reth_chainspec::{
+    ChainSpec, DepositContract, EthChainSpec, Hardforks, MAINNET_PRUNE_DELETE_LIMIT,
+    make_genesis_header,
+};
 use reth_cli::chainspec::{ChainSpecParser, parse_genesis};
 use reth_ethereum_cli::chainspec::SUPPORTED_CHAINS;
 use reth_evm::eth::spec::EthExecutorSpec;
@@ -375,7 +378,7 @@ impl From<Genesis> for BerachainChainSpec {
             deposit_contract,
             blob_params,
             base_fee_params,
-            ..Default::default()
+            prune_delete_limit: MAINNET_PRUNE_DELETE_LIMIT,
         };
 
         let mut genesis_header = BerachainHeader::from(inner.genesis_header());
@@ -541,6 +544,41 @@ mod tests {
         let params = chain_spec.base_fee_params_at_timestamp(0);
         assert_eq!(params.max_change_denominator, 100);
         assert_eq!(params.elasticity_multiplier, 2);
+    }
+
+    #[test]
+    fn test_default_prune_delete_limit_is_20000() {
+        // Test that the default prune delete limit from ..Default::default() is 20000
+        // (MAINNET_PRUNE_DELETE_LIMIT)
+        let mut genesis = Genesis::default();
+        genesis.config.london_block = Some(0);
+        genesis.config.cancun_time = Some(0);
+        genesis.config.terminal_total_difficulty = Some(U256::ZERO);
+        let extra_fields_json = json!({
+            "berachain": {
+                "prague1": {
+                    "time": 0,
+                    "baseFeeChangeDenominator": 8,
+                    "minimumBaseFeeWei": 1000000000,
+                    "polDistributorAddress": "0x4200000000000000000000000000000000000042"
+                }
+            }
+        });
+        genesis.config.extra_fields =
+            reth::rpc::types::serde_helpers::OtherFields::try_from(extra_fields_json).unwrap();
+
+        let chain_spec = BerachainChainSpec::from(genesis);
+
+        // Verify prune delete limit defaults to 20000 (MAINNET_PRUNE_DELETE_LIMIT)
+        assert_eq!(
+            chain_spec.prune_delete_limit(),
+            20000,
+            "Default prune delete limit should be 20000 (MAINNET_PRUNE_DELETE_LIMIT)"
+        );
+        assert_eq!(
+            chain_spec.inner.prune_delete_limit, 20000,
+            "Inner ChainSpec prune delete limit should be 20000"
+        );
     }
 
     #[test]

--- a/src/consensus/mod.rs
+++ b/src/consensus/mod.rs
@@ -34,6 +34,7 @@ where
 #[derive(Debug, Clone)]
 pub struct BerachainBeaconConsensus {
     inner: EthBeaconConsensus<BerachainChainSpec>,
+    /// Berachain chain specification.
     chain_spec: Arc<BerachainChainSpec>,
 }
 

--- a/src/consensus/mod.rs
+++ b/src/consensus/mod.rs
@@ -34,7 +34,6 @@ where
 #[derive(Debug, Clone)]
 pub struct BerachainBeaconConsensus {
     inner: EthBeaconConsensus<BerachainChainSpec>,
-    /// Berachain chain specification.
     chain_spec: Arc<BerachainChainSpec>,
 }
 

--- a/src/genesis/mod.rs
+++ b/src/genesis/mod.rs
@@ -23,10 +23,6 @@ pub enum BerachainConfigError {
     #[error("Base fee change denominator cannot be zero")]
     InvalidDenominator,
 
-    /// Fork activation time is invalid (e.g., in the past for future forks)
-    #[error("Invalid fork activation time: {0}")]
-    InvalidActivationTime(u64),
-
     /// PoL distributor address is missing from Prague1 configuration
     #[error("PoL distributor address is required in Prague1 configuration but was not provided")]
     MissingPoLDistributorAddress,
@@ -101,10 +97,7 @@ impl TryFrom<&OtherFields> for BerachainGenesisConfig {
                 Ok(cfg)
             }
             Some(Err(e)) => Err(BerachainConfigError::InvalidConfig(e)),
-            None => {
-                info!("No berachain configuration found in genesis, using defaults");
-                Err(BerachainConfigError::MissingBerachainField)
-            }
+            None => Err(BerachainConfigError::MissingBerachainField),
         }
     }
 }

--- a/src/node/evm/executor.rs
+++ b/src/node/evm/executor.rs
@@ -35,6 +35,7 @@ use std::{borrow::Cow, sync::Arc};
 
 #[derive(Debug)]
 pub struct BerachainBlockExecutor<'a, Evm> {
+    /// Berachain chain specification.
     spec: Arc<BerachainChainSpec>,
     /// Context for block execution.
     pub ctx: BerachainBlockExecutionCtx<'a>,


### PR DESCRIPTION
This PR addresses several code review recommendations to improve code clarity and maintainability:

• Replace `unwrap_or_default()` with `unwrap()` for terminal_total_difficulty since validation already ensures it's not None
• Remove misleading log messages about defaults when no defaults are actually used  
• Remove the unused InvalidActivationTime error variant
• Add inline documentation for chain specification fields
• Enhance hardfork display to show Prague1 configuration details (activation time, base fee denominator, minimum base fee, and PoL distributor address) during startup logging
• Show "Prague1 Misconfigured" if Prague1 is not properly configured as a timestamp-based fork