### PR TITLE
chore: protect :latest docker tag from accidental updates

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,7 +18,7 @@ jobs:
       make-target: docker-build-push
 
   docker-latest:
-    if: ${{ !contains(github.ref, '-rc') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') && !contains(github.ref, '+') && !contains(github.ref, '_') }}
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Summary
- Restrict `:latest` Docker tag to only apply to exact `vx.y.z` semantic version tags
- Previous logic only excluded `-rc` suffixes, now excludes any non-semantic version patterns
- Prevents accidental `:latest` updates from alpha, beta, RC, or other pre-release tags

## Changes
- Updated Docker workflow condition from `\!contains(github.ref, '-rc')` to strict pattern matching
- Now requires exact `vx.y.z` format with no additional suffixes (`-`, `+`, `_`)
