### PR TITLE
chore: bump version to 1.0.0-rc.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1439,7 +1439,7 @@ checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
 name = "bera-reth"
-version = "1.0.0-rc.9"
+version = "1.0.0-rc.10"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bera-reth"
-version = "1.0.0-rc.9"
+version = "1.0.0-rc.10"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 


### PR DESCRIPTION
Bumps the crate version to v1.0.0-rc.10 in preparation for the next release candidate.

## Changes
- Update version in `Cargo.toml` from `1.0.0-rc.9` to `1.0.0-rc.10`
- Update `Cargo.lock` accordingly

## Next Steps
1. Create and push git tag: `git tag v1.0.0-rc.10 && git push origin v1.0.0-rc.10`
2. Monitor release workflow in Actions
3. Review and publish the generated release

🤖 Generated with [Claude Code](https://claude.ai/code)