### PR TITLE
test: add strict 30M gas limit regression test for PoL transactions

### DIFF
--- a/tests/e2e/gas_limit_regression_test.rs
+++ b/tests/e2e/gas_limit_regression_test.rs
@@ -118,22 +118,22 @@ async fn test_pol_gas_limit_boundary_succeeds() -> eyre::Result<()> {
     println!("✅ PoL transaction with gas boundary validation executed successfully!");
     println!("   Block number: {}", block.number);
     println!("   Transaction count: {}", transactions.len());
-    println!("   PoL transaction hash: {:#x}", tx_hash);
+    println!("   PoL transaction hash: {tx_hash:#x}");
 
     // Log all receipt fields
     println!("📋 Transaction Receipt Details:");
     println!("   transaction_hash: {:#x}", receipt.transaction_hash);
     println!("   transaction_index: {:?}", receipt.transaction_index);
-    println!("   block_hash: {:?}", receipt.block_hash.map(|h| format!("{:#x}", h)));
+    println!("   block_hash: {:?}", receipt.block_hash.map(|h| format!("{h:#x}")));
     println!("   block_number: {:?}", receipt.block_number);
     println!("   gas_used: {}", receipt.gas_used);
     println!("   cumulative_gas_used: {}", receipt.cumulative_gas_used());
     println!("   effective_gas_price: {}", receipt.effective_gas_price);
     println!("   from: {:#x}", receipt.from);
-    println!("   to: {:?}", receipt.to.map(|addr| format!("{:#x}", addr)));
+    println!("   to: {:?}", receipt.to.map(|addr| format!("{addr:#x}")));
     println!(
         "   contract_address: {:?}",
-        receipt.contract_address.map(|addr| format!("{:#x}", addr))
+        receipt.contract_address.map(|addr| format!("{addr:#x}"))
     );
     println!("   status: {}", receipt.status());
     println!("   logs count: {}", receipt.logs().len());

--- a/tests/e2e/gas_limit_regression_test.rs
+++ b/tests/e2e/gas_limit_regression_test.rs
@@ -1,0 +1,124 @@
+//! Gas limit regression tests for PoL transactions
+//!
+//! These tests verify that the 30M gas limit for system calls in REVM
+//! remains compatible with PoL transaction execution.
+
+use crate::e2e::berachain_payload_attributes;
+use alloy_genesis::Genesis;
+use alloy_primitives::{Address, Bytes};
+use alloy_sol_macro::sol;
+use bera_reth::{
+    chainspec::BerachainChainSpec, node::BerachainNode, transaction::BerachainTxEnvelope,
+};
+use reth::{providers::ReceiptProvider, tasks::TaskManager};
+use reth_cli::chainspec::parse_genesis;
+use reth_e2e_test_utils::node::NodeTestContext;
+use reth_node_builder::{NodeBuilder, NodeHandle};
+use reth_node_core::{args::RpcServerArgs, node_config::NodeConfig};
+use reth_payload_primitives::BuiltPayload;
+use std::{str::FromStr, sync::Arc};
+
+// Gas boundary testing PoL distributor contract for regression testing
+sol! {
+    #[sol(bytecode = "0x608060405234801561000f575f80fd5b5060043610610029575f3560e01c806360644a6b1461002d575b5f80fd5b61004061003b3660046100da565b610042565b005b5f5a90506301c900308110156100925760405162461bcd60e51b815260206004820152601060248201526f496e73756666696369656e742067617360801b60448201526064015b60405180910390fd5b6301c9c3808111156100d55760405162461bcd60e51b815260206004820152600c60248201526b546f6f206d7563682067617360a01b6044820152606401610089565b505050565b5f80602083850312156100eb575f80fd5b823567ffffffffffffffff811115610101575f80fd5b8301601f81018513610111575f80fd5b803567ffffffffffffffff811115610127575f80fd5b856020828401011115610138575f80fd5b602091909101959094509250505056fea2646970667358221220520bb1eea6ca1b15920f93b3c22dc56d139dc7bf299271a290231604bd3bc5b464736f6c634300081a0033")]
+    contract SimplePoLDistributor {
+        /// This contract validates the 30M system call gas limit boundary
+        /// It requires exactly 29.95M-30M gas to ensure we're testing at the limit
+        function distributeFor(bytes calldata /*pubkey*/) public {
+            uint256 start_gas = gasleft();
+            require(start_gas >= 29_950_000, "Insufficient gas");
+            require(start_gas <= 30_000_000, "Too much gas");
+        }
+    }
+}
+
+/// PoL distributor contract address
+const POL_DISTRIBUTOR_ADDRESS: &str = "0x4200000000000000000000000000000000000042";
+
+/// Create a custom chainspec with the gas boundary validation PoL distributor contract
+async fn setup_test_with_gas_boundary_pol_contract()
+-> eyre::Result<(TaskManager, Arc<BerachainChainSpec>)> {
+    let tasks = TaskManager::current();
+
+    // Load the base genesis file
+    let genesis_path = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/eth-genesis.json");
+    let genesis_json = std::fs::read_to_string(genesis_path)?;
+    let mut genesis: Genesis = parse_genesis(&genesis_json)?;
+
+    // Replace the PoL distributor contract with our gas-heavy version
+    let pol_address = Address::from_str(POL_DISTRIBUTOR_ADDRESS)?;
+    let new_bytecode = Bytes::from_str(&SimplePoLDistributor::BYTECODE.to_string())?;
+
+    if let Some(account) = genesis.alloc.get_mut(&pol_address) {
+        account.code = Some(new_bytecode);
+        println!("✅ Replaced PoL distributor contract with gas boundary validator");
+    } else {
+        // If the PoL contract doesn't exist in genesis, this test cannot proceed
+        return Err(eyre::eyre!(
+            "PoL distributor contract not found at {} in genesis file. \
+             This test requires the contract to exist for replacement.",
+            POL_DISTRIBUTOR_ADDRESS
+        ));
+    }
+
+    let chain_spec = Arc::new(BerachainChainSpec::from(genesis));
+    Ok((tasks, chain_spec))
+}
+
+#[tokio::test]
+async fn test_pol_gas_limit_boundary_succeeds() -> eyre::Result<()> {
+    let (tasks, chain_spec) = setup_test_with_gas_boundary_pol_contract().await?;
+    let executor = tasks.executor();
+
+    let node_config = NodeConfig::new(chain_spec.clone())
+        .with_unused_ports()
+        .with_rpc(RpcServerArgs::default().with_unused_ports().with_http());
+
+    let NodeHandle { node, node_exit_future: _ } = NodeBuilder::new(node_config)
+        .testing_node(executor.clone())
+        .node(BerachainNode::default())
+        .launch()
+        .await?;
+
+    let mut ctx = NodeTestContext::new(node, berachain_payload_attributes).await?;
+
+    println!("🚀 Testing PoL transaction with 29.9M gas contract...");
+
+    // Advance a block - this should create and execute a PoL transaction
+    let payload = ctx.advance_block().await?;
+    let block = payload.block();
+    let transactions = &block.body().transactions;
+
+    // Verify we have transactions (should include the PoL tx)
+    assert!(!transactions.is_empty(), "Block should contain at least one PoL transaction");
+
+    // Verify the first transaction is a PoL transaction and did not revert
+    let first_tx = &transactions[0];
+    assert!(
+        matches!(first_tx, BerachainTxEnvelope::Berachain(_)),
+        "First transaction should be a PoL transaction"
+    );
+
+    // Get transaction receipt to verify it didn't revert
+    let tx_hash = *first_tx.hash();
+    let receipt = ctx
+        .rpc
+        .inner
+        .eth_api()
+        .provider()
+        .receipt(tx_hash)?
+        .ok_or_else(|| eyre::eyre!("Receipt not found for PoL transaction"))?;
+
+    assert!(
+        receipt.success,
+        "PoL transaction should not have reverted. This indicates the gas boundary validation failed."
+    );
+
+    println!("✅ PoL transaction with gas boundary validation executed successfully!");
+    println!("   Block number: {}", block.number);
+    println!("   Transaction count: {}", transactions.len());
+    println!("   PoL transaction hash: {:#x}", tx_hash);
+    println!("   PoL transaction gas used: {}", receipt.cumulative_gas_used);
+
+    Ok(())
+}

--- a/tests/e2e/gas_limit_regression_test.rs
+++ b/tests/e2e/gas_limit_regression_test.rs
@@ -1,6 +1,7 @@
 //! Gas limit regression tests for PoL transactions
 //!
-//! These tests verify that the 30M gas limit for system calls in REVM does not change
+//! These tests verify that the 30M gas limit for system calls in REVM remains exactly 30,000,000.
+//! Any deviation from this exact value will cause the test to fail.
 //!
 //! Context: REVM hardcodes a 30M gas limit for system calls in the handler:
 //! https://github.com/bluealloy/revm/blob/f3c794b4df282d8053d60e67bca5c4a306031357/crates/handler/src/system_call.rs#L65
@@ -21,16 +22,18 @@ use reth_node_core::{args::RpcServerArgs, node_config::NodeConfig};
 use reth_payload_primitives::BuiltPayload;
 use std::{str::FromStr, sync::Arc};
 
-// Gas boundary testing PoL distributor contract for regression testing
+// Strict gas limit validation contract for regression testing
+// This contract expects exactly 29,999,646 gas remaining at execution time.
+// This precise value corresponds to the 30M system call gas limit minus the gas
+// consumed by transaction processing and function call overhead.
 sol! {
-    #[sol(bytecode = "0x608060405234801561000f575f80fd5b5060043610610029575f3560e01c806360644a6b1461002d575b5f80fd5b61004061003b3660046100da565b610042565b005b5f5a90506301c900308110156100925760405162461bcd60e51b815260206004820152601060248201526f496e73756666696369656e742067617360801b60448201526064015b60405180910390fd5b6301c9c3808111156100d55760405162461bcd60e51b815260206004820152600c60248201526b546f6f206d7563682067617360a01b6044820152606401610089565b505050565b5f80602083850312156100eb575f80fd5b823567ffffffffffffffff811115610101575f80fd5b8301601f81018513610111575f80fd5b803567ffffffffffffffff811115610127575f80fd5b856020828401011115610138575f80fd5b602091909101959094509250505056fea2646970667358221220520bb1eea6ca1b15920f93b3c22dc56d139dc7bf299271a290231604bd3bc5b464736f6c634300081a0033")]
+    #[sol(bytecode = "0x608060405234801561000f575f80fd5b5060043610610029575f3560e01c806360644a6b1461002d575b5f80fd5b61004061003b366004610095565b610042565b005b5f5a9050806301c9c21e146100905760405162461bcd60e51b815260206004820152601060248201526f496e73756666696369656e742067617360801b604482015260640160405180910390fd5b505050565b5f80602083850312156100a6575f80fd5b823567ffffffffffffffff8111156100bc575f80fd5b8301601f810185136100cc575f80fd5b803567ffffffffffffffff8111156100e2575f80fd5b8560208284010111156100f3575f80fd5b602091909101959094509250505056fea2646970667358221220d5e6c7321d98a40b9a775d16eed1a1ef1182f64c7e8bf81f724feef606d28dde64736f6c634300081a0033")]
     contract SimplePoLDistributor {
-        /// This contract validates the 30M system call gas limit boundary
-        /// It requires exactly 29.95M-30M gas to ensure we're testing at the limit
-        function distributeFor(bytes calldata /*pubkey*/) public {
-            uint256 start_gas = gasleft();
-            require(start_gas >= 29_950_000, "Insufficient gas");
-            require(start_gas <= 30_000_000, "Too much gas");
+            function distributeFor(bytes calldata /*pubkey*/) public {
+              uint256 start_gas = gasleft();
+              // Strict validation: exactly 29,999,646 gas must remain at this point
+              // Any change to REVM's 30M system call limit will cause this to fail
+              require(start_gas == 29_999_646, "Insufficient gas");
         }
     }
 }
@@ -38,7 +41,7 @@ sol! {
 /// PoL distributor contract address
 const POL_DISTRIBUTOR_ADDRESS: &str = "0x4200000000000000000000000000000000000042";
 
-/// Create a custom chainspec with the gas boundary validation PoL distributor contract
+/// Create a custom chainspec with the strict gas limit validation PoL distributor contract
 async fn setup_test_with_gas_boundary_pol_contract()
 -> eyre::Result<(TaskManager, Arc<BerachainChainSpec>)> {
     let tasks = TaskManager::current();
@@ -54,7 +57,7 @@ async fn setup_test_with_gas_boundary_pol_contract()
 
     if let Some(account) = genesis.alloc.get_mut(&pol_address) {
         account.code = Some(new_bytecode);
-        println!("✅ Replaced PoL distributor contract with gas boundary validator");
+        println!("✅ Replaced PoL distributor contract with strict gas limit validator");
     } else {
         // If the PoL contract doesn't exist in genesis, this test cannot proceed
         return Err(eyre::eyre!(
@@ -85,7 +88,7 @@ async fn test_pol_gas_limit_boundary_succeeds() -> eyre::Result<()> {
 
     let mut ctx = NodeTestContext::new(node, berachain_payload_attributes_generator).await?;
 
-    println!("🚀 Testing PoL transaction with 29.9M gas contract...");
+    println!("🚀 Testing PoL transaction with strict 30M gas limit validation...");
 
     // Advance a block - this should create and execute a PoL transaction
     let payload = ctx.advance_block().await?;
@@ -112,12 +115,17 @@ async fn test_pol_gas_limit_boundary_succeeds() -> eyre::Result<()> {
         .await?
         .ok_or_else(|| eyre::eyre!("Receipt not found for PoL transaction"))?;
 
-    assert!(
-        receipt.status(),
-        "PoL transaction should not have reverted. This indicates the gas boundary validation failed."
-    );
+    if !receipt.status() {
+        println!("❌ PoL transaction reverted!");
+        println!("   Transaction hash: {tx_hash:#x}");
+        println!("   Block number: {:?}", receipt.block_number);
+        panic!(
+            "PoL transaction reverted. This indicates that REVM's 30M system call gas limit has been modified, \
+             or the gas consumption pattern has changed. Expected exactly 29,999,646 gas remaining."
+        );
+    }
 
-    println!("✅ PoL transaction with gas boundary validation executed successfully!");
+    println!("✅ PoL transaction with strict gas limit validation executed successfully!");
     println!("   Block number: {}", block.number);
     println!("   Transaction count: {}", transactions.len());
     println!("   PoL transaction hash: {tx_hash:#x}");

--- a/tests/e2e/gas_limit_regression_test.rs
+++ b/tests/e2e/gas_limit_regression_test.rs
@@ -1,7 +1,9 @@
 //! Gas limit regression tests for PoL transactions
 //!
-//! These tests verify that the 30M gas limit for system calls in REVM
-//! remains compatible with PoL transaction execution.
+//! These tests verify that the 30M gas limit for system calls in REVM does not change
+//!
+//! Context: REVM hardcodes a 30M gas limit for system calls in the handler:
+//! https://github.com/bluealloy/revm/blob/f3c794b4df282d8053d60e67bca5c4a306031357/crates/handler/src/system_call.rs#L65
 
 use crate::e2e::berachain_payload_attributes_generator;
 use alloy_genesis::Genesis;
@@ -93,7 +95,7 @@ async fn test_pol_gas_limit_boundary_succeeds() -> eyre::Result<()> {
     // Verify we have transactions (should include the PoL tx)
     assert!(!transactions.is_empty(), "Block should contain at least one PoL transaction");
 
-    // Verify the first transaction is a PoL transaction and did not revert
+    // Verify the first transaction is a PoL transaction
     let first_tx = &transactions[0];
     assert!(
         matches!(first_tx, BerachainTxEnvelope::Berachain(_)),
@@ -119,25 +121,6 @@ async fn test_pol_gas_limit_boundary_succeeds() -> eyre::Result<()> {
     println!("   Block number: {}", block.number);
     println!("   Transaction count: {}", transactions.len());
     println!("   PoL transaction hash: {tx_hash:#x}");
-
-    // Log all receipt fields
-    println!("📋 Transaction Receipt Details:");
-    println!("   transaction_hash: {:#x}", receipt.transaction_hash);
-    println!("   transaction_index: {:?}", receipt.transaction_index);
-    println!("   block_hash: {:?}", receipt.block_hash.map(|h| format!("{h:#x}")));
-    println!("   block_number: {:?}", receipt.block_number);
-    println!("   gas_used: {}", receipt.gas_used);
-    println!("   cumulative_gas_used: {}", receipt.cumulative_gas_used());
-    println!("   effective_gas_price: {}", receipt.effective_gas_price);
-    println!("   from: {:#x}", receipt.from);
-    println!("   to: {:?}", receipt.to.map(|addr| format!("{addr:#x}")));
-    println!(
-        "   contract_address: {:?}",
-        receipt.contract_address.map(|addr| format!("{addr:#x}"))
-    );
-    println!("   status: {}", receipt.status());
-    println!("   logs count: {}", receipt.logs().len());
-    println!("   inner envelope: {:?}", receipt.inner);
 
     Ok(())
 }

--- a/tests/e2e/gas_limit_regression_test.rs
+++ b/tests/e2e/gas_limit_regression_test.rs
@@ -72,7 +72,7 @@ async fn setup_test_with_gas_boundary_pol_contract()
 }
 
 #[tokio::test]
-async fn test_pol_gas_limit_boundary_succeeds() -> eyre::Result<()> {
+async fn test_pol_gas_limit_is_30_million() -> eyre::Result<()> {
     let (tasks, chain_spec) = setup_test_with_gas_boundary_pol_contract().await?;
     let executor = tasks.executor();
 

--- a/tests/e2e/gas_limit_regression_test.rs
+++ b/tests/e2e/gas_limit_regression_test.rs
@@ -3,14 +3,15 @@
 //! These tests verify that the 30M gas limit for system calls in REVM
 //! remains compatible with PoL transaction execution.
 
-use crate::e2e::berachain_payload_attributes;
+use crate::e2e::berachain_payload_attributes_generator;
 use alloy_genesis::Genesis;
+use alloy_network::ReceiptResponse;
 use alloy_primitives::{Address, Bytes};
 use alloy_sol_macro::sol;
 use bera_reth::{
     chainspec::BerachainChainSpec, node::BerachainNode, transaction::BerachainTxEnvelope,
 };
-use reth::{providers::ReceiptProvider, tasks::TaskManager};
+use reth::{rpc::api::EthApiServer, tasks::TaskManager};
 use reth_cli::chainspec::parse_genesis;
 use reth_e2e_test_utils::node::NodeTestContext;
 use reth_node_builder::{NodeBuilder, NodeHandle};
@@ -80,7 +81,7 @@ async fn test_pol_gas_limit_boundary_succeeds() -> eyre::Result<()> {
         .launch()
         .await?;
 
-    let mut ctx = NodeTestContext::new(node, berachain_payload_attributes).await?;
+    let mut ctx = NodeTestContext::new(node, berachain_payload_attributes_generator).await?;
 
     println!("🚀 Testing PoL transaction with 29.9M gas contract...");
 
@@ -99,18 +100,18 @@ async fn test_pol_gas_limit_boundary_succeeds() -> eyre::Result<()> {
         "First transaction should be a PoL transaction"
     );
 
-    // Get transaction receipt to verify it didn't revert
+    // Query the transaction receipt via RPC to verify it didn't revert
     let tx_hash = *first_tx.hash();
     let receipt = ctx
         .rpc
         .inner
         .eth_api()
-        .provider()
-        .receipt(tx_hash)?
+        .transaction_receipt(tx_hash)
+        .await?
         .ok_or_else(|| eyre::eyre!("Receipt not found for PoL transaction"))?;
 
     assert!(
-        receipt.success,
+        receipt.status(),
         "PoL transaction should not have reverted. This indicates the gas boundary validation failed."
     );
 
@@ -118,7 +119,25 @@ async fn test_pol_gas_limit_boundary_succeeds() -> eyre::Result<()> {
     println!("   Block number: {}", block.number);
     println!("   Transaction count: {}", transactions.len());
     println!("   PoL transaction hash: {:#x}", tx_hash);
-    println!("   PoL transaction gas used: {}", receipt.cumulative_gas_used);
+
+    // Log all receipt fields
+    println!("📋 Transaction Receipt Details:");
+    println!("   transaction_hash: {:#x}", receipt.transaction_hash);
+    println!("   transaction_index: {:?}", receipt.transaction_index);
+    println!("   block_hash: {:?}", receipt.block_hash.map(|h| format!("{:#x}", h)));
+    println!("   block_number: {:?}", receipt.block_number);
+    println!("   gas_used: {}", receipt.gas_used);
+    println!("   cumulative_gas_used: {}", receipt.cumulative_gas_used());
+    println!("   effective_gas_price: {}", receipt.effective_gas_price);
+    println!("   from: {:#x}", receipt.from);
+    println!("   to: {:?}", receipt.to.map(|addr| format!("{:#x}", addr)));
+    println!(
+        "   contract_address: {:?}",
+        receipt.contract_address.map(|addr| format!("{:#x}", addr))
+    );
+    println!("   status: {}", receipt.status());
+    println!("   logs count: {}", receipt.logs().len());
+    println!("   inner envelope: {:?}", receipt.inner);
 
     Ok(())
 }

--- a/tests/e2e/gas_limit_regression_test.rs
+++ b/tests/e2e/gas_limit_regression_test.rs
@@ -88,7 +88,7 @@ async fn test_pol_gas_limit_is_30_million() -> eyre::Result<()> {
 
     let mut ctx = NodeTestContext::new(node, berachain_payload_attributes_generator).await?;
 
-    println!("🚀 Testing PoL transaction with strict 30M gas limit validation...");
+    println!("Testing PoL transaction with strict 30M gas limit validation...");
 
     // Advance a block - this should create and execute a PoL transaction
     let payload = ctx.advance_block().await?;

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -17,6 +17,7 @@ use reth_ethereum_engine_primitives::EthPayloadAttributes;
 use reth_payload_primitives::PayloadBuilderAttributes;
 use std::{str::FromStr, sync::Arc};
 
+pub mod gas_limit_regression_test;
 pub mod transaction_tests;
 
 const TEST_PRIVATE_KEY: &str = "0xfffdbb37105441e14b0ee6330d855d8504ff39e705c3afa8f859ac9865f99306";

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -41,7 +41,7 @@ pub fn test_signer() -> eyre::Result<PrivateKeySigner> {
 }
 
 /// Create Berachain payload attributes for testing
-pub fn berachain_payload_attributes(timestamp: u64) -> BerachainPayloadBuilderAttributes {
+pub fn berachain_payload_attributes_generator(timestamp: u64) -> BerachainPayloadBuilderAttributes {
     let eth_attributes = EthPayloadAttributes {
         timestamp,
         prev_randao: B256::random(),

--- a/tests/e2e/transaction_tests.rs
+++ b/tests/e2e/transaction_tests.rs
@@ -1,6 +1,6 @@
 //! Transaction integration tests for RPC injection, mempool handling, and PoL transactions
 
-use crate::e2e::{berachain_payload_attributes, setup_test_boilerplate, test_signer};
+use crate::e2e::{berachain_payload_attributes_generator, setup_test_boilerplate, test_signer};
 use alloy_consensus::BlockHeader;
 use alloy_eips::eip7002::SYSTEM_ADDRESS;
 use alloy_primitives::{Address, ChainId};
@@ -34,7 +34,7 @@ async fn test_eip1559_transaction_via_rpc_is_accepted() -> eyre::Result<()> {
         .launch()
         .await?;
 
-    let mut ctx = NodeTestContext::new(node, berachain_payload_attributes).await?;
+    let mut ctx = NodeTestContext::new(node, berachain_payload_attributes_generator).await?;
     let signer = test_signer()?;
     let chain_id = chain_spec.chain_id();
 
@@ -115,7 +115,7 @@ async fn test_pol_transaction_rpc_injection_fails() -> eyre::Result<()> {
         .launch()
         .await?;
 
-    let ctx = NodeTestContext::new(node, berachain_payload_attributes).await?;
+    let ctx = NodeTestContext::new(node, berachain_payload_attributes_generator).await?;
     let chain_id = chain_spec.chain_id();
     let fake_pol_tx = create_fake_pol_tx(chain_id);
 
@@ -159,7 +159,7 @@ async fn test_pol_transaction_mempool_insertion_fails() -> eyre::Result<()> {
         .launch()
         .await?;
 
-    let ctx = NodeTestContext::new(node, berachain_payload_attributes).await?;
+    let ctx = NodeTestContext::new(node, berachain_payload_attributes_generator).await?;
     let chain_id = chain_spec.chain_id();
     let fake_pol_tx = create_fake_pol_tx(chain_id);
 
@@ -206,7 +206,7 @@ async fn test_pol_transaction_auto_inclusion() -> eyre::Result<()> {
         .launch()
         .await?;
 
-    let mut ctx = NodeTestContext::new(node, berachain_payload_attributes).await?;
+    let mut ctx = NodeTestContext::new(node, berachain_payload_attributes_generator).await?;
     let initial_block = ctx.rpc.inner.eth_api().provider().best_block_number()?;
 
     let payload = ctx.advance_block().await?;


### PR DESCRIPTION
## Summary

Adds a strict regression test to ensure REVM's 30M system call gas limit remains unchanged for PoL transactions. This addresses an audit concern about gas limit validation consistency.

The test:
- Deploys a custom PoL distributor contract that validates exactly 29,999,646 gas remains at execution time
- Fails if REVM's 30M system call limit changes or gas consumption patterns shift
- Provides early detection of breaking changes in gas handling

Closes https://github.com/berachain/bera-reth/issues/90
