### PR TITLE
chore: bump version to 1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1439,7 +1439,7 @@ checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
 name = "bera-reth"
-version = "1.0.0-rc.10"
+version = "1.0.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bera-reth"
-version = "1.0.0-rc.10"
+version = "1.0.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
     <img src="https://github.com/berachain/bera-reth/actions/workflows/ci.yml/badge.svg" alt="CI"/>
   </a>
   <a href="https://github.com/berachain/bera-reth">
-    <img src="https://img.shields.io/badge/status-in%20development-yellow.svg" alt="Status"/>
+    <img src="https://img.shields.io/badge/status-production-brightgreen" alt="Status"/>
   </a>
 </p>
 
@@ -16,8 +16,6 @@
 # Bera-Reth
 
 A high-performance Rust execution client for Berachain, built with the Reth SDK.
-
-> ⚠️ **Not ready for production**
 
 ## Getting Started
 


### PR DESCRIPTION
Bumps the crate version to v1.0.0 for the first stable production release.

## Changes
- Update version in `Cargo.toml` from `1.0.0-rc.10` to `1.0.0`
- Update README.md to remove development warnings and reflect production status
- Add production status badge

This marks bera-reth as production-ready and suitable for mainnet usage.

## Next Steps
1. Create and push git tag: `git tag v1.0.0 && git push origin v1.0.0`
2. Monitor release workflow in Actions
3. Review and publish the generated release