### PR TITLE
test: add gas limit regression test for 36M block limit

### DIFF
--- a/src/engine/builder.rs
+++ b/src/engine/builder.rs
@@ -383,3 +383,22 @@ where
 
     Ok(BuildOutcome::Better { payload, cached_reads })
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::test_utils::bepolia_chainspec;
+    use reth_chainspec::EthChainSpec;
+    use reth_node_core::{args::PayloadBuilderArgs, cli::config::PayloadBuilderConfig};
+
+    #[test]
+    fn test_berachain_uses_36m_gas_limit() {
+        let chain_spec = bepolia_chainspec();
+        let config = PayloadBuilderArgs::default();
+        let gas_limit = config.gas_limit_for(chain_spec.chain());
+
+        assert_eq!(
+            gas_limit, 36_000_000,
+            "Berachain must use default 36M gas limit from upstream Reth configuration"
+        );
+    }
+}


### PR DESCRIPTION
Adds unit test to verify Berachain uses the default 36,000,000 gas limit from upstream Reth configuration. This catches potential changes to gas limit behavior in future Reth updates.

Closes #85