### PR TITLE
feat: implement simulation API support with TryIntoSimTx

### DIFF
--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -15,7 +15,8 @@ use crate::{
     rpc::{BerachainAddOns, BerachainEthApiBuilder},
     transaction::BerachainTxEnvelope,
 };
-use alloy_consensus::error::ValueError;
+use alloy_consensus::{SignableTransaction, error::ValueError};
+use alloy_primitives::Signature;
 use alloy_rpc_types::TransactionRequest;
 use reth::{
     api::{BlockTy, FullNodeTypes, NodeTypes},
@@ -48,8 +49,11 @@ impl NodeTypes for BerachainNode {
 
 impl TryIntoSimTx<BerachainTxEnvelope> for TransactionRequest {
     fn try_into_sim_tx(self) -> Result<BerachainTxEnvelope, ValueError<Self>> {
-        // TODO: Add support for simulation API
-        Err(ValueError::new(self, "Simulation API is not supported on bera-reth yet"))
+        let tx = self
+            .build_typed_tx()
+            .map_err(|req| ValueError::new(req, "Transaction is not buildable"))?;
+        let signature = Signature::new(Default::default(), Default::default(), false);
+        Ok(tx.into_signed(signature).into())
     }
 }
 


### PR DESCRIPTION
Implements simulation API support by adding TryIntoSimTx for TransactionRequest, enabling the eth_simulateV1 RPC method.

## Changes
- Add TryIntoSimTx implementation for TransactionRequest in node/mod.rs
- Add From trait for converting Signed<EthereumTypedTransaction> to BerachainTxEnvelope
- Support all Ethereum transaction types (Legacy, EIP-2930, EIP-1559, EIP-4844, EIP-7702)

The implementation follows the same pattern as Reth's Optimism integration, using dummy signatures for simulation purposes.

Closes #75