### PR TITLE
fix: improve genesis parsing to handle missing berachain config gracefully

### DIFF
--- a/src/chainspec/mod.rs
+++ b/src/chainspec/mod.rs
@@ -212,11 +212,9 @@ impl BerachainChainSpec {
 impl From<Genesis> for BerachainChainSpec {
     /// Intentionally panics if required fields are missing from genesis or invalid.
     fn from(genesis: Genesis) -> Self {
-        let berachain_genesis_config = BerachainGenesisConfig::try_from(&genesis.config.extra_fields)
-            .unwrap_or_else(|e| {
-                panic!(
-                    "Failed to parse berachain genesis config: {e}. Please ensure the genesis file contains a valid 'berachain' configuration section"
-                );
+        let berachain_genesis_config =
+            BerachainGenesisConfig::try_from(&genesis.config.extra_fields).unwrap_or_else(|e| {
+                panic!("Failed to parse berachain genesis config: {e}. Please ensure the genesis file contains a valid 'berachain' configuration section");
             });
 
         // If not a berachain genesis, fallback to Ethereum behavior

--- a/src/chainspec/mod.rs
+++ b/src/chainspec/mod.rs
@@ -212,7 +212,7 @@ impl BerachainChainSpec {
 impl From<Genesis> for BerachainChainSpec {
     /// Intentionally panics if required fields are missing from genesis or invalid.
     fn from(genesis: Genesis) -> Self {
-        let berachain_genesis_config = BerachainGenesisConfig::from_genesis(&genesis.config.extra_fields)
+        let berachain_genesis_config = BerachainGenesisConfig::try_from(&genesis.config.extra_fields)
             .unwrap_or_else(|e| {
                 panic!(
                     "Failed to parse berachain genesis config: {e}. Please ensure the genesis file contains a valid 'berachain' configuration section"

--- a/src/chainspec/mod.rs
+++ b/src/chainspec/mod.rs
@@ -212,39 +212,21 @@ impl BerachainChainSpec {
 impl From<Genesis> for BerachainChainSpec {
     /// Intentionally panics if required fields are missing from genesis or invalid.
     fn from(genesis: Genesis) -> Self {
-        let berachain_genesis_config = match BerachainGenesisConfig::try_from(
-            &genesis.config.extra_fields,
-        ) {
-            Ok(config) => config,
-            Err(e) => {
-                use crate::genesis::BerachainConfigError;
-                match e {
-                    BerachainConfigError::MissingBerachainField => {
-                        tracing::warn!(
-                            "No berachain configuration found in genesis. Defaulting to Ethereum behaviour"
-                        );
-                        return Self::ethereum_fallback(genesis);
-                    }
-                    _ => {
-                        panic!(
-                            "Failed to parse berachain genesis config: {e}. Please ensure the genesis file contains a valid 'berachain' configuration section"
-                        );
-                    }
-                }
-            }
-        };
+        let berachain_genesis_config = BerachainGenesisConfig::from_genesis(&genesis.config.extra_fields)
+            .unwrap_or_else(|e| {
+                panic!(
+                    "Failed to parse berachain genesis config: {e}. Please ensure the genesis file contains a valid 'berachain' configuration section"
+                );
+            });
 
         // If not a berachain genesis, fallback to Ethereum behavior
         if !berachain_genesis_config.is_berachain() {
-            tracing::warn!(
-                "Prague1 not configured in berachain genesis. Defaulting to Ethereum behaviour"
-            );
             return Self::ethereum_fallback(genesis);
         }
 
         let prague1_config = berachain_genesis_config
             .prague1
-            .expect("Prague1 should be Some since is_prague1_enabled() was true");
+            .expect("Prague1 should be Some since is_berachain() was true");
 
         // Berachain networks must start with Cancun at genesis
         if genesis.config.cancun_time != Some(0) {

--- a/src/chainspec/mod.rs
+++ b/src/chainspec/mod.rs
@@ -195,13 +195,56 @@ impl ChainSpecParser for BerachainChainSpecParser {
     }
 }
 
+impl BerachainChainSpec {
+    /// Create a BerachainChainSpec that fallbacks to Ethereum behavior
+    fn ethereum_fallback(genesis: Genesis) -> Self {
+        let inner = ChainSpec::from(genesis);
+        let genesis_header = BerachainHeader::from(inner.genesis_header());
+        Self {
+            inner,
+            genesis_header,
+            pol_contract_address: Address::ZERO,
+            prague1_minimum_base_fee: 0,
+        }
+    }
+}
+
 impl From<Genesis> for BerachainChainSpec {
     /// Intentionally panics if required fields are missing from genesis or invalid.
     fn from(genesis: Genesis) -> Self {
-        let berachain_genesis_config =
-            BerachainGenesisConfig::try_from(&genesis.config.extra_fields).unwrap_or_else(|e| {
-                panic!("Failed to parse berachain genesis config: {e}. Please ensure the genesis file contains a valid 'berachain' configuration section with Prague1 settings");
-            });
+        let berachain_genesis_config = match BerachainGenesisConfig::try_from(
+            &genesis.config.extra_fields,
+        ) {
+            Ok(config) => config,
+            Err(e) => {
+                use crate::genesis::BerachainConfigError;
+                match e {
+                    BerachainConfigError::MissingBerachainField => {
+                        tracing::warn!(
+                            "No berachain configuration found in genesis. Defaulting to Ethereum behaviour"
+                        );
+                        return Self::ethereum_fallback(genesis);
+                    }
+                    _ => {
+                        panic!(
+                            "Failed to parse berachain genesis config: {e}. Please ensure the genesis file contains a valid 'berachain' configuration section"
+                        );
+                    }
+                }
+            }
+        };
+
+        // If Prague1 is not configured, fallback to Ethereum behavior
+        if !berachain_genesis_config.is_prague1_configured() {
+            tracing::warn!(
+                "Prague1 not configured in berachain genesis. Defaulting to Ethereum behaviour"
+            );
+            return Self::ethereum_fallback(genesis);
+        }
+
+        let prague1_config = berachain_genesis_config
+            .prague1
+            .expect("Prague1 should be Some since is_prague1_enabled() was true");
 
         // Berachain networks must start with Cancun at genesis
         if genesis.config.cancun_time != Some(0) {
@@ -251,8 +294,8 @@ impl From<Genesis> for BerachainChainSpec {
         }
 
         // Validate Prague1 comes after Prague if both are configured
-        match (genesis.config.prague_time, berachain_genesis_config.prague1.time) {
-            (Some(prague_time), prague1_time) if prague1_time < prague_time => {
+        match (genesis.config.prague_time, Some(prague1_config.time)) {
+            (Some(prague_time), Some(prague1_time)) if prague1_time < prague_time => {
                 panic!(
                     "Prague1 hardfork must activate at or after Prague hardfork. Prague time: {prague_time}, Prague1 time: {prague1_time}. Check that Prague1 time is not malformed (should be a valid Unix timestamp).",
                 );
@@ -308,7 +351,7 @@ impl From<Genesis> for BerachainChainSpec {
 
         hardforks.push((
             BerachainHardfork::Prague1.boxed(),
-            ForkCondition::Timestamp(berachain_genesis_config.prague1.time),
+            ForkCondition::Timestamp(prague1_config.time),
         ));
 
         if let Some(osaka_time) = genesis.config.osaka_time {
@@ -337,12 +380,10 @@ impl From<Genesis> for BerachainChainSpec {
         let hardforks = ChainHardforks::new(hardforks);
 
         // Create base fee parameters based on Prague1 configuration
-        let base_fee_params = if berachain_genesis_config.prague1.time == 0 {
+        let base_fee_params = if prague1_config.time == 0 {
             // Prague1 active at genesis - use constant params with Berachain's denominator
             BaseFeeParamsKind::Constant(BaseFeeParams {
-                max_change_denominator: berachain_genesis_config
-                    .prague1
-                    .base_fee_change_denominator,
+                max_change_denominator: prague1_config.base_fee_change_denominator,
                 elasticity_multiplier: 2, // Standard Ethereum value
             })
         } else {
@@ -360,9 +401,7 @@ impl From<Genesis> for BerachainChainSpec {
                 (
                     BerachainHardfork::Prague1.boxed(),
                     BaseFeeParams {
-                        max_change_denominator: berachain_genesis_config
-                            .prague1
-                            .base_fee_change_denominator,
+                        max_change_denominator: prague1_config.base_fee_change_denominator,
                         elasticity_multiplier: 2,
                     },
                 ),
@@ -385,15 +424,15 @@ impl From<Genesis> for BerachainChainSpec {
         let mut genesis_header = BerachainHeader::from(inner.genesis_header());
 
         // Set prev_proposer_pubkey to zero if Prague1 is active at genesis timestamp
-        let is_prague1_at_genesis = berachain_genesis_config.prague1.time <= genesis.timestamp;
+        let is_prague1_at_genesis = prague1_config.time <= genesis.timestamp;
         if is_prague1_at_genesis {
             genesis_header.prev_proposer_pubkey = Some(BlsPublicKey::ZERO);
         }
         Self {
             inner,
             genesis_header,
-            pol_contract_address: berachain_genesis_config.prague1.pol_distributor_address,
-            prague1_minimum_base_fee: berachain_genesis_config.prague1.minimum_base_fee_wei,
+            pol_contract_address: prague1_config.pol_distributor_address,
+            prague1_minimum_base_fee: prague1_config.minimum_base_fee_wei,
         }
     }
 }
@@ -583,16 +622,19 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Failed to parse berachain genesis config")]
     fn test_base_fee_params_missing_berachain_config() {
-        // Test panic when berachain config is missing
+        // Test fallback to Ethereum behavior when berachain config is missing
         let mut genesis = Genesis::default();
         genesis.config.london_block = Some(0);
         genesis.config.cancun_time = Some(0); // Required for Berachain
         genesis.config.terminal_total_difficulty = Some(U256::ZERO); // Required for Berachain
-        // No berachain config in extra_fields - should panic
+        // No berachain config in extra_fields - should fallback to Ethereum behavior
 
-        let _chain_spec = BerachainChainSpec::from(genesis);
+        let chain_spec = BerachainChainSpec::from(genesis);
+
+        // Should have default values for Berachain-specific fields
+        assert_eq!(chain_spec.pol_contract_address, Address::ZERO);
+        assert_eq!(chain_spec.prague1_minimum_base_fee, 0);
     }
 
     #[test]
@@ -961,5 +1003,115 @@ mod tests {
 
         let result = chain_spec.next_block_base_fee(&parent_header, 0);
         assert!(result.is_none()); // Correctly returns None when parent has no base fee
+    }
+
+    #[test]
+    fn test_prague1_not_enabled_empty_berachain() {
+        // Prague1 not enabled - berachain present but empty (no prague1)
+        let mut genesis = Genesis::default();
+        genesis.config.cancun_time = Some(0);
+        genesis.config.terminal_total_difficulty = Some(U256::ZERO);
+        let extra_fields_json = json!({
+            "berachain": {}
+        });
+        genesis.config.extra_fields =
+            reth::rpc::types::serde_helpers::OtherFields::try_from(extra_fields_json).unwrap();
+
+        let chain_spec = BerachainChainSpec::from(genesis);
+
+        // Should fallback to Ethereum behavior
+        assert_eq!(chain_spec.pol_contract_address, Address::ZERO);
+        assert_eq!(chain_spec.prague1_minimum_base_fee, 0);
+    }
+
+    #[test]
+    fn test_prague1_empty_should_panic() {
+        // Prague1 present but empty - should panic
+        let mut genesis = Genesis::default();
+        genesis.config.cancun_time = Some(0);
+        genesis.config.terminal_total_difficulty = Some(U256::ZERO);
+        let extra_fields_json = json!({
+            "berachain": {
+                "prague1": {}
+            }
+        });
+        genesis.config.extra_fields =
+            reth::rpc::types::serde_helpers::OtherFields::try_from(extra_fields_json).unwrap();
+
+        // This should panic because prague1 is present but empty/misconfigured
+        std::panic::catch_unwind(|| {
+            let _chain_spec = BerachainChainSpec::from(genesis);
+        })
+        .expect_err("Should panic when prague1 is present but empty");
+    }
+
+    #[test]
+    fn test_prague1_missing_fields_should_panic() {
+        // Prague1 present but missing required fields - should panic
+        let mut genesis = Genesis::default();
+        genesis.config.cancun_time = Some(0);
+        genesis.config.terminal_total_difficulty = Some(U256::ZERO);
+        let extra_fields_json = json!({
+            "berachain": {
+                "prague1": {
+                    "time": 0,
+                    "baseFeeChangeDenominator": 48,
+                    "minimumBaseFeeWei": 1000000000
+                    // Missing polDistributorAddress - should panic
+                }
+            }
+        });
+        genesis.config.extra_fields =
+            reth::rpc::types::serde_helpers::OtherFields::try_from(extra_fields_json).unwrap();
+
+        // This should panic because prague1 is present but misconfigured
+        std::panic::catch_unwind(|| {
+            let _chain_spec = BerachainChainSpec::from(genesis);
+        })
+        .expect_err("Should panic when prague1 is misconfigured");
+    }
+
+    #[test]
+    fn test_prague1_not_enabled_no_berachain_field() {
+        // Prague1 not enabled - no berachain field at all (already covered by existing test)
+        let mut genesis = Genesis::default();
+        genesis.config.cancun_time = Some(0);
+        genesis.config.terminal_total_difficulty = Some(U256::ZERO);
+        // No berachain config in extra_fields
+
+        let chain_spec = BerachainChainSpec::from(genesis);
+
+        // Should fallback to Ethereum behavior
+        assert_eq!(chain_spec.pol_contract_address, Address::ZERO);
+        assert_eq!(chain_spec.prague1_minimum_base_fee, 0);
+    }
+
+    #[test]
+    fn test_prague1_enabled_at_genesis_valid_config() {
+        // Prague1 enabled at genesis with valid configuration
+        let mut genesis = Genesis::default();
+        genesis.config.cancun_time = Some(0);
+        genesis.config.terminal_total_difficulty = Some(U256::ZERO);
+        let extra_fields_json = json!({
+            "berachain": {
+                "prague1": {
+                    "time": 0,
+                    "baseFeeChangeDenominator": 48,
+                    "minimumBaseFeeWei": 10000000000u64,
+                    "polDistributorAddress": "0x4200000000000000000000000000000000000042"
+                }
+            }
+        });
+        genesis.config.extra_fields =
+            reth::rpc::types::serde_helpers::OtherFields::try_from(extra_fields_json).unwrap();
+
+        let chain_spec = BerachainChainSpec::from(genesis);
+
+        // Should use Berachain configuration
+        assert_eq!(
+            chain_spec.pol_contract_address,
+            "0x4200000000000000000000000000000000000042".parse::<Address>().unwrap()
+        );
+        assert_eq!(chain_spec.prague1_minimum_base_fee, 10000000000);
     }
 }

--- a/src/chainspec/mod.rs
+++ b/src/chainspec/mod.rs
@@ -1098,4 +1098,25 @@ mod tests {
         );
         assert_eq!(chain_spec.prague1_minimum_base_fee, 10000000000);
     }
+
+    #[test]
+    fn test_bepolia_fixture() {
+        let bepolia_path =
+            concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/bepolia-genesis.json");
+        let bepolia_json = std::fs::read_to_string(bepolia_path).unwrap();
+        let genesis: Genesis = serde_json::from_str(&bepolia_json).unwrap();
+        let chain_spec = BerachainChainSpec::from(genesis);
+
+        // Verify Berachain-specific configuration from bepolia fixture
+        assert_eq!(
+            chain_spec.pol_contract_address,
+            address!("D2f19a79b026Fb636A7c300bF5947df113940761")
+        );
+        assert_eq!(chain_spec.prague1_minimum_base_fee, 10_000_000_000); // 10 gwei
+        assert_eq!(chain_spec.inner.chain.id(), 80069); // bepolia chain id
+
+        // Prague1 should be active after timestamp 1754496000
+        assert!(!chain_spec.is_prague1_active_at_timestamp(1754495999));
+        assert!(chain_spec.is_prague1_active_at_timestamp(1754496000));
+    }
 }

--- a/src/chainspec/mod.rs
+++ b/src/chainspec/mod.rs
@@ -274,8 +274,8 @@ impl From<Genesis> for BerachainChainSpec {
         }
 
         // Validate Prague1 comes after Prague if both are configured
-        match (genesis.config.prague_time, Some(prague1_config.time)) {
-            (Some(prague_time), Some(prague1_time)) if prague1_time < prague_time => {
+        match (genesis.config.prague_time, prague1_config.time) {
+            (Some(prague_time), prague1_time) if prague1_time < prague_time => {
                 panic!(
                     "Prague1 hardfork must activate at or after Prague hardfork. Prague time: {prague_time}, Prague1 time: {prague1_time}. Check that Prague1 time is not malformed (should be a valid Unix timestamp).",
                 );

--- a/src/chainspec/mod.rs
+++ b/src/chainspec/mod.rs
@@ -234,8 +234,8 @@ impl From<Genesis> for BerachainChainSpec {
             }
         };
 
-        // If Prague1 is not configured, fallback to Ethereum behavior
-        if !berachain_genesis_config.is_prague1_configured() {
+        // If not a berachain genesis, fallback to Ethereum behavior
+        if !berachain_genesis_config.is_berachain() {
             tracing::warn!(
                 "Prague1 not configured in berachain genesis. Defaulting to Ethereum behaviour"
             );

--- a/src/chainspec/mod.rs
+++ b/src/chainspec/mod.rs
@@ -423,14 +423,12 @@ impl From<Genesis> for BerachainChainSpec {
 mod tests {
     use super::*;
     use alloy_genesis::Genesis;
+    use alloy_primitives::address;
     use jsonrpsee_core::__reexports::serde_json::json;
 
     #[test]
-    fn test_chain_spec_default() {
+    fn test_deposit_contract_default_regression() {
         let chain_spec = BerachainChainSpec::default();
-
-        // Test that default creates a valid chain spec
-        assert_eq!(chain_spec.prune_delete_limit(), 20000);
         assert!(chain_spec.deposit_contract().is_none());
     }
 
@@ -617,6 +615,8 @@ mod tests {
         // Should have default values for Berachain-specific fields
         assert_eq!(chain_spec.pol_contract_address, Address::ZERO);
         assert_eq!(chain_spec.prague1_minimum_base_fee, 0);
+        assert!(!chain_spec.is_prague1_active_at_timestamp(0));
+        assert!(!chain_spec.is_prague1_active_at_timestamp(u64::MAX));
     }
 
     #[test]
@@ -1004,6 +1004,7 @@ mod tests {
         // Should fallback to Ethereum behavior
         assert_eq!(chain_spec.pol_contract_address, Address::ZERO);
         assert_eq!(chain_spec.prague1_minimum_base_fee, 0);
+        assert!(!chain_spec.is_prague1_active_at_timestamp(u64::MAX));
     }
 
     #[test]
@@ -1066,6 +1067,7 @@ mod tests {
         // Should fallback to Ethereum behavior
         assert_eq!(chain_spec.pol_contract_address, Address::ZERO);
         assert_eq!(chain_spec.prague1_minimum_base_fee, 0);
+        assert!(!chain_spec.is_prague1_active_at_timestamp(u64::MAX));
     }
 
     #[test]
@@ -1092,7 +1094,7 @@ mod tests {
         // Should use Berachain configuration
         assert_eq!(
             chain_spec.pol_contract_address,
-            "0x4200000000000000000000000000000000000042".parse::<Address>().unwrap()
+            address!("0x4200000000000000000000000000000000000042")
         );
         assert_eq!(chain_spec.prague1_minimum_base_fee, 10000000000);
     }

--- a/src/genesis/mod.rs
+++ b/src/genesis/mod.rs
@@ -11,10 +11,6 @@ use thiserror::Error;
 /// Errors for Berachain genesis configuration parsing
 #[derive(Debug, Error)]
 pub enum BerachainConfigError {
-    /// The required 'berachain' field is missing from the genesis configuration
-    #[error("Missing required 'berachain' field in genesis configuration")]
-    MissingBerachainField,
-
     /// Invalid configuration format or values
     #[error("Invalid berachain configuration: {0}")]
     InvalidConfig(#[from] serde_json::Error),
@@ -71,47 +67,6 @@ impl BerachainGenesisConfig {
     }
 }
 
-impl BerachainGenesisConfig {
-    /// Parse BerachainGenesisConfig from genesis
-    pub fn from_genesis(others: &OtherFields) -> Result<Self, BerachainConfigError> {
-        use tracing::info;
-
-        match others.get_deserialized::<Self>("berachain") {
-            Some(Ok(cfg)) => {
-                // If prague1 is configured, validate it fully
-                if let Some(prague1_config) = cfg.prague1 {
-                    if prague1_config.base_fee_change_denominator == 0 {
-                        return Err(BerachainConfigError::InvalidDenominator);
-                    }
-                    if prague1_config.pol_distributor_address.is_zero() {
-                        return Err(BerachainConfigError::MissingPoLDistributorAddress);
-                    }
-
-                    info!(
-                        "Loaded Berachain genesis configuration: Prague1 enabled at time={}, base_fee_denominator={}, min_base_fee={} gwei, pol_distributor={}",
-                        prague1_config.time,
-                        prague1_config.base_fee_change_denominator,
-                        prague1_config.minimum_base_fee_wei / 1_000_000_000,
-                        prague1_config.pol_distributor_address
-                    );
-                } else {
-                    info!(
-                        "Loaded Berachain genesis configuration: Prague1 not configured, defaulting to Ethereum behavior"
-                    );
-                }
-
-                Ok(cfg)
-            }
-            Some(Err(e)) => Err(BerachainConfigError::InvalidConfig(e)),
-            None => {
-                // No berachain field - return a config that indicates it's not a berachain genesis
-                info!("No berachain configuration found, defaulting to Ethereum behavior");
-                Ok(Self { prague1: None })
-            }
-        }
-    }
-}
-
 impl TryFrom<&OtherFields> for BerachainGenesisConfig {
     type Error = BerachainConfigError;
 
@@ -146,7 +101,7 @@ impl TryFrom<&OtherFields> for BerachainGenesisConfig {
                 Ok(cfg)
             }
             Some(Err(e)) => Err(BerachainConfigError::InvalidConfig(e)),
-            None => Err(BerachainConfigError::MissingBerachainField),
+            None => Ok(Self { prague1: None }),
         }
     }
 }
@@ -166,7 +121,7 @@ mod tests {
 
         let v: Value = serde_json::from_str(json).unwrap();
         let other_fields = OtherFields::try_from(v).expect("must be a valid genesis config");
-        let cfg = BerachainGenesisConfig::from_genesis(&other_fields).expect("should succeed");
+        let cfg = BerachainGenesisConfig::try_from(&other_fields).expect("should succeed");
 
         // Should return a config that indicates it's not a berachain genesis
         assert_eq!(cfg.prague1, None);
@@ -231,7 +186,7 @@ mod tests {
         let v: Value = serde_json::from_str(json).unwrap();
         let other_fields = OtherFields::try_from(v).expect("must be a valid genesis config");
 
-        let cfg = BerachainGenesisConfig::from_genesis(&other_fields).expect("should succeed");
+        let cfg = BerachainGenesisConfig::try_from(&other_fields).expect("should succeed");
 
         // Prague1 should not be configured
         assert_eq!(cfg.prague1, None);
@@ -239,8 +194,8 @@ mod tests {
     }
 
     #[test]
-    fn test_genesis_config_from_genesis_error_handling() {
-        // Test that from_genesis returns errors instead of panicking
+    fn test_genesis_config_try_from_error_handling() {
+        // Test that try_from returns errors instead of panicking
         let json = r#"
         {
           "berachain": {
@@ -256,7 +211,7 @@ mod tests {
         let v: Value = serde_json::from_str(json).unwrap();
         let other_fields = OtherFields::try_from(v).expect("must be a valid genesis config");
 
-        let result = BerachainGenesisConfig::from_genesis(&other_fields);
+        let result = BerachainGenesisConfig::try_from(&other_fields);
         assert!(result.is_err());
         assert!(
             result.unwrap_err().to_string().contains("Base fee change denominator cannot be zero")

--- a/src/genesis/mod.rs
+++ b/src/genesis/mod.rs
@@ -173,6 +173,10 @@ mod tests {
         assert_eq!(prague1_config.time, 1620000000);
         assert_eq!(prague1_config.minimum_base_fee_wei, 1000000000);
         assert_eq!(prague1_config.base_fee_change_denominator, 48);
+        assert_eq!(
+            prague1_config.pol_distributor_address,
+            address!("4200000000000000000000000000000000000042")
+        );
     }
 
     #[test]

--- a/src/genesis/mod.rs
+++ b/src/genesis/mod.rs
@@ -65,8 +65,8 @@ impl Default for BerachainGenesisConfig {
 }
 
 impl BerachainGenesisConfig {
-    /// Returns true if Prague1 fork is configured and enabled
-    pub fn is_prague1_configured(&self) -> bool {
+    /// Returns true if it's a berachain genesis
+    pub fn is_berachain(&self) -> bool {
         self.prague1.is_some()
     }
 }
@@ -195,7 +195,7 @@ mod tests {
 
         // Prague1 should not be configured
         assert_eq!(cfg.prague1, None);
-        assert!(!cfg.is_prague1_configured());
+        assert!(!cfg.is_berachain());
     }
 
     #[test]

--- a/src/genesis/mod.rs
+++ b/src/genesis/mod.rs
@@ -47,25 +47,27 @@ pub struct BerachainForkConfig {
 #[serde(rename_all = "camelCase")]
 pub struct BerachainGenesisConfig {
     /// Configuration for the Prague1 hardfork, which introduces minimum base fee enforcement
-    pub prague1: BerachainForkConfig,
-}
-
-/// Default PoL contract address
-fn default_pol_contract_address() -> Address {
-    address!("4200000000000000000000000000000000000042")
+    pub prague1: Option<BerachainForkConfig>,
 }
 
 impl Default for BerachainGenesisConfig {
     /// Default config with Prague1 activated immediately at genesis
     fn default() -> Self {
         Self {
-            prague1: BerachainForkConfig {
+            prague1: Some(BerachainForkConfig {
                 time: 0,                             // Activate immediately at genesis
                 base_fee_change_denominator: 48,     // Berachain standard value
                 minimum_base_fee_wei: 1_000_000_000, // 1 gwei
-                pol_distributor_address: default_pol_contract_address(),
-            },
+                pol_distributor_address: address!("4200000000000000000000000000000000000042"),
+            }),
         }
+    }
+}
+
+impl BerachainGenesisConfig {
+    /// Returns true if Prague1 fork is configured and enabled
+    pub fn is_prague1_configured(&self) -> bool {
+        self.prague1.is_some()
     }
 }
 
@@ -78,21 +80,27 @@ impl TryFrom<&OtherFields> for BerachainGenesisConfig {
 
         match others.get_deserialized::<Self>("berachain") {
             Some(Ok(cfg)) => {
-                // Validate the parsed configuration
-                if cfg.prague1.base_fee_change_denominator == 0 {
-                    return Err(BerachainConfigError::InvalidDenominator);
-                }
-                if cfg.prague1.pol_distributor_address.is_zero() {
-                    return Err(BerachainConfigError::MissingPoLDistributorAddress);
-                }
+                // If prague1 is configured, validate it fully
+                if let Some(prague1_config) = cfg.prague1 {
+                    if prague1_config.base_fee_change_denominator == 0 {
+                        return Err(BerachainConfigError::InvalidDenominator);
+                    }
+                    if prague1_config.pol_distributor_address.is_zero() {
+                        return Err(BerachainConfigError::MissingPoLDistributorAddress);
+                    }
 
-                info!(
-                    "Loaded Berachain genesis configuration: Prague1 time={}, base_fee_denominator={}, min_base_fee={} gwei, pol_distributor={}",
-                    cfg.prague1.time,
-                    cfg.prague1.base_fee_change_denominator,
-                    cfg.prague1.minimum_base_fee_wei / 1_000_000_000,
-                    cfg.prague1.pol_distributor_address
-                );
+                    info!(
+                        "Loaded Berachain genesis configuration: Prague1 enabled at time={}, base_fee_denominator={}, min_base_fee={} gwei, pol_distributor={}",
+                        prague1_config.time,
+                        prague1_config.base_fee_change_denominator,
+                        prague1_config.minimum_base_fee_wei / 1_000_000_000,
+                        prague1_config.pol_distributor_address
+                    );
+                } else {
+                    info!(
+                        "Loaded Berachain genesis configuration: Prague1 not configured, defaulting to Ethereum behavior"
+                    );
+                }
 
                 Ok(cfg)
             }
@@ -166,9 +174,28 @@ mod tests {
         let cfg = BerachainGenesisConfig::try_from(&other_fields)
             .expect("berachain field must deserialize");
 
-        assert_eq!(cfg.prague1.time, 1620000000);
-        assert_eq!(cfg.prague1.minimum_base_fee_wei, 1000000000);
-        assert_eq!(cfg.prague1.base_fee_change_denominator, 48);
+        let prague1_config = cfg.prague1.expect("Prague1 should be configured");
+        assert_eq!(prague1_config.time, 1620000000);
+        assert_eq!(prague1_config.minimum_base_fee_wei, 1000000000);
+        assert_eq!(prague1_config.base_fee_change_denominator, 48);
+    }
+
+    #[test]
+    fn test_genesis_config_berachain_present_no_prague1() {
+        // Berachain field present but no prague1 -> should be valid with prague1 = None
+        let json = r#"
+        {
+          "berachain": {}
+        }
+        "#;
+        let v: Value = serde_json::from_str(json).unwrap();
+        let other_fields = OtherFields::try_from(v).expect("must be a valid genesis config");
+
+        let cfg = BerachainGenesisConfig::try_from(&other_fields).expect("should be valid");
+
+        // Prague1 should not be configured
+        assert_eq!(cfg.prague1, None);
+        assert!(!cfg.is_prague1_configured());
     }
 
     #[test]

--- a/src/genesis/mod.rs
+++ b/src/genesis/mod.rs
@@ -71,6 +71,47 @@ impl BerachainGenesisConfig {
     }
 }
 
+impl BerachainGenesisConfig {
+    /// Parse BerachainGenesisConfig from genesis
+    pub fn from_genesis(others: &OtherFields) -> Result<Self, BerachainConfigError> {
+        use tracing::info;
+
+        match others.get_deserialized::<Self>("berachain") {
+            Some(Ok(cfg)) => {
+                // If prague1 is configured, validate it fully
+                if let Some(prague1_config) = cfg.prague1 {
+                    if prague1_config.base_fee_change_denominator == 0 {
+                        return Err(BerachainConfigError::InvalidDenominator);
+                    }
+                    if prague1_config.pol_distributor_address.is_zero() {
+                        return Err(BerachainConfigError::MissingPoLDistributorAddress);
+                    }
+
+                    info!(
+                        "Loaded Berachain genesis configuration: Prague1 enabled at time={}, base_fee_denominator={}, min_base_fee={} gwei, pol_distributor={}",
+                        prague1_config.time,
+                        prague1_config.base_fee_change_denominator,
+                        prague1_config.minimum_base_fee_wei / 1_000_000_000,
+                        prague1_config.pol_distributor_address
+                    );
+                } else {
+                    info!(
+                        "Loaded Berachain genesis configuration: Prague1 not configured, defaulting to Ethereum behavior"
+                    );
+                }
+
+                Ok(cfg)
+            }
+            Some(Err(e)) => Err(BerachainConfigError::InvalidConfig(e)),
+            None => {
+                // No berachain field - return a config that indicates it's not a berachain genesis
+                info!("No berachain configuration found, defaulting to Ethereum behavior");
+                Ok(Self { prague1: None })
+            }
+        }
+    }
+}
+
 impl TryFrom<&OtherFields> for BerachainGenesisConfig {
     type Error = BerachainConfigError;
 
@@ -125,12 +166,11 @@ mod tests {
 
         let v: Value = serde_json::from_str(json).unwrap();
         let other_fields = OtherFields::try_from(v).expect("must be a valid genesis config");
-        let res = BerachainGenesisConfig::try_from(&other_fields);
-        assert!(
-            res.expect_err("must be an error")
-                .to_string()
-                .contains("Missing required 'berachain' field")
-        );
+        let cfg = BerachainGenesisConfig::from_genesis(&other_fields).expect("should succeed");
+
+        // Should return a config that indicates it's not a berachain genesis
+        assert_eq!(cfg.prague1, None);
+        assert!(!cfg.is_berachain());
     }
 
     #[test]
@@ -191,11 +231,36 @@ mod tests {
         let v: Value = serde_json::from_str(json).unwrap();
         let other_fields = OtherFields::try_from(v).expect("must be a valid genesis config");
 
-        let cfg = BerachainGenesisConfig::try_from(&other_fields).expect("should be valid");
+        let cfg = BerachainGenesisConfig::from_genesis(&other_fields).expect("should succeed");
 
         // Prague1 should not be configured
         assert_eq!(cfg.prague1, None);
         assert!(!cfg.is_berachain());
+    }
+
+    #[test]
+    fn test_genesis_config_from_genesis_error_handling() {
+        // Test that from_genesis returns errors instead of panicking
+        let json = r#"
+        {
+          "berachain": {
+            "prague1": {
+                "time": 0,
+                "baseFeeChangeDenominator": 0,
+                "minimumBaseFeeWei": 1000000000,
+                "polDistributorAddress": "0x4200000000000000000000000000000000000042"
+            }
+          }
+        }
+        "#;
+        let v: Value = serde_json::from_str(json).unwrap();
+        let other_fields = OtherFields::try_from(v).expect("must be a valid genesis config");
+
+        let result = BerachainGenesisConfig::from_genesis(&other_fields);
+        assert!(result.is_err());
+        assert!(
+            result.unwrap_err().to_string().contains("Base fee change denominator cannot be zero")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- No berachain field → fallback to Ethereum behavior  
- berachain present but no prague1 → fallback to Ethereum behavior
- berachain and prague1 present → validate fully, panic if misconfigured


Closes #99