### PR TITLE
perf: parallelize Docker multi-arch builds using native runners

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -19,7 +19,7 @@ env:
   DOCKER_USERNAME: ${{ github.actor }}
 
 jobs:
-  docker-build:
+  docker-build-amd64:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -33,8 +33,29 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ env.DOCKER_USERNAME }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push AMD64 Docker image
+        run: DOCKER_IMAGE_NAME=${{ env.DOCKER_IMAGE_NAME }} PROFILE=${{ inputs.profile }} make docker-build-push-amd64
+
+  docker-build-arm64:
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v5
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -43,5 +64,33 @@ jobs:
           username: ${{ env.DOCKER_USERNAME }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push Docker image
-        run: DOCKER_IMAGE_NAME=${{ env.DOCKER_IMAGE_NAME }} PROFILE=${{ inputs.profile }} make ${{ inputs.make-target }}
+      - name: Build and push ARM64 Docker image
+        run: DOCKER_IMAGE_NAME=${{ env.DOCKER_IMAGE_NAME }} PROFILE=${{ inputs.profile }} make docker-build-push-arm64
+
+  docker-manifest:
+    needs: [docker-build-amd64, docker-build-arm64]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v5
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ env.DOCKER_USERNAME }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and push manifest
+        run: |
+          if [[ "${{ inputs.make-target }}" == *"latest"* ]]; then
+            DOCKER_IMAGE_NAME=${{ env.DOCKER_IMAGE_NAME }} make docker-manifest-create-latest
+          else
+            DOCKER_IMAGE_NAME=${{ env.DOCKER_IMAGE_NAME }} make docker-manifest-create
+          fi


### PR DESCRIPTION
Split the single Docker build job into parallel architecture-specific jobs to eliminate QEMU emulation bottleneck.

The AMD64 build runs on standard Ubuntu runners while ARM64 builds use native ARM runners, which should reduce total build time considerably.

Added corresponding Makefile targets for building individual architectures and creating multi-arch manifests, allowing the workflow to build both architectures simultaneously before combining them into a single manifest.