### PR TITLE
test: add nightly sync tests for mainnet and bepolia

### DIFF
--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -2,8 +2,8 @@ name: Docker Nightly
 
 on:
   schedule:
-    # Run at 1:00 AM and 1:00 PM UTC every day (every 12 hours)
-    - cron: "0 1,13 * * *"
+    # Run at 1:00 AM UTC every day (every 24 hours)
+    - cron: "0 1 * * *"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -5,8 +5,8 @@ name: hive
 on:
   workflow_dispatch:
   schedule:
-    # Run 5 hours after nightly builds (1 AM + 5 hours = 6 AM, 1 PM + 5 hours = 6 PM UTC)
-    - cron: "0 6,18 * * *"
+    # Run at 1:00 AM UTC every day (same time as nightly builds)
+    - cron: "0 1 * * *"
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -53,8 +53,8 @@ jobs:
         run: cargo build --profile maxperf
       - name: Run etherscan sync
         run: |
-          # Convert peers file to comma-separated string
-          TRUSTED_PEERS=$(cat el-peers.txt | tr '\n' ',' | sed 's/,$//')
+          TRUSTED_PEERS=$(cat el-peers.txt)
+          echo "Using trusted peers: $TRUSTED_PEERS"
           ./target/maxperf/bera-reth node \
             --chain ./eth-genesis.json \
             --datadir ./tmp \

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -16,13 +16,28 @@ concurrency:
 
 jobs:
   sync:
-    name: sync (etherscan)
+    name: sync (${{ matrix.network.name }})
     runs-on: ubuntu-latest-large
     env:
       RUST_LOG: info,sync=error
       RUST_BACKTRACE: 1
       BERASCAN_API_KEY: ${{ secrets.BERASCAN_API_KEY }}
     timeout-minutes: 720
+    strategy:
+      matrix:
+        network:
+          - name: berachain
+            chain_id: 80094
+            genesis_url: https://raw.githubusercontent.com/berachain/beacon-kit/main/testing/networks/80094/eth-genesis.json
+            peers_url: https://raw.githubusercontent.com/berachain/beacon-kit/main/testing/networks/80094/el-peers.txt
+            etherscan_url: https://api.etherscan.io/v2/api?chainid=80094
+            max_block: 9000000
+          - name: berachain-bepolia
+            chain_id: 80069
+            genesis_url: https://raw.githubusercontent.com/berachain/beacon-kit/main/testing/networks/80069/eth-genesis.json
+            peers_url: https://raw.githubusercontent.com/berachain/beacon-kit/main/testing/networks/80069/el-peers.txt
+            etherscan_url: https://api.etherscan.io/v2/api?chainid=80069
+            max_block: 1000000
     steps:
       - uses: actions/checkout@v4
       - uses: rui314/setup-mold@v1
@@ -30,29 +45,34 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
-      - name: Download genesis file
+      - name: Download genesis file and trusted peers
         run: |
-          curl -o eth-genesis.json https://raw.githubusercontent.com/berachain/beacon-kit/main/testing/networks/80094/eth-genesis.json
+          curl -o eth-genesis.json ${{ matrix.network.genesis_url }}
+          curl -o el-peers.txt ${{ matrix.network.peers_url }}
       - name: Build bera-reth
         run: cargo build --profile maxperf
       - name: Run etherscan sync
         run: |
+          # Convert peers file to comma-separated string
+          TRUSTED_PEERS=$(cat el-peers.txt | tr '\n' ',' | sed 's/,$//')
           ./target/maxperf/bera-reth node \
             --chain ./eth-genesis.json \
             --datadir ./tmp \
-            --debug.etherscan "https://api.etherscan.io/v2/api?chainid=80094&apikey=$BERASCAN_API_KEY" \
+            --debug.etherscan "${{ matrix.network.etherscan_url }}&apikey=$BERASCAN_API_KEY" \
+            --debug.max-block ${{ matrix.network.max_block }} \
             --debug.terminate \
-            --trusted-peers "enode://0c5a4a3c0e81fce2974e4d317d88df783731183d534325e32e0fdf8f4b119d7889fa254d3a38890606ec300d744e2aa9c87099a4a032f5c94efe53f3fcdfecfe@34.22.104.177:30303,enode://b6a3137d3a36ef37c4d31843775a9dc293f41bcbde33b6309c80b1771b6634827cd188285136a57474427bd8845adc2f6fe2e0b106bd58d14795b08910b9c326@34.64.247.85:30303,enode://0b6633300614bc2b9749aee0cace7a091ec5348762aee7b1d195f7616d03a9409019d9bef336624bab72e0d069cd4cf0b0de6fbbf53f04f6b6e4c5b39c6bdca6@34.22.73.21:30303,enode://552b001abebb5805fcd734ad367cd05d9078d18f23ec598d7165460fadcfc51116ad95c418f7ea9a141aa8cbc496c8bea3322b67a5de0d3380f11aab1a797513@34.64.37.55:30303,enode://5b037f66099d5ded86eb7e1619f6d06ceb15609e8cc345ced22a4772b06178004e1490a3cd32fd1222789de4c6e4021c2d648a3d750f6d5323e64b771bbd8de7@35.247.182.34:30303,enode://846db253c53753d3ea1197aec296306dc84c25f3afdf142b65cb0fe0f984de55072daa3bbf05a9aea046a38a2292403137b6eafefd5646fcf62120b74e3b898d@34.87.9.231:30303,enode://64b7f6ee9bcd942ad4949c70f2077627f078a057dfd930e6e904e12643d8952f5ae87c91e24559765393f244a72c9d5c011d7d5176e59191d38f315db85a20f5@34.126.78.49:30303,enode://cf4d19bfb8ec507427ec882bac0bac85a0c8c9ddaa0ec91b773bb614e5e09d107cd9fbe323b96f62f31c493f8f42cc5495c18b87c08560c5dea1dfd25256dcf6@35.240.200.36:30303,enode://bb7e44178543431feac8f0ee3827056b7b84d8235b802a8bdbbcd4939dab7f7dd2579ff577a38b002bb0139792af67abd2dd5c9f4f85b8da6e914fa76dca82bc@34.40.14.50:30303,enode://8fef1f5df45e7b31be00a21e1da5665d5a5f5bf4c379086b843f03eade941bdd157f08c95b31880c492577edb9a9b185df7191eaebf54ab06d5bd683b289f3af@35.246.168.217:30303,enode://ce9c87cfe089f6811d26c96913fa3ec10b938d9017fc6246684c74a33679ee34ceca9447180fb509e37bf2b706c2877a82085d34bfd83b5b520ee1288b0fc32f@34.40.28.159:30303,enode://713657eb6a53feadcbc47e634ad557326a51eb6818a3e19a00a8111492f50a666ccbf2f5d334d247ecf941e68d242ef5c3b812b63c44d381ef11f79c2cdb45c7@35.234.82.236:30303,enode://d071fa740e063ce1bb9cdc2b7937baeff6dc4000f91588d730a731c38a6ff0d4015814812c160fab8695e46f74b9b618735368ea2f16db4d785f16d29b3fb7b0@35.203.86.197:30303,enode://ffc452fe451a2e5f89fe634744aea334d92dcd30d881b76209d2db7dbf4b7ee047e7c69a5bb1633764d987a7441d9c4bc57ccdbfd6442a2f860bf953bc89a9b9@34.118.187.161:30303,enode://da94328302a1d1422209d1916744e90b6095a48b2340dcec39b22002c098bb4d58a880dab98eb26edf03fa4705d1b62f99a8c5c14e6666e4726b6d3066d8a4d7@34.95.30.190:30303,enode://19c7671a4844699b481e81a5bcfe7bafc7fefa953c16ebbe1951b1046371e73839e9058de6b7d3c934318fe7e7233dde3621c1c1018eb8b294ea3d4516147150@34.47.60.196:30303" \
+            --trusted-peers "$TRUSTED_PEERS" \
             -vvv --http --http.api eth
       - name: Verify sync progress
         run: |
-          # Check if we've synced beyond 9 million blocks
+          # Check if we've synced beyond the target block
           BLOCK_NUMBER=$(curl -s -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' http://localhost:8545 | jq -r .result)
           BLOCK_DECIMAL=$(printf "%d" $BLOCK_NUMBER)
+          TARGET_BLOCK=${{ matrix.network.max_block }}
           echo "Latest block number: $BLOCK_DECIMAL"
-          if [ $BLOCK_DECIMAL -gt 9000000 ]; then
-            echo "✅ Sync test successful - block number $BLOCK_DECIMAL > 9,000,000"
+          if [ $BLOCK_DECIMAL -gt $TARGET_BLOCK ]; then
+            echo "✅ Sync test successful - block number $BLOCK_DECIMAL > $TARGET_BLOCK"
           else
-            echo "❌ Sync test failed - block number $BLOCK_DECIMAL <= 9,000,000"
+            echo "❌ Sync test failed - block number $BLOCK_DECIMAL <= $TARGET_BLOCK"
             exit 1
           fi 

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -66,10 +66,10 @@ jobs:
       - name: Verify sync progress
         run: |
           # Check if we've synced beyond the target block
-          BLOCK_NUMBER=$(curl -s -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' http://localhost:8545 | jq -r .result)
-          BLOCK_DECIMAL=$(printf "%d" $BLOCK_NUMBER)
+          BLOCK_NUMBER_HEX=$(curl -s -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' http://localhost:8545 | jq -r .result)
+          BLOCK_DECIMAL=$(printf "%d" $BLOCK_NUMBER_HEX)
           TARGET_BLOCK=${{ matrix.network.max_block }}
-          echo "Latest block number: $BLOCK_DECIMAL"
+          echo "Latest block number: $BLOCK_DECIMAL (hex: $BLOCK_NUMBER_HEX)"
           if [ $BLOCK_DECIMAL -gt $TARGET_BLOCK ]; then
             echo "✅ Sync test successful - block number $BLOCK_DECIMAL > $TARGET_BLOCK"
           else

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,58 @@
+# Runs sync tests.
+
+name: sync test
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+env:
+  CARGO_TERM_COLOR: always
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  sync:
+    name: sync (etherscan)
+    runs-on: ubuntu-latest-large
+    env:
+      RUST_LOG: info,sync=error
+      RUST_BACKTRACE: 1
+      BERASCAN_API_KEY: ${{ secrets.BERASCAN_API_KEY }}
+    timeout-minutes: 720
+    steps:
+      - uses: actions/checkout@v4
+      - uses: rui314/setup-mold@v1
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+      - name: Download genesis file
+        run: |
+          curl -o eth-genesis.json https://raw.githubusercontent.com/berachain/beacon-kit/main/testing/networks/80094/eth-genesis.json
+      - name: Build bera-reth
+        run: cargo build --profile maxperf
+      - name: Run etherscan sync
+        run: |
+          ./target/maxperf/bera-reth node \
+            --chain ./eth-genesis.json \
+            --datadir ./tmp \
+            --debug.etherscan "https://api.etherscan.io/v2/api?chainid=80094&apikey=$BERASCAN_API_KEY" \
+            --debug.terminate \
+            --trusted-peers "enode://0c5a4a3c0e81fce2974e4d317d88df783731183d534325e32e0fdf8f4b119d7889fa254d3a38890606ec300d744e2aa9c87099a4a032f5c94efe53f3fcdfecfe@34.22.104.177:30303,enode://b6a3137d3a36ef37c4d31843775a9dc293f41bcbde33b6309c80b1771b6634827cd188285136a57474427bd8845adc2f6fe2e0b106bd58d14795b08910b9c326@34.64.247.85:30303,enode://0b6633300614bc2b9749aee0cace7a091ec5348762aee7b1d195f7616d03a9409019d9bef336624bab72e0d069cd4cf0b0de6fbbf53f04f6b6e4c5b39c6bdca6@34.22.73.21:30303,enode://552b001abebb5805fcd734ad367cd05d9078d18f23ec598d7165460fadcfc51116ad95c418f7ea9a141aa8cbc496c8bea3322b67a5de0d3380f11aab1a797513@34.64.37.55:30303,enode://5b037f66099d5ded86eb7e1619f6d06ceb15609e8cc345ced22a4772b06178004e1490a3cd32fd1222789de4c6e4021c2d648a3d750f6d5323e64b771bbd8de7@35.247.182.34:30303,enode://846db253c53753d3ea1197aec296306dc84c25f3afdf142b65cb0fe0f984de55072daa3bbf05a9aea046a38a2292403137b6eafefd5646fcf62120b74e3b898d@34.87.9.231:30303,enode://64b7f6ee9bcd942ad4949c70f2077627f078a057dfd930e6e904e12643d8952f5ae87c91e24559765393f244a72c9d5c011d7d5176e59191d38f315db85a20f5@34.126.78.49:30303,enode://cf4d19bfb8ec507427ec882bac0bac85a0c8c9ddaa0ec91b773bb614e5e09d107cd9fbe323b96f62f31c493f8f42cc5495c18b87c08560c5dea1dfd25256dcf6@35.240.200.36:30303,enode://bb7e44178543431feac8f0ee3827056b7b84d8235b802a8bdbbcd4939dab7f7dd2579ff577a38b002bb0139792af67abd2dd5c9f4f85b8da6e914fa76dca82bc@34.40.14.50:30303,enode://8fef1f5df45e7b31be00a21e1da5665d5a5f5bf4c379086b843f03eade941bdd157f08c95b31880c492577edb9a9b185df7191eaebf54ab06d5bd683b289f3af@35.246.168.217:30303,enode://ce9c87cfe089f6811d26c96913fa3ec10b938d9017fc6246684c74a33679ee34ceca9447180fb509e37bf2b706c2877a82085d34bfd83b5b520ee1288b0fc32f@34.40.28.159:30303,enode://713657eb6a53feadcbc47e634ad557326a51eb6818a3e19a00a8111492f50a666ccbf2f5d334d247ecf941e68d242ef5c3b812b63c44d381ef11f79c2cdb45c7@35.234.82.236:30303,enode://d071fa740e063ce1bb9cdc2b7937baeff6dc4000f91588d730a731c38a6ff0d4015814812c160fab8695e46f74b9b618735368ea2f16db4d785f16d29b3fb7b0@35.203.86.197:30303,enode://ffc452fe451a2e5f89fe634744aea334d92dcd30d881b76209d2db7dbf4b7ee047e7c69a5bb1633764d987a7441d9c4bc57ccdbfd6442a2f860bf953bc89a9b9@34.118.187.161:30303,enode://da94328302a1d1422209d1916744e90b6095a48b2340dcec39b22002c098bb4d58a880dab98eb26edf03fa4705d1b62f99a8c5c14e6666e4726b6d3066d8a4d7@34.95.30.190:30303,enode://19c7671a4844699b481e81a5bcfe7bafc7fefa953c16ebbe1951b1046371e73839e9058de6b7d3c934318fe7e7233dde3621c1c1018eb8b294ea3d4516147150@34.47.60.196:30303" \
+            -vvv --http --http.api eth
+      - name: Verify sync progress
+        run: |
+          # Check if we've synced beyond 9 million blocks
+          BLOCK_NUMBER=$(curl -s -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' http://localhost:8545 | jq -r .result)
+          BLOCK_DECIMAL=$(printf "%d" $BLOCK_NUMBER)
+          echo "Latest block number: $BLOCK_DECIMAL"
+          if [ $BLOCK_DECIMAL -gt 9000000 ]; then
+            echo "✅ Sync test successful - block number $BLOCK_DECIMAL > 9,000,000"
+          else
+            echo "❌ Sync test failed - block number $BLOCK_DECIMAL <= 9,000,000"
+            exit 1
+          fi 

--- a/src/chainspec/mod.rs
+++ b/src/chainspec/mod.rs
@@ -55,10 +55,11 @@ impl EthChainSpec for BerachainChainSpec {
     type Header = BerachainHeader;
 
     fn chain(&self) -> Chain {
-        if self.inner.chain_id() == 80094 {
-            return Chain::from(Berachain)
+        match self.inner.chain_id() {
+            id if id == (Berachain as u64) => Chain::from(Berachain),
+            id if id == (BerachainBepolia as u64) => Chain::from(BerachainBepolia),
+            _ => self.inner.chain(),
         }
-        self.inner.chain()
     }
 
     fn base_fee_params_at_block(&self, block_number: u64) -> BaseFeeParams {

--- a/src/chainspec/mod.rs
+++ b/src/chainspec/mod.rs
@@ -55,6 +55,8 @@ impl EthChainSpec for BerachainChainSpec {
     type Header = BerachainHeader;
 
     fn chain(&self) -> Chain {
+        // Required for etherscan integration (--debug.etherscan) to work correctly
+        // Maps chain IDs to their corresponding NamedChain variants
         match self.inner.chain_id() {
             id if id == (Berachain as u64) => Chain::from(Berachain),
             id if id == (BerachainBepolia as u64) => Chain::from(BerachainBepolia),

--- a/src/chainspec/mod.rs
+++ b/src/chainspec/mod.rs
@@ -16,14 +16,14 @@ use derive_more::{Constructor, Into};
 use reth::{
     chainspec::{
         BaseFeeParams, BaseFeeParamsKind, Chain, ChainHardforks, EthereumHardfork,
-        EthereumHardforks, ForkCondition, Hardfork,
+        EthereumHardforks, ForkCondition, Hardfork, NamedChain::BerachainBepolia,
     },
     primitives::SealedHeader,
     revm::primitives::{Address, B256, U256, b256},
 };
 use reth_chainspec::{
     ChainSpec, DepositContract, EthChainSpec, Hardforks, MAINNET_PRUNE_DELETE_LIMIT,
-    make_genesis_header,
+    NamedChain::Berachain, make_genesis_header,
 };
 use reth_cli::chainspec::{ChainSpecParser, parse_genesis};
 use reth_ethereum_cli::chainspec::SUPPORTED_CHAINS;
@@ -55,6 +55,9 @@ impl EthChainSpec for BerachainChainSpec {
     type Header = BerachainHeader;
 
     fn chain(&self) -> Chain {
+        if self.inner.chain_id() == 80094 {
+            return Chain::from(Berachain)
+        }
         self.inner.chain()
     }
 


### PR DESCRIPTION
  ## Summary
  Adds automated sync tests that run nightly to verify bera-reth can sync both mainnet and bepolia networks.

  ## Changes
  - Matrix sync test workflow for mainnet (9M blocks) and bepolia (1M blocks)
  - Dynamic genesis file and trusted peers fetching from beacon-kit
  - Etherscan integration for sync verification
  - Updated docker-nightly and hive to run daily at same time (1 AM UTC)
  - Fixed chainspec to properly handle Berachain and BerachainBepolia chain IDs