### PR TITLE
fix: reduce mainnet sync load in CI

### DIFF
--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -204,5 +204,5 @@ jobs:
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_COLOR: ${{ job.status }}
-          SLACK_MESSAGE: "Failed run: https://github.com/berachain/bera-reth/actions/runs/${{ github.run_id }}"
+          SLACK_MESSAGE: "Hive test failed: https://github.com/berachain/bera-reth/actions/runs/${{ github.run_id }}"
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -51,7 +51,7 @@ jobs:
             genesis_url: https://raw.githubusercontent.com/berachain/beacon-kit/main/testing/networks/80094/eth-genesis.json
             peers_url: https://raw.githubusercontent.com/berachain/beacon-kit/main/testing/networks/80094/el-peers.txt
             etherscan_url: https://api.etherscan.io/v2/api?chainid=80094
-            max_block: 5000000
+            max_block: 1000000
           - name: berachain-bepolia
             chain_id: 80069
             genesis_url: https://raw.githubusercontent.com/berachain/beacon-kit/main/testing/networks/80069/eth-genesis.json

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -41,8 +41,9 @@ jobs:
       RUST_LOG: info,sync=error
       RUST_BACKTRACE: 1
       BERASCAN_API_KEY: ${{ secrets.BERASCAN_API_KEY }}
-    timeout-minutes: 720
+    timeout-minutes: 2880
     strategy:
+      max-parallel: 1
       matrix:
         network:
           - name: berachain
@@ -50,7 +51,7 @@ jobs:
             genesis_url: https://raw.githubusercontent.com/berachain/beacon-kit/main/testing/networks/80094/eth-genesis.json
             peers_url: https://raw.githubusercontent.com/berachain/beacon-kit/main/testing/networks/80094/el-peers.txt
             etherscan_url: https://api.etherscan.io/v2/api?chainid=80094
-            max_block: 9000000
+            max_block: 5000000
           - name: berachain-bepolia
             chain_id: 80069
             genesis_url: https://raw.githubusercontent.com/berachain/beacon-kit/main/testing/networks/80069/eth-genesis.json

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   build:
     name: build bera-reth
-    runs-on: gha-runner-amd64-large
+    runs-on: ubuntu-latest-large
     steps:
       - uses: actions/checkout@v4
       - uses: rui314/setup-mold@v1
@@ -36,7 +36,7 @@ jobs:
   sync:
     name: sync (${{ matrix.network.name }})
     needs: build
-    runs-on: gha-runner-amd64-large
+    runs-on: ubuntu-latest-large
     env:
       RUST_LOG: info,sync=error
       RUST_BACKTRACE: 1
@@ -51,7 +51,7 @@ jobs:
             genesis_url: https://raw.githubusercontent.com/berachain/beacon-kit/main/testing/networks/80094/eth-genesis.json
             peers_url: https://raw.githubusercontent.com/berachain/beacon-kit/main/testing/networks/80094/el-peers.txt
             etherscan_url: https://api.etherscan.io/v2/api?chainid=80094
-            max_block: 5000000
+            max_block: 1000000
           - name: berachain-bepolia
             chain_id: 80069
             genesis_url: https://raw.githubusercontent.com/berachain/beacon-kit/main/testing/networks/80069/eth-genesis.json
@@ -116,7 +116,7 @@ jobs:
   notify-on-error:
     needs: sync
     if: failure()
-    runs-on: gha-runner-amd64-large
+    runs-on: ubuntu-latest-large
     steps:
       - name: Slack Webhook Action
         uses: rtCamp/action-slack-notify@v2

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -50,7 +50,7 @@ jobs:
             genesis_url: https://raw.githubusercontent.com/berachain/beacon-kit/main/testing/networks/80094/eth-genesis.json
             peers_url: https://raw.githubusercontent.com/berachain/beacon-kit/main/testing/networks/80094/el-peers.txt
             etherscan_url: https://api.etherscan.io/v2/api?chainid=80094
-            max_block: 2500000
+            max_block: 1500000
           - name: berachain-bepolia
             chain_id: 80069
             genesis_url: https://raw.githubusercontent.com/berachain/beacon-kit/main/testing/networks/80069/eth-genesis.json

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -43,7 +43,6 @@ jobs:
       BERASCAN_API_KEY: ${{ secrets.BERASCAN_API_KEY }}
     timeout-minutes: 2880
     strategy:
-      max-parallel: 2
       matrix:
         network:
           - name: berachain

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -111,4 +111,16 @@ jobs:
           else
             echo "❌ Sync test failed - block number $BLOCK_DECIMAL < $TARGET_BLOCK"
             exit 1
-          fi 
+          fi
+
+  notify-on-error:
+    needs: sync
+    if: failure()
+    runs-on: ubuntu-latest-large
+    steps:
+      - name: Slack Webhook Action
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_COLOR: ${{ job.status }}
+          SLACK_MESSAGE: "Sync test failed: https://github.com/berachain/bera-reth/actions/runs/${{ github.run_id }}"
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }} 

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   build:
     name: build bera-reth
-    runs-on: ubuntu-latest-large
+    runs-on: gha-runner-amd64-large
     steps:
       - uses: actions/checkout@v4
       - uses: rui314/setup-mold@v1
@@ -36,7 +36,7 @@ jobs:
   sync:
     name: sync (${{ matrix.network.name }})
     needs: build
-    runs-on: ubuntu-latest-large
+    runs-on: gha-runner-amd64-large
     env:
       RUST_LOG: info,sync=error
       RUST_BACKTRACE: 1
@@ -51,7 +51,7 @@ jobs:
             genesis_url: https://raw.githubusercontent.com/berachain/beacon-kit/main/testing/networks/80094/eth-genesis.json
             peers_url: https://raw.githubusercontent.com/berachain/beacon-kit/main/testing/networks/80094/el-peers.txt
             etherscan_url: https://api.etherscan.io/v2/api?chainid=80094
-            max_block: 1000000
+            max_block: 5000000
           - name: berachain-bepolia
             chain_id: 80069
             genesis_url: https://raw.githubusercontent.com/berachain/beacon-kit/main/testing/networks/80069/eth-genesis.json
@@ -116,7 +116,7 @@ jobs:
   notify-on-error:
     needs: sync
     if: failure()
-    runs-on: ubuntu-latest-large
+    runs-on: gha-runner-amd64-large
     steps:
       - name: Slack Webhook Action
         uses: rtCamp/action-slack-notify@v2

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -43,7 +43,7 @@ jobs:
       BERASCAN_API_KEY: ${{ secrets.BERASCAN_API_KEY }}
     timeout-minutes: 2880
     strategy:
-      max-parallel: 1
+      max-parallel: 2
       matrix:
         network:
           - name: berachain
@@ -51,7 +51,7 @@ jobs:
             genesis_url: https://raw.githubusercontent.com/berachain/beacon-kit/main/testing/networks/80094/eth-genesis.json
             peers_url: https://raw.githubusercontent.com/berachain/beacon-kit/main/testing/networks/80094/el-peers.txt
             etherscan_url: https://api.etherscan.io/v2/api?chainid=80094
-            max_block: 1000000
+            max_block: 2500000
           - name: berachain-bepolia
             chain_id: 80069
             genesis_url: https://raw.githubusercontent.com/berachain/beacon-kit/main/testing/networks/80069/eth-genesis.json


### PR DESCRIPTION
The mainnet sync job got cancelled after 10hours. It's unclear why. Possible reasons are not enough disk space, timeout, etc. Reducing sync load and concurrency for better resource allocation.

Also adding an onfailure slack message