### PR TITLE
chore: bump version to 1.1.0-rc.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1437,7 +1437,7 @@ checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
 name = "bera-reth"
-version = "1.0.1"
+version = "1.1.0-rc.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bera-reth"
-version = "1.0.1"
+version = "1.1.0-rc.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped application version to 1.1.0-rc.0 (release candidate).
  * No user-facing functionality changes.
  * Users may see the updated version identifier in package metadata and release listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->