### PR TITLE
feat: eth_config API

### DIFF
--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -99,6 +99,7 @@ jobs:
               - eth_getTransactionReceipt
               - eth_sendRawTransaction
               - eth_syncing
+              - eth_config
               # debug_ rpc methods
               - debug_
 

--- a/src/rpc/config.rs
+++ b/src/rpc/config.rs
@@ -109,19 +109,19 @@ where
 
         let mut config = EthConfig { current, next: None, last: None };
 
-        if let Some(last_fork_idx) = current_fork_idx.checked_sub(1) {
-            if let Some(last_fork_timestamp) = fork_timestamps.get(last_fork_idx).copied() {
-                let fake_header = {
-                    let mut header = latest.clone();
-                    header.timestamp = last_fork_timestamp;
-                    header
-                };
-                let last_precompiles = evm_to_precompiles_map(
-                    self.evm_config.evm_for_block(EmptyDB::default(), &fake_header),
-                );
+        if let Some(last_fork_idx) = current_fork_idx.checked_sub(1) &&
+            let Some(last_fork_timestamp) = fork_timestamps.get(last_fork_idx).copied()
+        {
+            let fake_header = {
+                let mut header = latest.clone();
+                header.timestamp = last_fork_timestamp;
+                header
+            };
+            let last_precompiles = evm_to_precompiles_map(
+                self.evm_config.evm_for_block(EmptyDB::default(), &fake_header),
+            );
 
-                config.last = self.build_fork_config_at(last_fork_timestamp, last_precompiles);
-            }
+            config.last = self.build_fork_config_at(last_fork_timestamp, last_precompiles);
         }
 
         if let Some(next_fork_timestamp) = fork_timestamps.get(current_fork_idx + 1).copied() {

--- a/src/rpc/config.rs
+++ b/src/rpc/config.rs
@@ -1,5 +1,4 @@
-//! Loads chain configuration. Adapted from
-//! reth/crates/rpc/rpc-eth-api/src/helpers/config.rs
+//! Berachain chain configuration handler for EIP-7910.
 
 use crate::{
     chainspec::BerachainChainSpec, node::evm::config::BerachainEvmConfig,
@@ -24,9 +23,7 @@ use reth_rpc_eth_types::EthApiError;
 
 use std::{borrow::Borrow, collections::BTreeMap};
 
-/// Handler for the `eth_config` RPC endpoint.
-///
-/// Ref: <https://eips.ethereum.org/EIPS/eip-7910>
+/// Berachain `eth_config` RPC handler implementing EIP-7910.
 #[derive(Debug, Clone)]
 pub struct BerachainConfigHandler<Provider> {
     provider: Provider,
@@ -39,13 +36,12 @@ where
         + BlockReaderIdExt<Header = BerachainHeader>
         + 'static,
 {
-    /// Creates a new [`EthConfigHandler`].
+    /// Creates a new handler.
     pub const fn new(provider: Provider, evm_config: BerachainEvmConfig) -> Self {
         Self { provider, evm_config }
     }
 
-    /// Returns fork config for specific timestamp.
-    /// Returns [`None`] if no blob params were found for this fork.
+    /// Builds fork config for timestamp, returns None if no blob params exist.
     fn build_fork_config_at(
         &self,
         timestamp: u64,
@@ -64,7 +60,6 @@ where
                 .extend(SystemContract::prague(chain_spec.deposit_contract().map(|c| c.address)));
         }
 
-        // Fork config only exists for timestamp-based hardforks.
         let fork_id = chain_spec
             .fork_id(&Head { timestamp, number: u64::MAX, ..Default::default() })
             .hash
@@ -89,7 +84,6 @@ where
             .ok_or_else(|| ProviderError::BestBlockNotFound)?
             .into_header();
 
-        // Short-circuit if Cancun is not active.
         if !chain_spec.is_cancun_active_at_timestamp(latest.timestamp()) {
             return Err(RethError::msg("cancun has not been activated"))
         }
@@ -170,7 +164,6 @@ fn evm_to_precompiles_map(
         .collect()
 }
 
-// TODO: move
 fn precompile_to_str(id: &PrecompileId) -> String {
     let str = match id {
         PrecompileId::EcRec => "ECREC",

--- a/src/rpc/config.rs
+++ b/src/rpc/config.rs
@@ -1,0 +1,197 @@
+//! Loads chain configuration. Adapted from
+//! reth/crates/rpc/rpc-eth-api/src/helpers/config.rs
+
+use crate::{
+    chainspec::BerachainChainSpec, node::evm::config::BerachainEvmConfig,
+    primitives::BerachainHeader,
+};
+use alloy_consensus::BlockHeader;
+use alloy_eips::eip7910::{EthConfig, EthForkConfig, SystemContract};
+use alloy_primitives::Address;
+use jsonrpsee::core::RpcResult;
+use reth::{
+    providers::BlockReaderIdExt,
+    revm::{database_interface::EmptyDB, precompile::PrecompileId},
+};
+use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks, Hardforks, Head};
+use reth_errors::{ProviderError, RethError};
+use reth_evm::{
+    ConfigureEvm, Evm,
+    precompiles::{Precompile, PrecompilesMap},
+};
+use reth_rpc_eth_api::helpers::config::EthConfigApiServer;
+use reth_rpc_eth_types::EthApiError;
+
+use std::{borrow::Borrow, collections::BTreeMap};
+
+/// Handler for the `eth_config` RPC endpoint.
+///
+/// Ref: <https://eips.ethereum.org/EIPS/eip-7910>
+#[derive(Debug, Clone)]
+pub struct BerachainConfigHandler<Provider> {
+    provider: Provider,
+    evm_config: BerachainEvmConfig,
+}
+
+impl<Provider> BerachainConfigHandler<Provider>
+where
+    Provider: ChainSpecProvider<ChainSpec = BerachainChainSpec>
+        + BlockReaderIdExt<Header = BerachainHeader>
+        + 'static,
+{
+    /// Creates a new [`EthConfigHandler`].
+    pub const fn new(provider: Provider, evm_config: BerachainEvmConfig) -> Self {
+        Self { provider, evm_config }
+    }
+
+    /// Returns fork config for specific timestamp.
+    /// Returns [`None`] if no blob params were found for this fork.
+    fn build_fork_config_at(
+        &self,
+        timestamp: u64,
+        precompiles: BTreeMap<String, Address>,
+    ) -> Option<EthForkConfig> {
+        let chain_spec = self.provider.chain_spec();
+
+        let mut system_contracts = BTreeMap::<SystemContract, Address>::default();
+
+        if chain_spec.is_cancun_active_at_timestamp(timestamp) {
+            system_contracts.extend(SystemContract::cancun());
+        }
+
+        if chain_spec.is_prague_active_at_timestamp(timestamp) {
+            system_contracts
+                .extend(SystemContract::prague(chain_spec.deposit_contract().map(|c| c.address)));
+        }
+
+        // Fork config only exists for timestamp-based hardforks.
+        let fork_id = chain_spec
+            .fork_id(&Head { timestamp, number: u64::MAX, ..Default::default() })
+            .hash
+            .0
+            .into();
+
+        Some(EthForkConfig {
+            activation_time: timestamp,
+            blob_schedule: chain_spec.blob_params_at_timestamp(timestamp)?,
+            chain_id: chain_spec.chain().id(),
+            fork_id,
+            precompiles,
+            system_contracts,
+        })
+    }
+
+    fn config(&self) -> Result<EthConfig, RethError> {
+        let chain_spec = self.provider.chain_spec();
+        let latest = self
+            .provider
+            .latest_header()?
+            .ok_or_else(|| ProviderError::BestBlockNotFound)?
+            .into_header();
+
+        // Short-circuit if Cancun is not active.
+        if !chain_spec.is_cancun_active_at_timestamp(latest.timestamp()) {
+            return Err(RethError::msg("cancun has not been activated"))
+        }
+
+        let current_precompiles =
+            evm_to_precompiles_map(self.evm_config.evm_for_block(EmptyDB::default(), &latest));
+
+        let mut fork_timestamps =
+            chain_spec.forks_iter().filter_map(|(_, cond)| cond.as_timestamp()).collect::<Vec<_>>();
+        fork_timestamps.dedup();
+
+        let (current_fork_idx, current_fork_timestamp) = fork_timestamps
+            .iter()
+            .position(|ts| &latest.timestamp < ts)
+            .and_then(|idx| idx.checked_sub(1))
+            .or_else(|| fork_timestamps.len().checked_sub(1))
+            .and_then(|idx| fork_timestamps.get(idx).map(|ts| (idx, *ts)))
+            .ok_or_else(|| RethError::msg("no active timestamp fork found"))?;
+
+        let current = self
+            .build_fork_config_at(current_fork_timestamp, current_precompiles)
+            .ok_or_else(|| RethError::msg("no fork config for current fork"))?;
+
+        let mut config = EthConfig { current, next: None, last: None };
+
+        if let Some(last_fork_idx) = current_fork_idx.checked_sub(1) {
+            if let Some(last_fork_timestamp) = fork_timestamps.get(last_fork_idx).copied() {
+                let fake_header = {
+                    let mut header = latest.clone();
+                    header.timestamp = last_fork_timestamp;
+                    header
+                };
+                let last_precompiles = evm_to_precompiles_map(
+                    self.evm_config.evm_for_block(EmptyDB::default(), &fake_header),
+                );
+
+                config.last = self.build_fork_config_at(last_fork_timestamp, last_precompiles);
+            }
+        }
+
+        if let Some(next_fork_timestamp) = fork_timestamps.get(current_fork_idx + 1).copied() {
+            let fake_header = {
+                let mut header = latest;
+                header.timestamp = next_fork_timestamp;
+                header
+            };
+            let next_precompiles = evm_to_precompiles_map(
+                self.evm_config.evm_for_block(EmptyDB::default(), &fake_header),
+            );
+
+            config.next = self.build_fork_config_at(next_fork_timestamp, next_precompiles);
+        }
+
+        Ok(config)
+    }
+}
+
+impl<Provider> EthConfigApiServer for BerachainConfigHandler<Provider>
+where
+    Provider: ChainSpecProvider<ChainSpec = BerachainChainSpec>
+        + BlockReaderIdExt<Header = BerachainHeader>
+        + 'static,
+{
+    fn config(&self) -> RpcResult<EthConfig> {
+        Ok(self.config().map_err(EthApiError::from)?)
+    }
+}
+
+fn evm_to_precompiles_map(
+    evm: impl Evm<Precompiles = PrecompilesMap>,
+) -> BTreeMap<String, Address> {
+    let precompiles = evm.precompiles();
+    precompiles
+        .addresses()
+        .filter_map(|address| {
+            Some((precompile_to_str(precompiles.get(address)?.precompile_id()), *address))
+        })
+        .collect()
+}
+
+// TODO: move
+fn precompile_to_str(id: &PrecompileId) -> String {
+    let str = match id {
+        PrecompileId::EcRec => "ECREC",
+        PrecompileId::Sha256 => "SHA256",
+        PrecompileId::Ripemd160 => "RIPEMD160",
+        PrecompileId::Identity => "ID",
+        PrecompileId::ModExp => "MODEXP",
+        PrecompileId::Bn254Add => "BN254_ADD",
+        PrecompileId::Bn254Mul => "BN254_MUL",
+        PrecompileId::Bn254Pairing => "BN254_PAIRING",
+        PrecompileId::Blake2F => "BLAKE2F",
+        PrecompileId::KzgPointEvaluation => "KZG_POINT_EVALUATION",
+        PrecompileId::Bls12G1Add => "BLS12_G1ADD",
+        PrecompileId::Bls12G1Msm => "BLS12_G1MSM",
+        PrecompileId::Bls12G2Add => "BLS12_G2ADD",
+        PrecompileId::Bls12G2Msm => "BLS12_G2MSM",
+        PrecompileId::Bls12Pairing => "BLS12_PAIRING_CHECK",
+        PrecompileId::Bls12MapFpToGp1 => "BLS12_MAP_FP_TO_G1",
+        PrecompileId::Bls12MapFp2ToGp2 => "BLS12_MAP_FP2_TO_G2",
+        PrecompileId::P256Verify => "P256_VERIFY",
+        PrecompileId::Custom(custom) => custom.borrow(),
+    };
+    str.to_owned()
+}

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -36,7 +36,7 @@ use reth_node_builder::rpc::{
     RpcHandle,
 };
 use reth_rpc_convert::{RpcConvert, RpcConverter};
-use reth_rpc_eth_api::{EthApiServer, helpers::pending_block::BuildPendingEnv};
+use reth_rpc_eth_api::helpers::pending_block::BuildPendingEnv;
 
 /// Builds `BerachainEthApi` for Berachain.
 #[derive(Debug, Default)]

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -1,16 +1,19 @@
+use reth_rpc_eth_api::helpers::config::EthConfigApiServer;
 pub mod api;
 pub mod config;
 pub mod receipt;
 
 use crate::{
+    chainspec::BerachainChainSpec,
     engine::{
         BerachainExecutionData, rpc::BerachainEngineApiBuilder,
         validator::BerachainEngineValidatorBuilder,
     },
-    node::evm::config::BerachainNextBlockEnvAttributes,
+    node::evm::config::{BerachainEvmConfig, BerachainNextBlockEnvAttributes},
     primitives::BerachainPrimitives,
     rpc::{
         api::{BerachainApi, BerachainNetwork},
+        config::BerachainConfigHandler,
         receipt::BerachainEthReceiptConverter,
     },
 };
@@ -18,7 +21,11 @@ use reth::{
     api::{FullNodeComponents, HeaderTy, PrimitivesTy},
     chainspec::EthereumHardforks,
     revm::context::TxEnv,
-    rpc::{api::eth::FromEvmError, builder::Identity, server_types::eth::EthApiError},
+    rpc::{
+        api::eth::FromEvmError,
+        builder::{Identity, RethRpcModule},
+        server_types::eth::EthApiError,
+    },
 };
 use reth_chainspec::{ChainSpecProvider, EthChainSpec, Hardforks};
 use reth_evm::{ConfigureEvm, EvmFactory, EvmFactoryFor, SpecFor, TxEnvFor};
@@ -29,7 +36,7 @@ use reth_node_builder::rpc::{
     RpcHandle,
 };
 use reth_rpc_convert::{RpcConvert, RpcConverter};
-use reth_rpc_eth_api::helpers::pending_block::BuildPendingEnv;
+use reth_rpc_eth_api::{EthApiServer, helpers::pending_block::BuildPendingEnv};
 
 /// Builds `BerachainEthApi` for Berachain.
 #[derive(Debug, Default)]
@@ -135,14 +142,14 @@ impl<N, EthB, PVB, EB, EVB, RpcMiddleware> NodeAddOns<N>
 where
     N: FullNodeComponents<
             Types: NodeTypes<
-                ChainSpec: EthChainSpec + EthereumHardforks,
+                ChainSpec = BerachainChainSpec,
                 Primitives = BerachainPrimitives,
                 Payload: reth_engine_primitives::EngineTypes<
                     ExecutionData = BerachainExecutionData,
                 >,
             >,
             Provider: ChainSpecProvider<ChainSpec: EthereumHardforks>,
-            Evm: ConfigureEvm<NextBlockEnvCtx = BerachainNextBlockEnvAttributes>,
+            Evm = BerachainEvmConfig,
         >,
     EthB: EthApiBuilder<N>,
     PVB: PayloadValidatorBuilder<N>,
@@ -158,7 +165,17 @@ where
         self,
         ctx: reth_node_api::AddOnsContext<'_, N>,
     ) -> eyre::Result<Self::Handle> {
-        self.inner.launch_add_ons(ctx).await
+        let berachain_config =
+            BerachainConfigHandler::new(ctx.node.provider().clone(), ctx.node.evm_config().clone());
+
+        self.inner
+            .launch_add_ons_with(ctx, move |container| {
+                container
+                    .modules
+                    .merge_if_module_configured(RethRpcModule::Eth, berachain_config.into_rpc())?;
+                Ok(())
+            })
+            .await
     }
 }
 
@@ -166,13 +183,13 @@ impl<N, EthB, PVB, EB, EVB> RethRpcAddOns<N> for BerachainAddOns<N, EthB, PVB, E
 where
     N: FullNodeComponents<
             Types: NodeTypes<
-                ChainSpec: EthChainSpec + EthereumHardforks,
+                ChainSpec = BerachainChainSpec,
                 Primitives = BerachainPrimitives,
                 Payload: reth_engine_primitives::EngineTypes<
                     ExecutionData = BerachainExecutionData,
                 >,
             >,
-            Evm: ConfigureEvm<NextBlockEnvCtx = BerachainNextBlockEnvAttributes>,
+            Evm = BerachainEvmConfig,
         >,
     EthB: EthApiBuilder<N>,
     PVB: PayloadValidatorBuilder<N>,

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -1,4 +1,5 @@
 pub mod api;
+pub mod config;
 pub mod receipt;
 
 use crate::{


### PR DESCRIPTION
Has been added to reth upstream. Helps with debugging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an EIP-7910 configuration RPC endpoint exposing current, previous, and upcoming fork configurations, including system contracts and precompile mappings.
  * Exposes chain configuration derived from the latest block and chain spec for more accurate, real-time insights.

* **Refactor**
  * Consolidated Berachain-specific RPC configuration to streamline module integration and improve compatibility across RPC add-ons.

* **Tests**
  * CI updated to include eth_config RPC coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->