### PR TITLE
chore: update tx propagation script base fee

### DIFF
--- a/.github/assets/eth-tx-sender-ci.sh
+++ b/.github/assets/eth-tx-sender-ci.sh
@@ -81,7 +81,7 @@ send_transaction() {
         --private-key "$PRIVATE_KEY" \
         --nonce "$nonce" \
         --gas-limit 21000 \
-        --gas-price 1.1gwei \
+        --gas-price 50gwei \
         --priority-gas-price 1.1gwei \
         --rpc-url "$RPC_URL"
         2>/dev/null)

--- a/.github/assets/eth-tx-sender-ci.sh
+++ b/.github/assets/eth-tx-sender-ci.sh
@@ -81,7 +81,7 @@ send_transaction() {
         --private-key "$PRIVATE_KEY" \
         --nonce "$nonce" \
         --gas-limit 21000 \
-        --gas-price 50gwei \
+        --gas-price 100gwei \
         --priority-gas-price 1.1gwei \
         --rpc-url "$RPC_URL"
         2>/dev/null)


### PR DESCRIPTION
Extremely unlikely to ever reach 100gwei, so we should always reasonably expect inclusion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the default gas price used by the CI transaction sender from 1.1 gwei to 100 gwei. This change aims to speed up transaction inclusion on the network, resulting in faster confirmations during automated runs. Users may observe quicker completion of related workflows, with higher on-chain fees as a trade-off. No other behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->