### PR TITLE
feat(evm): enable RIP-7212 P-256 precompile for WebAuthn support

### DIFF
--- a/src/evm/mod.rs
+++ b/src/evm/mod.rs
@@ -93,7 +93,6 @@ impl<DB: Database, I> BerachainEvmBuilder<DB, I> {
             ))),
         };
 
-        // Berachain custom precompiles.
         maybe_enable_rip7212_p256verify_precompile(&mut precompiles, self.cfg_env.chain_id);
 
         let inner = Context::mainnet()
@@ -132,11 +131,13 @@ fn maybe_enable_rip7212_p256verify_precompile(precompiles: &mut PrecompilesMap, 
     });
 }
 
+/// Chain ID for beranode-cli devnet environment.
+const BERACHAIN_DEVNET_CHAIN_ID: u64 = 80087;
+
 fn is_berachain_chain_id(chain_id: u64) -> bool {
     chain_id == NamedChain::Berachain as u64
         || chain_id == NamedChain::BerachainBepolia as u64
-        // beranode-cli devnet chain id
-        || chain_id == 80087
+        || chain_id == BERACHAIN_DEVNET_CHAIN_ID
 }
 
 /// Berachain EVM implementation.
@@ -396,7 +397,7 @@ mod tests {
         let factory = BerachainEvmFactory;
 
         // Berachain chain_ids should enable RIP-7212 precompile even before Osaka.
-        for chain_id in [NamedChain::Berachain as u64, NamedChain::BerachainBepolia as u64, 80087] {
+        for chain_id in [NamedChain::Berachain as u64, NamedChain::BerachainBepolia as u64, BERACHAIN_DEVNET_CHAIN_ID] {
             let mut cfg_env = CfgEnv::default();
             cfg_env.spec = SpecId::CANCUN;
             cfg_env.chain_id = chain_id;


### PR DESCRIPTION
## Summary

Enables the RIP-7212 secp256r1 (P-256) signature verification precompile at address `0x100` for Berachain networks.

This unlocks WebAuthn/passkey-based account abstraction when combined with EIP-7702 (already supported).

## Changes

- Add `maybe_enable_rip7212_p256verify_precompile()` function that conditionally enables the precompile for Berachain chain IDs
- Add `is_berachain_chain_id()` helper supporting mainnet (80094), Bepolia (80069), and devnet (80087)
- Wire precompile injection into `BerachainEvmBuilder.build()`
- Add test coverage for precompile availability across chain IDs

## Technical Details

- Uses revm's existing `secp256r1::p256_verify` implementation
- Gas cost: 3,450 (standard RIP-7212)
- Only enabled for Berachain chain IDs (non-Berachain chains unaffected)
- Does not override if precompile already exists at `0x100` (e.g., Osaka variant)

## What This Enables

Smart contracts can call `0x100` to verify P-256/secp256r1 signatures, enabling:
- Passkey/WebAuthn authentication
- Apple Secure Enclave signatures
- Android Keystore signatures
- FIDO2/WebAuthn device signatures

Combined with EIP-7702, users can delegate their EOA to a passkey-aware smart account that verifies signatures via this precompile.

## Test Plan

- [x] Unit test verifying precompile presence for all Berachain chain IDs
- [x] Unit test verifying precompile absence for non-Berachain chains pre-Osaka
- [ ] Integration test with BeaconKit
- [ ] Testnet deployment verification

## References

- [RIP-7212: secp256r1 Precompile](https://github.com/ethereum/RIPs/blob/master/RIPS/rip-7212.md)
- [Paradigm Alphanet Implementation](https://github.com/paradigmxyz/alphanet)
- [Daimo P256Verifier](https://github.com/daimo-eth/p256-verifier)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conditionally enable a P256Verify cryptographic precompile at address 0x100 for Berachain networks (Berachain, BerachainBepolia, and devnet), applied only on those chain IDs and without overriding existing 0x100 behavior elsewhere.

* **Tests**
  * Added tests to verify the precompile is present for Berachain chain IDs and absent on non-Berachain networks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->