### PR TITLE
chore: bump version to 1.4.0 + bump lz4_flex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1449,7 +1449,7 @@ checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
 name = "bera-reth"
-version = "1.4.0-rc.6"
+version = "1.4.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4894,9 +4894,9 @@ dependencies = [
 
 [[package]]
 name = "lz4_flex"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab6473172471198271ff72e9379150e9dfd70d8e533e0752a27e515b48dd375e"
+checksum = "98c23545df7ecf1b16c303910a69b079e8e251d60f7dd2cc9b4177f2afaf1746"
 
 [[package]]
 name = "mach2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bera-reth"
-version = "1.4.0-rc.6"
+version = "1.4.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 


### PR DESCRIPTION
Needed to upgrade lz4_flex to address cargo deny

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 1.4.0 (stable release)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->