### PR TITLE
chore(CI): fix security audit warning

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -71,8 +71,6 @@ ignore = [
   "RUSTSEC-2024-0436",
   # https://rustsec.org/advisories/RUSTSEC-2025-0141 bincode is unmaintained, need to transition all deps to wincode first
   "RUSTSEC-2025-0141",
-  # https://rustsec.org/advisories/RUSTSEC-2026-0002 lru unused directly: https://github.com/alloy-rs/alloy/pull/3460
-  "RUSTSEC-2026-0002",
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.


### PR DESCRIPTION
Seems our CI is failing after `lru` version bump in a97f1a9 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled security advisory validation that was previously skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->