### PR TITLE
fix: ignore RUSTSEC-2026-0002 lru advisory pinned by discv5

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -71,6 +71,8 @@ ignore = [
   "RUSTSEC-2024-0436",
   # https://rustsec.org/advisories/RUSTSEC-2025-0141 bincode is unmaintained, need to transition all deps to wincode first
   "RUSTSEC-2025-0141",
+  # https://rustsec.org/advisories/RUSTSEC-2026-0002 lru 0.12.5 unsound IterMut, pinned by discv5
+  "RUSTSEC-2026-0002",
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.


### PR DESCRIPTION
This should fix failing CI on main branch.

Similar to upstream reth https://github.com/paradigmxyz/reth/pull/20819/files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security advisory configurations to exclude an additional vulnerability identifier from automated checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->