### PR TITLE
fix(chainspec): make --chain required on stage/db subcommands

### DIFF
--- a/src/chainspec/mod.rs
+++ b/src/chainspec/mod.rs
@@ -26,7 +26,6 @@ use reth_chainspec::{
     NamedChain::Berachain, make_genesis_header,
 };
 use reth_cli::chainspec::{ChainSpecParser, parse_genesis};
-use reth_ethereum_cli::chainspec::SUPPORTED_CHAINS;
 use reth_evm::eth::spec::EthExecutorSpec;
 use std::{fmt::Display, sync::Arc};
 
@@ -424,7 +423,19 @@ pub struct BerachainChainSpecParser;
 impl ChainSpecParser for BerachainChainSpecParser {
     type ChainSpec = BerachainChainSpec;
 
-    const SUPPORTED_CHAINS: &'static [&'static str] = SUPPORTED_CHAINS;
+    // Berachain does not provide built-in named chain specs (the genesis alloc is too
+    // large to embed). Callers must supply an explicit path via --chain. An empty slice
+    // here prevents Clap from advertising Ethereum chain names (mainnet, sepolia, …) as
+    // valid values when they cannot actually be resolved.
+    const SUPPORTED_CHAINS: &'static [&'static str] = &[];
+
+    // No default: returning None makes --chain a required argument on all subcommands
+    // that use EnvironmentArgs (stage, db, prune, …). This eliminates the previous
+    // broken behaviour where omitting --chain caused Clap to fall back to "mainnet",
+    // which parse_genesis would then try to open as a file path and fail with ENOENT.
+    fn default_value() -> Option<&'static str> {
+        None
+    }
 
     fn parse(s: &str) -> eyre::Result<Arc<Self::ChainSpec>> {
         Ok(Arc::new(parse_genesis(s)?.into()))


### PR DESCRIPTION
# Summary

Removes all supported built-in chains from bera-reth, and makes the `--chain <path>` option work.

# Details

The `--chain` parameter advertises ethereum chains, but not Bera's.    This is not useful.  It's not possible to bake in bera-mainnet because the spec is 48mb. And only bepolia would be silly.  So that's the reason why there should be no `--chain` builtins.

The bug regarding `--chain <path>` manifested in rewinds.  For various reasons, I have to sometimes rewind state (see https://github.com/paradigmxyz/reth/issues/23234).

So to "unwind", I have to provide a --chain parameter. Because of a flaw in this function, passing "--chain /path/to/genesis.json" does not work.    The workaround to accomplish an unwind was: make a hardlink or symlink ./mainnet (in the directory where bera-reth is being invoked) pointing to genesis.json

n.b. `reth node` does not use this path to evaluate `--chain`

## Fix

Two changes to `BerachainChainSpecParser`:

1. Override `default_value()` to return `None` — makes `--chain` a required argument on all `EnvironmentArgs`-based subcommands (`stage unwind`, `stage run`, `db`, `prune`, …). Omitting it now fails with a clear "required argument missing" rather than a file-not-found on `"mainnet"`.

2. Replace the borrowed `SUPPORTED_CHAINS` from `reth_ethereum_cli` with `&[]` — stops advertising `mainnet`, `sepolia`, etc. as valid `--chain` values when they cannot be resolved. 

The `node` subcommand is unaffected — it uses `NodeCommand`'s own chain argument wiring, not `EnvironmentArgs`.

## Testing

- `cargo check` clean
- 48 existing chainspec unit tests pass (`cargo test -p bera-reth -- chainspec`)
- No existing tests invoke stage/db subcommands without `--chain`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The `--chain` CLI parameter is now required for subcommands instead of being optional with a default fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->