### PR TITLE
fix: default engine persistence and memory buffer for production

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,6 +195,4 @@ start-bera-reth-local:
 		--authrpc.addr "0.0.0.0" \
 		--authrpc.jwtsecret $(JWT_PATH) \
 		--datadir $(ETH_DATA_DIR) \
-		--ipcpath $(IPC_PATH) \
-		--engine.persistence-threshold 0 \
-		--engine.memory-block-buffer-target 0
+		--ipcpath $(IPC_PATH)

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,10 +18,7 @@ use reth_node_builder::NodeHandle;
 use std::sync::Arc;
 use tracing::info;
 
-/// Production engine defaults: persist canonical blocks immediately and do not
-/// retain an extra in-memory window behind the head (`memory_block_buffer_target`).
-/// Upstream reth uses a higher persistence threshold; Berachain's block times
-/// favor minimal in-memory buffering.
+const BERACHAIN_DEFAULT_PERSISTENCE_THRESHOLD: u64 = 0;
 const BERACHAIN_DEFAULT_PERSISTENCE_THRESHOLD: u64 = 0;
 const BERACHAIN_DEFAULT_MEMORY_BLOCK_BUFFER_TARGET: u64 = 0;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,10 +18,12 @@ use reth_node_builder::NodeHandle;
 use std::sync::Arc;
 use tracing::info;
 
-/// Persist every canonical block to disk immediately rather than buffering.
-/// Upstream reth defaults to 2, but Berachain's faster block times benefit from
-/// eager persistence to keep the in-memory block window minimal.
+/// Production engine defaults: persist canonical blocks immediately and do not
+/// retain an extra in-memory window behind the head (`memory_block_buffer_target`).
+/// Upstream reth uses a higher persistence threshold; Berachain's block times
+/// favor minimal in-memory buffering.
 const BERACHAIN_DEFAULT_PERSISTENCE_THRESHOLD: u64 = 0;
+const BERACHAIN_DEFAULT_MEMORY_BLOCK_BUFFER_TARGET: u64 = 0;
 
 fn main() {
     // Install signal handler for better crash reporting
@@ -32,6 +34,7 @@ fn main() {
 
     reth_node_core::args::DefaultEngineValues::default()
         .with_persistence_threshold(BERACHAIN_DEFAULT_PERSISTENCE_THRESHOLD)
+        .with_memory_block_buffer_target(BERACHAIN_DEFAULT_MEMORY_BLOCK_BUFFER_TARGET)
         .try_init()
         .expect("engine defaults must be set before CLI parsing");
 


### PR DESCRIPTION
Set memory_block_buffer_target to 0 via DefaultEngineValues alongside the existing persistence_threshold=0. 

Drop redundant Makefile flags from the local BeaconKit dev target.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized node engine configuration settings from command-line arguments to code defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->