### PR TITLE
feat(cli): bake genesis into build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11
 reth-storage-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
 reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
 serde = { version = "1.0", features = ["derive"], default-features = false }
+serde_json = "1.0"
 thiserror = "2.0"
 tokio = "1.46.0"
 tracing = "0.1.41"
@@ -79,7 +80,6 @@ reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1
 reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
 reth-trie-common = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
 revm-inspectors = "0.34.2"
-serde_json = "1.0"
 test-fuzz = "7"
 
 [build-dependencies]

--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,18 @@
 #![allow(missing_docs)]
 
-use std::{env, error::Error};
+use std::{
+    env,
+    error::Error,
+    fs,
+    path::{Path, PathBuf},
+};
 use vergen::{BuildBuilder, CargoBuilder, Emitter};
 use vergen_git2::Git2Builder;
+
+const MAINNET_FIXTURE_PATH: &str = "tests/fixtures/mainnet-genesis.json";
+const BEPOLIA_FIXTURE_PATH: &str = "tests/fixtures/bepolia-genesis.json";
+const MAINNET_BAKED_FILENAME: &str = "mainnet-eth-genesis.json";
+const BEPOLIA_BAKED_FILENAME: &str = "bepolia-eth-genesis.json";
 
 fn main() -> Result<(), Box<dyn Error>> {
     let mut emitter = Emitter::default();
@@ -32,6 +42,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // Set the build profile
     let out_dir = env::var("OUT_DIR").unwrap();
+    bake_eth_genesis_specs(&out_dir)?;
     let profile = out_dir.rsplit(std::path::MAIN_SEPARATOR).nth(3).unwrap();
     println!("cargo:rustc-env=BERA_RETH_BUILD_PROFILE={profile}");
 
@@ -63,5 +74,29 @@ fn main() -> Result<(), Box<dyn Error>> {
         )
     );
 
+    Ok(())
+}
+
+fn bake_eth_genesis_specs(out_dir: &str) -> Result<(), Box<dyn Error>> {
+    println!("cargo:rerun-if-changed={MAINNET_FIXTURE_PATH}");
+    println!("cargo:rerun-if-changed={BEPOLIA_FIXTURE_PATH}");
+
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR")?;
+    let mainnet_out = Path::new(out_dir).join(MAINNET_BAKED_FILENAME);
+    let bepolia_out = Path::new(out_dir).join(BEPOLIA_BAKED_FILENAME);
+
+    copy_fixture_to_out_dir(&manifest_dir, MAINNET_FIXTURE_PATH, &mainnet_out)?;
+    copy_fixture_to_out_dir(&manifest_dir, BEPOLIA_FIXTURE_PATH, &bepolia_out)?;
+
+    Ok(())
+}
+
+fn copy_fixture_to_out_dir(
+    manifest_dir: &str,
+    fixture_relative_path: &str,
+    destination: &Path,
+) -> Result<(), Box<dyn Error>> {
+    let source = PathBuf::from(manifest_dir).join(fixture_relative_path);
+    fs::copy(source, destination)?;
     Ok(())
 }

--- a/src/chainspec/mod.rs
+++ b/src/chainspec/mod.rs
@@ -26,12 +26,18 @@ use reth_chainspec::{
     NamedChain::Berachain, make_genesis_header,
 };
 use reth_cli::chainspec::{ChainSpecParser, parse_genesis};
-use reth_ethereum_cli::chainspec::SUPPORTED_CHAINS;
 use reth_evm::eth::spec::EthExecutorSpec;
 use std::{fmt::Display, sync::Arc};
 
 /// Default minimum base fee when Prague1 is not active.
 const DEFAULT_MIN_BASE_FEE_WEI: u64 = 0;
+const BERACHAIN_MAINNET: &str = "mainnet";
+const BERACHAIN_BEPOLIA: &str = "bepolia";
+const BERACHAIN_SUPPORTED_CHAINS: &[&str] = &[BERACHAIN_MAINNET, BERACHAIN_BEPOLIA];
+const MAINNET_ETH_GENESIS_JSON: &str =
+    include_str!(concat!(env!("OUT_DIR"), "/mainnet-eth-genesis.json"));
+const BEPOLIA_ETH_GENESIS_JSON: &str =
+    include_str!(concat!(env!("OUT_DIR"), "/bepolia-eth-genesis.json"));
 
 /// Berachain chain specification wrapping Reth's ChainSpec with Berachain hardforks
 #[derive(Debug, Clone, Into, Constructor, PartialEq, Eq, Default)]
@@ -424,10 +430,19 @@ pub struct BerachainChainSpecParser;
 impl ChainSpecParser for BerachainChainSpecParser {
     type ChainSpec = BerachainChainSpec;
 
-    const SUPPORTED_CHAINS: &'static [&'static str] = SUPPORTED_CHAINS;
+    const SUPPORTED_CHAINS: &'static [&'static str] = BERACHAIN_SUPPORTED_CHAINS;
+
+    fn default_value() -> Option<&'static str> {
+        Some(BERACHAIN_MAINNET)
+    }
 
     fn parse(s: &str) -> eyre::Result<Arc<Self::ChainSpec>> {
-        Ok(Arc::new(parse_genesis(s)?.into()))
+        let genesis = match s {
+            BERACHAIN_MAINNET => serde_json::from_str(MAINNET_ETH_GENESIS_JSON)?,
+            BERACHAIN_BEPOLIA => serde_json::from_str(BEPOLIA_ETH_GENESIS_JSON)?,
+            _ => parse_genesis(s)?,
+        };
+        Ok(Arc::new(genesis.into()))
     }
 }
 
@@ -550,8 +565,8 @@ impl From<Genesis> for BerachainChainSpec {
         }
 
         // Validate Prague3 ordering if configured (Prague3 must come at or after Prague2)
-        if let Some(prague3_config) = prague3_config_opt.as_ref() &&
-            prague3_config.time < prague2_config.time
+        if let Some(prague3_config) = prague3_config_opt.as_ref()
+            && prague3_config.time < prague2_config.time
         {
             panic!(
                 "Prague3 hardfork must activate at or after Prague2 hardfork. Prague2 time: {}, Prague3 time: {}.",
@@ -1835,6 +1850,24 @@ mod tests {
         genesis.config.extra_fields =
             reth::rpc::types::serde_helpers::OtherFields::try_from(extra_fields_json).unwrap();
         let _chain_spec = BerachainChainSpec::from(genesis);
+    }
+
+    #[test]
+    fn test_parser_supports_mainnet_and_bepolia() {
+        assert_eq!(
+            BerachainChainSpecParser::SUPPORTED_CHAINS,
+            [BERACHAIN_MAINNET, BERACHAIN_BEPOLIA]
+        );
+        assert_eq!(BerachainChainSpecParser::default_value(), Some(BERACHAIN_MAINNET));
+    }
+
+    #[test]
+    fn test_parser_builtin_mainnet_and_bepolia_parse() {
+        let mainnet = BerachainChainSpecParser::parse(BERACHAIN_MAINNET).unwrap();
+        let bepolia = BerachainChainSpecParser::parse(BERACHAIN_BEPOLIA).unwrap();
+
+        assert_eq!(mainnet.inner.chain.id(), 80094);
+        assert_eq!(bepolia.inner.chain.id(), 80069);
     }
 
     #[test]

--- a/src/chainspec/mod.rs
+++ b/src/chainspec/mod.rs
@@ -565,8 +565,8 @@ impl From<Genesis> for BerachainChainSpec {
         }
 
         // Validate Prague3 ordering if configured (Prague3 must come at or after Prague2)
-        if let Some(prague3_config) = prague3_config_opt.as_ref()
-            && prague3_config.time < prague2_config.time
+        if let Some(prague3_config) = prague3_config_opt.as_ref() &&
+            prague3_config.time < prague2_config.time
         {
             panic!(
                 "Prague3 hardfork must activate at or after Prague2 hardfork. Prague2 time: {}, Prague3 time: {}.",


### PR DESCRIPTION
build.rs copies test fixture into build tree (this is allegedly cleaner)

currently is uncompressed, not trying to be too clever here


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chainspec parser includes built-in genesis configurations for mainnet and bepolia; default network set to mainnet.

* **Build Changes**
  * Ethereum genesis fixtures are baked into the build output so built-in networks are available at runtime.

* **Dependency Changes**
  * JSON serialization library promoted from dev-only to a regular runtime dependency.

* **Tests**
  * Added unit tests validating supported networks, default selection, and built-in genesis parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->