### PR TITLE
fix(docker): include genesis fixtures in build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,6 +8,10 @@
 !build.rs
 !rustfmt.toml
 
+# include genesis fixtures baked into binary
+!/tests/fixtures/mainnet-genesis.json
+!/tests/fixtures/bepolia-genesis.json
+
 # include for vergen constants
 !/.git
 


### PR DESCRIPTION
This should address the CI docker-latest error when running build.rs -> https://github.com/berachain/bera-reth/actions/runs/24355024122/job/71119591276


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build configuration to include test fixtures in the image build context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->