### PR TITLE
feat(preconf): add observability metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1495,7 +1495,6 @@ dependencies = [
  "reth-chain-state",
  "reth-chainspec",
  "reth-cli",
- "reth-cli-commands",
  "reth-cli-util",
  "reth-codecs",
  "reth-consensus-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,6 @@ reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag 
 reth-chain-state = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
 reth-chainspec = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
 reth-cli = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
 reth-cli-util = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
 reth-codecs = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
 reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }

--- a/deny.toml
+++ b/deny.toml
@@ -71,8 +71,6 @@ ignore = [
   "RUSTSEC-2024-0436",
   # https://rustsec.org/advisories/RUSTSEC-2025-0141 bincode is unmaintained, need to transition all deps to wincode first
   "RUSTSEC-2025-0141",
-  # https://rustsec.org/advisories/RUSTSEC-2026-0002 lru 0.12.5 unsound IterMut, pinned by discv5
-  "RUSTSEC-2026-0002",
   # https://rustsec.org/advisories/RUSTSEC-2023-0089 atomic-polyfill unmaintained, pinned by test-fuzz
   "RUSTSEC-2023-0089",
   # https://rustsec.org/advisories/RUSTSEC-2026-0105 core2 is unmaintained (all versions yanked), no safe upgrade available; transitive dep via ssz/multiaddr

--- a/src/flashblocks/metrics.rs
+++ b/src/flashblocks/metrics.rs
@@ -1,0 +1,32 @@
+//! Metrics for the flashblock RPC consumer.
+//!
+//! Unlabeled metrics live in `FlashBlockServiceMetrics`. Labeled counters are
+//! emitted via the `record_*` helpers so call sites stay symbolic.
+
+use metrics::{Counter, Gauge, Histogram, counter};
+use reth_metrics::Metrics;
+
+#[derive(Metrics)]
+#[metrics(scope = "flashblock_service")]
+pub(crate) struct FlashBlockServiceMetrics {
+    /// Number of flashblocks in the last completed sequence.
+    pub(crate) last_flashblock_length: Histogram,
+    /// Duration of the last flashblock execution in seconds.
+    pub(crate) execution_duration: Histogram,
+    /// Current block height being processed.
+    pub(crate) current_block_height: Gauge,
+    /// Current flashblock index within the sequence.
+    pub(crate) current_index: Gauge,
+    /// 1 = receiving flashblocks from upstream sequencer, 0 = stream error/ended.
+    pub(crate) upstream_connected: Gauge,
+    /// Number of upstream WebSocket reconnect attempts (incremented on stream error backoff).
+    pub(crate) ws_reconnects_total: Counter,
+}
+
+pub(crate) fn record_insert(result: &'static str) {
+    counter!("flashblock_service_insert_total", "result" => result).increment(1);
+}
+
+pub(crate) fn record_build_skip(reason: &'static str) {
+    counter!("flashblock_service_build_skip_total", "reason" => reason).increment(1);
+}

--- a/src/flashblocks/mod.rs
+++ b/src/flashblocks/mod.rs
@@ -16,7 +16,10 @@ pub mod service;
 pub use service::{FlashBlockBuildInfo, FlashBlockService};
 
 mod cache;
+mod metrics;
 mod worker;
+
+pub(crate) use metrics::{FlashBlockServiceMetrics, record_build_skip, record_insert};
 
 pub mod ws;
 pub use ws::{FlashBlockDecoder, WsConnect, WsFlashBlockStream};

--- a/src/flashblocks/service.rs
+++ b/src/flashblocks/service.rs
@@ -1,15 +1,14 @@
 use crate::flashblocks::{
-    FlashBlockCompleteSequence, InProgressFlashBlockRx,
+    FlashBlockCompleteSequence, FlashBlockServiceMetrics, InProgressFlashBlockRx,
     cache::SequenceManager,
     payload::PendingFlashBlock,
+    record_insert,
     traits::{FlashblockPayload, FlashblockPayloadBase},
     worker::FlashBlockBuilder,
 };
 use alloy_primitives::B256;
 use futures_util::{FutureExt, Stream, StreamExt};
-use metrics::{Gauge, Histogram};
 use reth_evm::ConfigureEvm;
-use reth_metrics::Metrics;
 use reth_primitives_traits::{AlloyBlockHeader, BlockTy, HeaderTy, NodePrimitives, ReceiptTy};
 use reth_revm::cached::CachedReads;
 use reth_storage_api::{BlockReaderIdExt, StateProviderFactory};
@@ -134,6 +133,7 @@ where
                 result = self.incoming_flashblock_rx.next() => {
                     match result {
                         Some(Ok(flashblock)) => {
+                            self.metrics.upstream_connected.set(1.0);
                             self.process_flashblock(flashblock);
 
                             while let Some(result) = self.incoming_flashblock_rx.next().now_or_never().flatten() {
@@ -146,6 +146,8 @@ where
                             self.try_start_build_job();
                         }
                         Some(Err(err)) => {
+                            self.metrics.upstream_connected.set(0.0);
+                            self.metrics.ws_reconnects_total.increment(1);
                             warn!(
                                 target: "flashblocks",
                                 %err,
@@ -155,6 +157,7 @@ where
                             sleep(CONNECTION_BACKOUT_PERIOD).await;
                         }
                         None => {
+                            self.metrics.upstream_connected.set(0.0);
                             warn!(target: "flashblocks", "Flashblock stream ended");
                             break;
                         }
@@ -171,8 +174,12 @@ where
             self.metrics.last_flashblock_length.record(self.sequences.pending().count() as f64);
         }
 
-        if let Err(err) = self.sequences.insert_flashblock(flashblock) {
-            warn!(target: "flashblocks", %err, "Failed to insert flashblock");
+        match self.sequences.insert_flashblock(flashblock) {
+            Ok(()) => record_insert("ok"),
+            Err(err) => {
+                record_insert("error");
+                warn!(target: "flashblocks", %err, "Failed to insert flashblock");
+            }
         }
     }
 
@@ -223,16 +230,3 @@ pub struct FlashBlockBuildInfo {
 
 type BuildJob<N> =
     (Instant, oneshot::Receiver<eyre::Result<Option<(PendingFlashBlock<N>, CachedReads)>>>);
-
-#[derive(Metrics)]
-#[metrics(scope = "flashblock_service")]
-struct FlashBlockServiceMetrics {
-    /// Number of flashblocks in the last completed sequence.
-    last_flashblock_length: Histogram,
-    /// Duration of the last flashblock execution in seconds.
-    execution_duration: Histogram,
-    /// Current block height being processed.
-    current_block_height: Gauge,
-    /// Current flashblock index within the sequence.
-    current_index: Gauge,
-}

--- a/src/flashblocks/worker.rs
+++ b/src/flashblocks/worker.rs
@@ -1,4 +1,6 @@
-use crate::flashblocks::{payload::PendingFlashBlock, traits::FlashblockPayloadBase};
+use crate::flashblocks::{
+    payload::PendingFlashBlock, record_build_skip, traits::FlashblockPayloadBase,
+};
 use alloy_eips::{BlockNumberOrTag, eip2718::WithEncoded};
 use alloy_primitives::B256;
 use reth_chain_state::{ComputedTrieData, ExecutedBlock};
@@ -71,7 +73,8 @@ where
         let latest_hash = latest.hash();
 
         if args.base.parent_hash() != latest_hash {
-            trace!(target: "flashblocks", flashblock_parent = ?args.base.parent_hash(), local_latest=?latest.num_hash(),"Skipping non consecutive flashblock");
+            record_build_skip("non_consecutive");
+            trace!(target: "flashblocks", flashblock_parent = ?args.base.parent_hash(), local_latest=?latest.num_hash(), "Skipping non consecutive flashblock");
             return Ok(None);
         }
 

--- a/src/rpc/api.rs
+++ b/src/rpc/api.rs
@@ -1,7 +1,7 @@
 use crate::{
     flashblocks::{BerachainFlashblockPayload, FlashblocksListeners},
     primitives::BerachainHeader,
-    rpc::receipt::BerachainReceiptEnvelope,
+    rpc::{receipt::BerachainReceiptEnvelope, record_state_fallback, record_state_lookup},
     transaction::{BerachainTxEnvelope, BerachainTxType, POL_TX_TYPE},
 };
 use alloy_consensus::{BlockHeader, Transaction};
@@ -349,12 +349,35 @@ where
     /// Only returns a block whose parent hash matches the latest canonical header,
     /// ensuring stale flashblocks are not served during reorgs.
     pub fn pending_flashblock(&self) -> Option<PendingBlock<N::Primitives>> {
-        let latest_hash = self.provider().latest_header().ok().flatten()?.hash();
+        let latest_hash = match self.provider().latest_header().ok().flatten() {
+            Some(h) => h.hash(),
+            None => {
+                record_state_lookup("miss_no_header");
+                return None;
+            }
+        };
 
-        self.flashblocks
-            .as_ref()
-            .and_then(|f| f.pending_block_rx.borrow().as_ref().map(|b| b.pending.clone()))
-            .filter(|pending| pending.block().parent_hash() == latest_hash)
+        let Some(flashblocks) = self.flashblocks.as_ref() else {
+            record_state_lookup("miss_no_listener");
+            return None;
+        };
+
+        let pending = flashblocks.pending_block_rx.borrow().as_ref().map(|b| b.pending.clone());
+
+        match pending {
+            None => {
+                record_state_lookup("miss_no_pending");
+                None
+            }
+            Some(p) if p.block().parent_hash() == latest_hash => {
+                record_state_lookup("hit");
+                Some(p)
+            }
+            Some(_) => {
+                record_state_lookup("miss_stale_hash");
+                None
+            }
+        }
     }
 }
 
@@ -812,6 +835,7 @@ where
         let Ok(latest_historical) =
             self.provider().history_by_block_hash(parent_hash).map_err(Into::<EthApiError>::into)
         else {
+            record_state_fallback("parent_absent");
             tracing::info!(
                 %parent_hash,
                 "parent block not imported yet, falling back to canonical state"

--- a/src/rpc/metrics.rs
+++ b/src/rpc/metrics.rs
@@ -1,0 +1,15 @@
+//! Metrics for the preconf RPC layer.
+
+use metrics::counter;
+
+/// Outcome of a `pending_flashblock()` lookup. Recorded once per call.
+pub(crate) fn record_state_lookup(result: &'static str) {
+    counter!("preconf_rpc_state_lookup_total", "result" => result).increment(1);
+}
+
+/// Recorded when a pending flashblock was found but its parent block is not yet
+/// available in the historical state DB, forcing a fallback to canonical state.
+/// Distinct from `state_lookup_total` to avoid double-counting on a single RPC.
+pub(crate) fn record_state_fallback(reason: &'static str) {
+    counter!("preconf_rpc_state_fallback_total", "reason" => reason).increment(1);
+}

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -3,7 +3,10 @@ use reth_rpc_eth_api::helpers::config::EthConfigApiServer;
 use std::sync::Arc;
 pub mod api;
 pub mod config;
+mod metrics;
 pub mod receipt;
+
+pub(crate) use metrics::{record_state_fallback, record_state_lookup};
 
 use crate::{
     chainspec::BerachainChainSpec,

--- a/src/sequencer/builder.rs
+++ b/src/sequencer/builder.rs
@@ -57,7 +57,12 @@ use std::{
 };
 use tracing::{debug, info, trace, warn};
 
-use crate::transaction::BerachainTxType;
+use crate::{
+    sequencer::{
+        FlashblockSequencerMetrics, record_build_exit, record_emitted, record_publish_error,
+    },
+    transaction::BerachainTxType,
+};
 
 type BestTransactionsIter<Pool> = Box<
     dyn BestTransactions<Item = Arc<ValidPoolTransaction<<Pool as TransactionPool>::Transaction>>>,
@@ -319,12 +324,14 @@ where
 
     // Apply pre-execution changes (PoL, withdrawals, etc.)
     builder.apply_pre_execution_changes().map_err(|err| {
+        record_build_exit("pre_exec_failed");
         warn!(target: "sequencer::builder", %err, "failed to apply pre-execution changes");
         PayloadBuilderError::Internal(err.into())
     })?;
 
     // Check if Prague3 is active
     if chain_spec.is_prague3_active_at_timestamp(attributes.timestamp()) {
+        record_build_exit("prague3_rejected");
         return Err(PayloadBuilderError::Other(Box::from(
             "Prague 3 block building is not supported",
         )));
@@ -350,12 +357,17 @@ where
     let mut tracker = FlashblockExecutionTracker::new();
     let mut blob_sidecars = BlobSidecars::Empty;
     let mut flashblock_index = 0u64;
+    let mut last_emitted_cumulative_gas: u64 = 0;
     let mut last_flashblock_time = Instant::now();
     let interval = sequencer_config.interval;
     let build_start_time = Instant::now();
+    let metrics = FlashblockSequencerMetrics::default();
 
     // Helper to emit flashblock. Per BRIP-0007, no state root computation needed.
-    let emit = |flashblock_index: u64, tracker: &FlashblockExecutionTracker, is_last: bool| {
+    let emit = |flashblock_index: u64,
+                tracker: &FlashblockExecutionTracker,
+                interval_gas: u64,
+                is_last: bool| {
         emit_flashblock(
             &publisher,
             payload_id,
@@ -363,10 +375,12 @@ where
             &base,
             flashblock_index == 0,
             tracker,
+            interval_gas,
             block_number,
             &sequencer_config.signer,
             &withdrawals,
             is_last,
+            &metrics,
         );
     };
 
@@ -376,6 +390,7 @@ where
     // track the current state even when no transactions are being processed.
     loop {
         if payload_requested.load(Ordering::Relaxed) {
+            record_build_exit("payload_requested");
             info!(
                 target: "sequencer::builder",
                 id = %payload_id,
@@ -389,6 +404,7 @@ where
 
         // Check if deadline exceeded (--builder.deadline).
         if build_start_time.elapsed() >= deadline {
+            record_build_exit("deadline");
             info!(
                 target: "sequencer::builder",
                 id = %payload_id,
@@ -403,6 +419,7 @@ where
 
         // Check if gas limit reached (use a small buffer to account for minimum tx gas)
         if tracker.cumulative_gas_used + 21_000 > block_gas_limit {
+            record_build_exit("gas_limit");
             info!(
                 target: "sequencer::builder",
                 id = %payload_id,
@@ -417,8 +434,14 @@ where
 
         // Emit flashblock at regular intervals (may be empty, serving as heartbeat)
         if last_flashblock_time.elapsed() >= interval {
-            emit(flashblock_index, &tracker, false);
+            let actual = last_flashblock_time.elapsed();
+            let drift = actual.saturating_sub(interval);
+            let interval_gas =
+                tracker.cumulative_gas_used.saturating_sub(last_emitted_cumulative_gas);
+            metrics.interval_drift_seconds.record(drift.as_secs_f64());
+            emit(flashblock_index, &tracker, interval_gas, false);
             flashblock_index += 1;
+            last_emitted_cumulative_gas = tracker.cumulative_gas_used;
             tracker.clear_interval();
             last_flashblock_time = Instant::now();
         }
@@ -531,7 +554,9 @@ where
 
     // Always emit the final flashblock marked as last, even if empty.
     // This signals to RPC nodes that no more flashblocks will arrive for this payload.
-    emit(flashblock_index, &tracker, true);
+    let final_interval_gas =
+        tracker.cumulative_gas_used.saturating_sub(last_emitted_cumulative_gas);
+    emit(flashblock_index, &tracker, final_interval_gas, true);
 
     // Finalize the block
     let BlockBuilderOutcome { execution_result, block, .. } = builder.finish(&state_provider)?;
@@ -539,6 +564,8 @@ where
     let requests = chain_spec
         .is_prague_active_at_timestamp(attributes.timestamp())
         .then_some(execution_result.requests);
+
+    metrics.build_duration_seconds.record(build_start_time.elapsed().as_secs_f64());
 
     let sealed_block = Arc::new(block.sealed_block().clone());
     info!(
@@ -566,11 +593,15 @@ fn emit_flashblock(
     base: &BerachainFlashblockPayloadBase,
     include_base_in_payload: bool,
     tracker: &FlashblockExecutionTracker,
+    interval_gas: u64,
     block_number: u64,
     signer: &FlashblockSigner,
     withdrawals: &[Withdrawal],
     is_last: bool,
+    metrics: &FlashblockSequencerMetrics,
 ) {
+    metrics.gas_used_per_flashblock.record(interval_gas as f64);
+
     // Withdrawals are included in first flashblock only (index 0)
     let diff_withdrawals = if include_base_in_payload { withdrawals.to_vec() } else { vec![] };
 
@@ -582,7 +613,9 @@ fn emit_flashblock(
 
     // Sign over transactions hash
     let tx_hash = compute_transactions_hash(&tracker.interval_transactions);
+    let sign_start = Instant::now();
     let signature = signer.sign_flashblock(block_number, payload_id, index, tx_hash);
+    metrics.signing_duration_seconds.record(sign_start.elapsed().as_secs_f64());
 
     let flashblock = BerachainFlashblockPayload {
         payload_id,
@@ -594,8 +627,12 @@ fn emit_flashblock(
         is_last,
     };
 
+    record_emitted(is_last);
+    metrics.transactions_per_flashblock.record(tracker.interval_transactions.len() as f64);
+
     match publisher.publish(&flashblock) {
-        Ok(count) => {
+        Ok((count, bytes)) => {
+            metrics.payload_bytes.record(bytes as f64);
             debug!(
                 target: "sequencer::builder",
                 payload_id = %payload_id,
@@ -608,6 +645,7 @@ fn emit_flashblock(
             );
         }
         Err(e) => {
+            record_publish_error("serialize");
             warn!(
                 target: "sequencer::builder",
                 payload_id = %payload_id,

--- a/src/sequencer/metrics.rs
+++ b/src/sequencer/metrics.rs
@@ -1,0 +1,49 @@
+//! Metrics for the flashblock sequencer (producer side).
+//!
+//! Unlabeled metrics live in `FlashblockSequencerMetrics`. Labeled counters are
+//! emitted via the `record_*` helpers so call sites stay symbolic.
+
+use metrics::{Counter, Gauge, Histogram, counter};
+use reth_metrics::Metrics;
+
+#[derive(Clone, Metrics)]
+#[metrics(scope = "flashblock_sequencer")]
+pub(crate) struct FlashblockSequencerMetrics {
+    /// Full duration of `build_flashblock_payload` in seconds.
+    pub(crate) build_duration_seconds: Histogram,
+    /// Observed delta between configured interval and actual emission gap, in seconds.
+    /// Positive drift = emissions running behind schedule.
+    pub(crate) interval_drift_seconds: Histogram,
+    /// Transactions included in a single flashblock interval.
+    pub(crate) transactions_per_flashblock: Histogram,
+    /// Gas used in a single flashblock interval.
+    pub(crate) gas_used_per_flashblock: Histogram,
+    /// Size of serialized flashblock JSON payload in bytes.
+    pub(crate) payload_bytes: Histogram,
+    /// BLS signing duration in seconds.
+    pub(crate) signing_duration_seconds: Histogram,
+    /// Current WebSocket subscriber count (mirrors `WebSocketPublisher::subscriber_count`).
+    pub(crate) ws_subscribers: Gauge,
+    /// Total broadcast messages dropped by lagging WebSocket clients.
+    pub(crate) ws_client_lagged_total: Counter,
+}
+
+pub(crate) fn record_build_exit(reason: &'static str) {
+    counter!("flashblock_sequencer_build_exit_total", "reason" => reason).increment(1);
+}
+
+pub(crate) fn record_emitted(is_last: bool) {
+    let is_last = if is_last { "true" } else { "false" };
+    counter!("flashblock_sequencer_emitted_total", "is_last" => is_last).increment(1);
+}
+
+pub(crate) fn record_ws_connection(result: &'static str) {
+    counter!("flashblock_sequencer_ws_connections_total", "result" => result).increment(1);
+}
+
+/// Recorded when `WebSocketPublisher::publish` fails (currently only on
+/// serialization errors). Kept separate from `emitted_total` so the build path
+/// can be tracked independently of the publish path.
+pub(crate) fn record_publish_error(reason: &'static str) {
+    counter!("flashblock_sequencer_publish_error_total", "reason" => reason).increment(1);
+}

--- a/src/sequencer/mod.rs
+++ b/src/sequencer/mod.rs
@@ -4,8 +4,14 @@
 //! at regular intervals (~200ms) and publishes them via WebSocket.
 
 mod builder;
+mod metrics;
 mod publisher;
 pub mod signing;
+
+pub(crate) use metrics::{
+    FlashblockSequencerMetrics, record_build_exit, record_emitted, record_publish_error,
+    record_ws_connection,
+};
 
 pub use builder::{FlashblockPayloadBuilder, FlashblockPayloadServiceBuilder};
 pub use publisher::WebSocketPublisher;

--- a/src/sequencer/publisher.rs
+++ b/src/sequencer/publisher.rs
@@ -19,6 +19,8 @@ use tokio_tungstenite::{accept_async, tungstenite::Message};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 
+use crate::sequencer::{FlashblockSequencerMetrics, record_ws_connection};
+
 /// Capacity for the flashblock broadcast channel.
 const FLASHBLOCK_CHANNEL_CAPACITY: usize = 20;
 
@@ -34,13 +36,19 @@ pub struct WebSocketPublisher {
     sender: broadcast::Sender<String>,
     address: SocketAddr,
     subscriber_count: Arc<AtomicUsize>,
+    metrics: FlashblockSequencerMetrics,
 }
 
 impl WebSocketPublisher {
     /// Create a new WebSocket publisher.
     pub fn new(address: SocketAddr) -> Self {
         let (sender, _) = broadcast::channel(FLASHBLOCK_CHANNEL_CAPACITY);
-        Self { sender, address, subscriber_count: Arc::new(AtomicUsize::new(0)) }
+        Self {
+            sender,
+            address,
+            subscriber_count: Arc::new(AtomicUsize::new(0)),
+            metrics: FlashblockSequencerMetrics::default(),
+        }
     }
 
     /// Get the number of active subscribers.
@@ -54,9 +62,14 @@ impl WebSocketPublisher {
     }
 
     /// Publish a flashblock to all subscribers.
-    pub fn publish(&self, payload: &BerachainFlashblockPayload) -> io::Result<usize> {
+    ///
+    /// Returns `(subscribers, bytes)` where `subscribers` is the receiver count and
+    /// `bytes` is the length of the serialized JSON payload. Exposing the size lets
+    /// callers record the `payload_bytes` metric without re-serializing.
+    pub fn publish(&self, payload: &BerachainFlashblockPayload) -> io::Result<(usize, usize)> {
         let json = serde_json::to_string(payload)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        let bytes = json.len();
 
         match self.sender.send(json) {
             Ok(count) => {
@@ -67,11 +80,11 @@ impl WebSocketPublisher {
                     subscribers = count,
                     "published flashblock"
                 );
-                Ok(count)
+                Ok((count, bytes))
             }
             Err(_) => {
                 // No subscribers - this is fine
-                Ok(0)
+                Ok((0, bytes))
             }
         }
     }
@@ -99,19 +112,20 @@ impl WebSocketPublisher {
                     match result {
                         Ok((stream, addr)) => {
                             if self.subscriber_count.load(Ordering::Relaxed) >= MAX_CONNECTIONS {
+                                record_ws_connection("rejected_limit");
                                 warn!(target: "sequencer::publisher", %addr, "connection limit reached");
                                 continue;
                             }
                             let rx = self.sender.subscribe();
                             let count = self.subscriber_count.clone();
                             let conn_cancel = cancel.clone();
+                            let metrics = self.metrics.clone();
                             tokio::spawn(async move {
-                                if let Err(e) = handle_connection(stream, addr, rx, count, conn_cancel).await {
-                                    warn!(target: "sequencer::publisher", %addr, error = %e, "connection error");
-                                }
+                                handle_connection(stream, addr, rx, count, conn_cancel, metrics).await;
                             });
                         }
                         Err(e) => {
+                            record_ws_connection("accept_error");
                             error!(target: "sequencer::publisher", error = %e, "failed to accept connection");
                         }
                     }
@@ -129,10 +143,22 @@ async fn handle_connection(
     mut rx: broadcast::Receiver<String>,
     subscriber_count: Arc<AtomicUsize>,
     cancel: CancellationToken,
-) -> eyre::Result<()> {
-    let ws_stream = tokio::time::timeout(HANDSHAKE_TIMEOUT, accept_async(stream))
-        .await
-        .map_err(|_| eyre::eyre!("handshake timeout"))??;
+    metrics: FlashblockSequencerMetrics,
+) {
+    let ws_stream = match tokio::time::timeout(HANDSHAKE_TIMEOUT, accept_async(stream)).await {
+        Ok(Ok(s)) => s,
+        Ok(Err(e)) => {
+            record_ws_connection("handshake_error");
+            warn!(target: "sequencer::publisher", %addr, error = %e, "handshake failed");
+            return;
+        }
+        Err(_) => {
+            record_ws_connection("handshake_error");
+            warn!(target: "sequencer::publisher", %addr, "handshake timeout");
+            return;
+        }
+    };
+    record_ws_connection("accepted");
     let (mut write, mut read) = ws_stream.split();
 
     subscriber_count.fetch_add(1, Ordering::Relaxed);
@@ -142,6 +168,9 @@ async fn handle_connection(
         count = subscriber_count.load(Ordering::Relaxed),
         "client connected"
     );
+    metrics.ws_subscribers.set(subscriber_count.load(Ordering::Relaxed) as f64);
+
+    let mut session_error: Option<String> = None;
 
     // Handle incoming messages and broadcast outgoing flashblocks
     loop {
@@ -156,11 +185,13 @@ async fn handle_connection(
                 match result {
                     Ok(json) => {
                         if let Err(e) = write.send(Message::Text(json.into())).await {
+                            session_error = Some(format!("send failed: {e}"));
                             debug!(target: "sequencer::publisher", %addr, error = %e, "failed to send message");
                             break;
                         }
                     }
                     Err(broadcast::error::RecvError::Lagged(n)) => {
+                        metrics.ws_client_lagged_total.increment(n);
                         warn!(target: "sequencer::publisher", %addr, skipped = n, "client lagging");
                     }
                     Err(broadcast::error::RecvError::Closed) => {
@@ -173,6 +204,7 @@ async fn handle_connection(
                 match msg {
                     Some(Ok(Message::Ping(data))) => {
                         if let Err(e) = write.send(Message::Pong(data)).await {
+                            session_error = Some(format!("pong failed: {e}"));
                             debug!(target: "sequencer::publisher", %addr, error = %e, "failed to send pong");
                             break;
                         }
@@ -181,6 +213,7 @@ async fn handle_connection(
                         break;
                     }
                     Some(Err(e)) => {
+                        session_error = Some(format!("ws error: {e}"));
                         debug!(target: "sequencer::publisher", %addr, error = %e, "websocket error");
                         break;
                     }
@@ -190,6 +223,11 @@ async fn handle_connection(
         }
     }
 
+    if let Some(err) = session_error {
+        record_ws_connection("closed_error");
+        warn!(target: "sequencer::publisher", %addr, %err, "connection error");
+    }
+
     subscriber_count.fetch_sub(1, Ordering::Relaxed);
     info!(
         target: "sequencer::publisher",
@@ -197,6 +235,5 @@ async fn handle_connection(
         count = subscriber_count.load(Ordering::Relaxed),
         "client disconnected"
     );
-
-    Ok(())
+    metrics.ws_subscribers.set(subscriber_count.load(Ordering::Relaxed) as f64);
 }


### PR DESCRIPTION
Adds Prometheus metrics covering the preconf pipeline.

Sequencer (producer side):
- Build pipeline: `build_duration_seconds`, `interval_drift_seconds`, `build_exit_total{reason}`, `signing_duration_seconds`
- Per-flashblock: `transactions_per_flashblock`, `gas_used_per_flashblock`, `payload_bytes`, `emitted_total{is_last}`
- WebSocket publisher: `ws_subscribers`, `ws_connections_total{result}`, `ws_client_lagged_total`

Flashblock consumer (RPC side):
- Stream health: `upstream_connected`, `ws_reconnects_total`
- Ingestion: `insert_total{result}`, `build_skip_total{reason}`

RPC:
- `preconf_rpc_state_lookup_total{result}`: preconf state queries classified by outcome (hit, idle, misconfig, stale, etc.)
