### PR TITLE
fix(rpc): adjust deposit contract address returned by eth_config

### DIFF
--- a/src/chainspec/mod.rs
+++ b/src/chainspec/mod.rs
@@ -812,9 +812,12 @@ mod tests {
     use reth_chainspec::ForkHash;
 
     #[test]
-    fn test_deposit_contract_default_regression() {
-        let chain_spec = BerachainChainSpec::default();
-        assert!(chain_spec.deposit_contract().is_none());
+    fn test_builtin_genesis_deposit_contract() {
+        let expected = address!("4242424242424242424242424242424242424242");
+        let mainnet = BerachainChainSpecParser::parse(BERACHAIN_MAINNET).unwrap();
+        let bepolia = BerachainChainSpecParser::parse(BERACHAIN_BEPOLIA).unwrap();
+        assert_eq!(mainnet.deposit_contract().map(|c| c.address), Some(expected));
+        assert_eq!(bepolia.deposit_contract().map(|c| c.address), Some(expected));
     }
 
     #[test]

--- a/tests/fixtures/bepolia-genesis.json
+++ b/tests/fixtures/bepolia-genesis.json
@@ -68,6 +68,7 @@
     "constantinopleBlock": 0,
     "daoForkBlock": 0,
     "daoForkSupport": true,
+    "depositContractAddress": "0x4242424242424242424242424242424242424242",
     "eip150Block": 0,
     "eip155Block": 0,
     "eip158Block": 0,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test suite to validate deposit contract configurations are properly included in mainnet and bepolia genesis fixtures.

* **Chores**
  * Updated genesis configuration files to include deposit contract address specifications for mainnet and bepolia networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->