### PR TITLE
fix(engine): replace getPayloadV5 panic with UnsupportedFork

### DIFF
--- a/src/engine/payload.rs
+++ b/src/engine/payload.rs
@@ -288,9 +288,11 @@ impl TryFrom<BerachainBuiltPayload> for BerachainExecutionPayloadEnvelopeV4 {
     }
 }
 
-impl From<BerachainBuiltPayload> for ExecutionPayloadEnvelopeV5 {
-    fn from(_value: BerachainBuiltPayload) -> Self {
-        panic!("ExecutionPayloadV5 conversion not yet supported for Berachain")
+impl TryFrom<BerachainBuiltPayload> for ExecutionPayloadEnvelopeV5 {
+    type Error = BuiltPayloadConversionError;
+
+    fn try_from(_value: BerachainBuiltPayload) -> Result<Self, Self::Error> {
+        Err(BuiltPayloadConversionError::UnexpectedEip4844Sidecars)
     }
 }
 
@@ -542,5 +544,33 @@ mod tests {
             envelope.execution_requests.is_empty(),
             "execution_requests must default to empty when payload has no requests"
         );
+    }
+
+    #[test]
+    fn test_try_into_v5_returns_error_not_panic() {
+        let header = BerachainHeader {
+            prev_proposer_pubkey: None,
+            blob_gas_used: Some(0),
+            excess_blob_gas: Some(0),
+            ..Default::default()
+        };
+        let block = alloy_consensus::Block {
+            header,
+            body: alloy_consensus::BlockBody {
+                transactions: vec![],
+                ommers: vec![],
+                withdrawals: None,
+            },
+        };
+        let sealed = SealedBlock::new_unhashed(block);
+        let payload = BerachainBuiltPayload::new(
+            PayloadId::new([3; 8]),
+            std::sync::Arc::new(sealed),
+            U256::ZERO,
+            None,
+        );
+
+        let result: Result<ExecutionPayloadEnvelopeV5, _> = payload.try_into();
+        assert!(result.is_err(), "V5 conversion must return an error, never panic");
     }
 }

--- a/src/engine/payload.rs
+++ b/src/engine/payload.rs
@@ -581,7 +581,11 @@ mod tests {
             None,
         );
 
-        let result: Result<ExecutionPayloadEnvelopeV5, _> = payload.try_into();
-        assert!(result.is_err(), "V5 conversion must return an error, never panic");
+        let result: Result<ExecutionPayloadEnvelopeV5, UnsupportedPayloadEnvelopeV5> =
+            payload.try_into();
+        assert!(
+            matches!(result, Err(UnsupportedPayloadEnvelopeV5)),
+            "V5 conversion must return UnsupportedPayloadEnvelopeV5, never panic"
+        );
     }
 }

--- a/src/engine/payload.rs
+++ b/src/engine/payload.rs
@@ -288,11 +288,22 @@ impl TryFrom<BerachainBuiltPayload> for BerachainExecutionPayloadEnvelopeV4 {
     }
 }
 
+/// Error returned when a [`BerachainBuiltPayload`] is converted into an
+/// [`ExecutionPayloadEnvelopeV5`].
+///
+/// Berachain serves the Osaka payload via `engine_getPayloadV4P11`, so the V5
+/// envelope is never produced. The trait bound on [`reth_engine_primitives::EngineTypes`]
+/// requires the conversion to exist; this error makes the unsupported case
+/// explicit instead of panicking.
+#[derive(Debug, thiserror::Error)]
+#[error("ExecutionPayloadEnvelopeV5 is not supported on Berachain; use engine_getPayloadV4P11")]
+pub struct UnsupportedPayloadEnvelopeV5;
+
 impl TryFrom<BerachainBuiltPayload> for ExecutionPayloadEnvelopeV5 {
-    type Error = BuiltPayloadConversionError;
+    type Error = UnsupportedPayloadEnvelopeV5;
 
     fn try_from(_value: BerachainBuiltPayload) -> Result<Self, Self::Error> {
-        Err(BuiltPayloadConversionError::UnexpectedEip4844Sidecars)
+        Err(UnsupportedPayloadEnvelopeV5)
     }
 }
 

--- a/src/engine/rpc.rs
+++ b/src/engine/rpc.rs
@@ -46,6 +46,13 @@ pub struct BerachainEngineApiBuilder<EV> {
 pub const BERACHAIN_ADDITIONAL_CAPABILITIES: &[&str] =
     &["engine_newPayloadV4P11", "engine_forkchoiceUpdatedV3P11", "engine_getPayloadV4P11"];
 
+/// Capabilities inherited from upstream Reth that Berachain does not support.
+///
+/// Berachain serves the Osaka payload via `engine_getPayloadV4P11`, so the V5
+/// method is implemented but never advertised, and any direct call returns
+/// `UnsupportedFork`.
+pub const BERACHAIN_REMOVED_CAPABILITIES: &[&str] = &["engine_getPayloadV5"];
+
 impl<N, EV> EngineApiBuilder<N> for BerachainEngineApiBuilder<EV>
 where
     N: FullNodeComponents<
@@ -585,10 +592,13 @@ where
 
     async fn get_payload_v5(
         &self,
-        payload_id: PayloadId,
+        _payload_id: PayloadId,
     ) -> RpcResult<EngineT::ExecutionPayloadEnvelopeV5> {
         trace!(target: "rpc::engine", "Serving engine_getPayloadV5");
-        Ok(self.inner.get_payload_v5_metered(payload_id).await?)
+        Err(EngineApiError::EngineObjectValidationError(
+            EngineObjectValidationError::UnsupportedFork,
+        )
+        .into())
     }
 
     async fn get_payload_bodies_by_hash_v1(
@@ -618,6 +628,7 @@ where
 
     async fn exchange_capabilities(&self, _capabilities: Vec<String>) -> RpcResult<Vec<String>> {
         let mut caps = self.inner.capabilities().list();
+        caps.retain(|c| !BERACHAIN_REMOVED_CAPABILITIES.contains(&c.as_str()));
         for &cap in BERACHAIN_ADDITIONAL_CAPABILITIES {
             let s = cap.to_string();
             if !caps.contains(&s) {


### PR DESCRIPTION
Berachain serves the Osaka payload via engine_getPayloadV4P11; V5 was
inherited from upstream Reth but the BerachainBuiltPayload conversion
panicked, and the V5 capability was still advertised through
exchangeCapabilities. The handler now returns -38005 UnsupportedFork
directly (so the conversion is never reached), the From impl is replaced
by a TryFrom that returns an error, and V5 is filtered from the
advertised capability list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Payload conversion now returns a clear unsupported-payload error for the V5 path instead of causing a panic.

* **Chores**
  * Removed advertising of V5 payload engine support; V5 payload requests will be rejected with an unsupported-fork error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->