### PR TITLE
chore: merge main into preconf-dev 

### DIFF
--- a/.github/assets/hive/build_simulators.sh
+++ b/.github/assets/hive/build_simulators.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Synced with reth v1.11.3
+# Synced with reth v1.11.4
 set -eo pipefail
 
 # Create the hive_assets directory

--- a/.github/assets/hive/expected_failures.yaml
+++ b/.github/assets/hive/expected_failures.yaml
@@ -1,4 +1,4 @@
-# Synced with reth v1.11.3
+# Synced with reth v1.11.4
 # tracked by https://github.com/paradigmxyz/reth/issues/13879
 rpc-compat:
   - debug_getRawBlock/get-invalid-number (bera-reth)

--- a/.github/assets/hive/ignored_tests.yaml
+++ b/.github/assets/hive/ignored_tests.yaml
@@ -1,4 +1,4 @@
-# Synced with reth v1.11.3
+# Synced with reth v1.11.4
 # Ignored Tests Configuration
 #
 # This file contains tests that should be ignored for various reasons (flaky, known issues, etc).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6563,7 +6563,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types",
@@ -6603,7 +6603,7 @@ dependencies = [
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6627,7 +6627,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6659,7 +6659,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -6679,7 +6679,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -6693,7 +6693,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -6773,7 +6773,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -6783,7 +6783,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6801,7 +6801,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6821,7 +6821,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6831,7 +6831,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -6847,7 +6847,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -6860,7 +6860,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6872,7 +6872,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6898,7 +6898,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -6925,7 +6925,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -6954,7 +6954,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -6984,7 +6984,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6999,7 +6999,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7024,7 +7024,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7048,7 +7048,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -7072,7 +7072,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7107,7 +7107,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7165,7 +7165,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -7193,7 +7193,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7216,7 +7216,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7241,7 +7241,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-service"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "futures",
  "pin-project",
@@ -7263,7 +7263,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -7320,7 +7320,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -7348,7 +7348,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7363,7 +7363,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -7379,7 +7379,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7401,7 +7401,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -7412,7 +7412,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -7440,7 +7440,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7461,7 +7461,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "clap",
  "eyre",
@@ -7484,7 +7484,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7500,7 +7500,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7518,7 +7518,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -7531,7 +7531,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7560,7 +7560,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7580,7 +7580,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -7590,7 +7590,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7614,7 +7614,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7636,7 +7636,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -7649,7 +7649,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7667,7 +7667,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7705,7 +7705,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7719,7 +7719,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "serde",
  "serde_json",
@@ -7729,7 +7729,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7757,7 +7757,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "bytes",
  "futures",
@@ -7777,7 +7777,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "bitflags 2.10.0",
  "byteorder",
@@ -7793,7 +7793,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "bindgen",
  "cc",
@@ -7802,7 +7802,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "futures",
  "metrics",
@@ -7814,7 +7814,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -7823,7 +7823,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -7837,7 +7837,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7894,7 +7894,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7919,7 +7919,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7942,7 +7942,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7957,7 +7957,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -7971,7 +7971,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -7988,7 +7988,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -8012,7 +8012,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8081,7 +8081,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8136,7 +8136,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -8174,7 +8174,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8198,7 +8198,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8222,7 +8222,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "bytes",
  "eyre",
@@ -8246,7 +8246,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -8258,7 +8258,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8279,7 +8279,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -8291,7 +8291,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8314,7 +8314,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8324,7 +8324,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8338,7 +8338,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8372,7 +8372,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8417,7 +8417,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8446,7 +8446,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -8462,7 +8462,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -8475,7 +8475,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -8552,7 +8552,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-eip7928",
  "alloy-eips",
@@ -8582,7 +8582,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -8623,7 +8623,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -8644,7 +8644,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8674,7 +8674,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -8718,7 +8718,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8766,7 +8766,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -8780,7 +8780,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8796,7 +8796,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8846,7 +8846,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8873,7 +8873,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -8887,7 +8887,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -8907,7 +8907,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -8922,7 +8922,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8946,7 +8946,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8963,7 +8963,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -8981,7 +8981,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8997,7 +8997,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -9007,7 +9007,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "clap",
  "eyre",
@@ -9024,7 +9024,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "clap",
  "eyre",
@@ -9042,7 +9042,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9086,7 +9086,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9112,7 +9112,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9139,7 +9139,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -9159,7 +9159,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9184,7 +9184,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9203,7 +9203,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.4#2ac58a25f561827e2b816a3c1ed972194f3b2915"
 dependencies = [
  "zstd",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1475,6 +1475,7 @@ dependencies = [
  "jsonrpsee",
  "jsonrpsee-core",
  "jsonrpsee-proc-macros",
+ "metrics",
  "modular-bitfield",
  "reth",
  "reth-basic-payload-builder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1449,7 +1449,7 @@ checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
 name = "bera-reth"
-version = "1.3.3"
+version = "1.4.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1495,7 +1495,6 @@ dependencies = [
  "reth-chain-state",
  "reth-chainspec",
  "reth-cli",
- "reth-cli-commands",
  "reth-cli-util",
  "reth-codecs",
  "reth-consensus-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bera-reth"
-version = "1.3.3"
+version = "1.4.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,6 @@ reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag 
 reth-chain-state = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.4" }
 reth-chainspec = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.4" }
 reth-cli = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.4" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.4" }
 reth-cli-util = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.4" }
 reth-codecs = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.4" }
 reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.4" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,40 +32,40 @@ jsonrpsee-proc-macros = "0.26.0"
 async-trait = "0.1.88"
 metrics = "0.24.3"
 modular-bitfield = "0.13.1"
-reth = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
-reth-codecs = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
-reth-ethereum-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
-reth-payload-validator = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
-reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
-reth-rpc-engine-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
+reth = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.4" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.4" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.4" }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.4" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.4" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.4" }
+reth-codecs = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.4" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.4" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.4" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.4" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.4" }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.4" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.4" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.4" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.4" }
+reth-ethereum-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.4" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.4" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.4" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.4" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.4" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.4" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.4" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.4" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.4" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.4" }
+reth-payload-validator = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.4" }
+reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.4" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.4" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.4" }
+reth-rpc-engine-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.4" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.4" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.4" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.4" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.4" }
 serde = { version = "1.0", features = ["derive"], default-features = false }
 serde_json = "1.0"
 thiserror = "2.0"
@@ -77,9 +77,9 @@ alloy-provider = "1.6.3"
 alloy-rpc-client = "1.6.3"
 alloy-rpc-types-trace = "1.6.3"
 eyre = "0.6.12"
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.4" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.4" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.4" }
 revm-inspectors = "0.34.2"
 test-fuzz = "7"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ jsonrpsee-core = { version = "0.26.0", features = ["server"] }
 jsonrpsee-proc-macros = "0.26.0"
 
 async-trait = "0.1.88"
+metrics = "0.24.3"
 modular-bitfield = "0.13.1"
 reth = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
 reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }

--- a/deny.toml
+++ b/deny.toml
@@ -73,6 +73,10 @@ ignore = [
   "RUSTSEC-2025-0141",
   # https://rustsec.org/advisories/RUSTSEC-2026-0105 core2 is unmaintained (all versions yanked), no safe upgrade available; transitive dep via ssz/multiaddr
   "RUSTSEC-2026-0105",
+  # https://rustsec.org/advisories/RUSTSEC-2026-0118 hickory-proto NSEC3 unbounded loop; transitive dep via reth-dns-discovery, awaiting upstream bump to >=0.26.1
+  "RUSTSEC-2026-0118",
+  # https://rustsec.org/advisories/RUSTSEC-2026-0119 hickory-proto O(n^2) name compression; transitive dep via reth-dns-discovery, awaiting upstream bump to >=0.26.1
+  "RUSTSEC-2026-0119",
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.

--- a/src/chainspec/mod.rs
+++ b/src/chainspec/mod.rs
@@ -1,6 +1,7 @@
 //! Berachain chain specification with Ethereum hardforks plus Prague1 minimum base fee
 
 use crate::{
+    deposits::DEPOSIT_EVENT_SIGNATURE,
     genesis::{BerachainGenesisConfig, Prague3Config, Prague4Config},
     hardforks::{BerachainHardfork, BerachainHardforks},
     primitives::{BerachainHeader, header::BlsPublicKey},
@@ -19,7 +20,7 @@ use reth::{
         EthereumHardforks, ForkCondition, Hardfork, NamedChain::BerachainBepolia,
     },
     primitives::SealedHeader,
-    revm::primitives::{Address, B256, U256, b256},
+    revm::primitives::{Address, B256, U256},
 };
 use reth_chainspec::{
     ChainSpec, DepositContract, EthChainSpec, Hardforks, MAINNET_PRUNE_DELETE_LIMIT,
@@ -725,14 +726,10 @@ impl From<Genesis> for BerachainChainSpec {
         // have the deployment block in the genesis file, so we use block zero. We use the same
         // deposit topic as the mainnet contract if we have the deposit contract address in the
         // genesis json.
-        let deposit_contract =
-            genesis.config.deposit_contract_address.map(|address| DepositContract {
-                address,
-                block: 0,
-                // This value is copied from Reth mainnet. Berachain's deposit contract topic is
-                // different but also unused.
-                topic: b256!("0x649bbc62d0e31342afea4e5cd82d4049e7e1ee912fc0889aa790803be39038c5"),
-            });
+        let deposit_contract = genesis
+            .config
+            .deposit_contract_address
+            .map(|address| DepositContract { address, block: 0, topic: DEPOSIT_EVENT_SIGNATURE });
 
         let hardforks = ChainHardforks::new(hardforks);
 

--- a/src/chainspec/mod.rs
+++ b/src/chainspec/mod.rs
@@ -2184,7 +2184,7 @@ mod tests {
         assert_eq!(fork_id_before_prague.next, 1746633600, "next fork should be Prague");
         assert_eq!(fork_id_prague.next, 1754496000, "next fork should be Prague1");
         assert_eq!(fork_id_prague1.next, 1758124800, "next fork should be Prague2");
-        assert_eq!(fork_id_prague2.next, 9999999999999999, "next fork should be Osaka");
+        assert_eq!(fork_id_prague2.next, 1779897600, "next fork should be Osaka");
 
         // Expected fork hash values for Bepolia (matching bera-geth test values)
         assert_eq!(fork_id_before_prague.hash, ForkHash([0xae, 0x79, 0x53, 0x0c]));
@@ -2357,7 +2357,7 @@ mod tests {
         assert_eq!(latest_fork_id.next, 0, "latest fork should have no next fork");
 
         // Verify this matches the final Osaka state.
-        assert_eq!(latest_fork_id.hash, ForkHash([0x4b, 0xd5, 0x84, 0x03]));
+        assert_eq!(latest_fork_id.hash, ForkHash([0x79, 0x16, 0x74, 0x96]));
     }
 
     #[test]

--- a/src/chainspec/mod.rs
+++ b/src/chainspec/mod.rs
@@ -812,9 +812,12 @@ mod tests {
     use reth_chainspec::ForkHash;
 
     #[test]
-    fn test_deposit_contract_default_regression() {
-        let chain_spec = BerachainChainSpec::default();
-        assert!(chain_spec.deposit_contract().is_none());
+    fn test_builtin_genesis_deposit_contract() {
+        let expected = address!("4242424242424242424242424242424242424242");
+        let mainnet = BerachainChainSpecParser::parse(BERACHAIN_MAINNET).unwrap();
+        let bepolia = BerachainChainSpecParser::parse(BERACHAIN_BEPOLIA).unwrap();
+        assert_eq!(mainnet.deposit_contract().map(|c| c.address), Some(expected));
+        assert_eq!(bepolia.deposit_contract().map(|c| c.address), Some(expected));
     }
 
     #[test]

--- a/src/chainspec/mod.rs
+++ b/src/chainspec/mod.rs
@@ -2157,7 +2157,7 @@ mod tests {
             timestamp: 1754496000,
         };
 
-        // After Prague2
+        // After Prague2, before Osaka
         let head_prague2_active = Head {
             number: 100,
             hash: B256::ZERO,
@@ -2187,7 +2187,7 @@ mod tests {
         assert_eq!(fork_id_before_prague.next, 1746633600, "next fork should be Prague");
         assert_eq!(fork_id_prague.next, 1754496000, "next fork should be Prague1");
         assert_eq!(fork_id_prague1.next, 1758124800, "next fork should be Prague2");
-        assert_eq!(fork_id_prague2.next, 0, "no next fork after Prague2");
+        assert_eq!(fork_id_prague2.next, 9999999999999999, "next fork should be Osaka");
 
         // Expected fork hash values for Bepolia (matching bera-geth test values)
         assert_eq!(fork_id_before_prague.hash, ForkHash([0xae, 0x79, 0x53, 0x0c]));
@@ -2263,7 +2263,7 @@ mod tests {
             timestamp: 1762164459,
         };
 
-        // Prague4 active
+        // Prague4 active, before Osaka
         let head_prague4_active = Head {
             number: 100,
             hash: B256::ZERO,
@@ -2272,13 +2272,13 @@ mod tests {
             timestamp: 1762963200,
         };
 
-        // Far future
+        // After all configured forks, including Osaka
         let head_far_future = Head {
             number: 1000,
             hash: B256::ZERO,
             difficulty: Default::default(),
             total_difficulty: Default::default(),
-            timestamp: 2000000000,
+            timestamp: 10000000000000000,
         };
 
         // Calculate fork IDs
@@ -2318,7 +2318,7 @@ mod tests {
         assert_eq!(fork_id_prague1.next, 1759248000, "next fork should be Prague2");
         assert_eq!(fork_id_prague2.next, 1762164459, "next fork should be Prague3");
         assert_eq!(fork_id_prague3.next, 1762963200, "next fork should be Prague4");
-        assert_eq!(fork_id_prague4.next, 0, "no next fork after Prague4");
+        assert_eq!(fork_id_prague4.next, 9999999999999999, "next fork should be Osaka");
         assert_eq!(fork_id_future.next, 0, "no next fork in far future");
 
         // Expected fork hash values for mainnet (matching bera-geth test values)
@@ -2329,7 +2329,7 @@ mod tests {
         assert_eq!(fork_id_prague2.hash, ForkHash([0xcb, 0xbf, 0x6c, 0x9f]));
         assert_eq!(fork_id_prague3.hash, ForkHash([0x64, 0x94, 0xa1, 0x76]));
         assert_eq!(fork_id_prague4.hash, ForkHash([0x70, 0x1a, 0x09, 0x7f]));
-        assert_eq!(fork_id_future.hash, ForkHash([0x70, 0x1a, 0x09, 0x7f]));
+        assert_eq!(fork_id_future.hash, ForkHash([0x96, 0xd1, 0x6c, 0xa7]));
     }
 
     #[test]
@@ -2343,13 +2343,13 @@ mod tests {
 
         let latest_fork_id = spec.latest_fork_id();
 
-        // Create a head far in the future (after all Prague2 activation at 1758124800)
+        // Create a head after all configured Bepolia forks, including Osaka.
         let head_final = Head {
             number: 100,
             hash: B256::ZERO,
             difficulty: Default::default(),
             total_difficulty: Default::default(),
-            timestamp: 2000000000, // Far future
+            timestamp: 10000000000000000,
         };
         let current_fork_id = spec.fork_id(&head_final);
 
@@ -2359,8 +2359,8 @@ mod tests {
         );
         assert_eq!(latest_fork_id.next, 0, "latest fork should have no next fork");
 
-        // Verify this matches the final Prague2 state from bera-geth test
-        assert_eq!(latest_fork_id.hash, ForkHash([0x2e, 0xdd, 0x8d, 0x57]));
+        // Verify this matches the final Osaka state.
+        assert_eq!(latest_fork_id.hash, ForkHash([0x4b, 0xd5, 0x84, 0x03]));
     }
 
     #[test]

--- a/src/consensus/mod.rs
+++ b/src/consensus/mod.rs
@@ -260,7 +260,19 @@ impl HeaderValidator<BerachainHeader> for BerachainBeaconConsensus {
         <EthBeaconConsensus<BerachainChainSpec> as HeaderValidator<BerachainHeader>>::validate_header(
             &self.inner,
             header,
+        )?;
+
+        // Enforce the Prague1 fork gate on `prev_proposer_pubkey` here so the import path
+        // matches the Engine API and executor. Without this, peer-imported headers could
+        // bypass the invariant and only get caught later at execution time.
+        crate::engine::validate_proposer_pubkey_prague1(
+            &*self.chain_spec,
+            header.timestamp(),
+            header.prev_proposer_pubkey,
         )
+        .map_err(|err| ConsensusError::Other(err.to_string()))?;
+
+        Ok(())
     }
 
     fn validate_header_against_parent(
@@ -397,5 +409,84 @@ mod tests {
             result.is_ok(),
             "Pre-Prague1 block with normal transactions should pass validation"
         );
+    }
+
+    /// Build a header that satisfies upstream `EthBeaconConsensus::validate_header`
+    /// for the given timestamp on the bepolia chainspec, so any failure in
+    /// `BerachainBeaconConsensus::validate_header` is attributable to the
+    /// Berachain-specific gate.
+    fn upstream_valid_header(timestamp: u64, post_prague: bool) -> BerachainHeader {
+        BerachainHeader {
+            number: 1,
+            timestamp,
+            difficulty: U256::ZERO,
+            nonce: Default::default(),
+            ommers_hash: EMPTY_OMMER_ROOT_HASH,
+            gas_limit: 30_000_000,
+            gas_used: 0,
+            base_fee_per_gas: Some(1_000_000_000),
+            withdrawals_root: Some(EMPTY_WITHDRAWALS),
+            blob_gas_used: Some(0),
+            excess_blob_gas: Some(0),
+            parent_beacon_block_root: Some(BlockHash::ZERO),
+            requests_hash: post_prague.then_some(BlockHash::ZERO),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_validate_header_rejects_pre_prague1_proposer_pubkey() {
+        let chain_spec = bepolia_chainspec();
+        let consensus = BerachainBeaconConsensus::new(chain_spec.clone());
+
+        let mut header = upstream_valid_header(0, false);
+        header.prev_proposer_pubkey = Some(mock_bls_pubkey());
+
+        assert!(!chain_spec.is_prague1_active_at_timestamp(header.timestamp));
+
+        let sealed = SealedHeader::new(header, BlockHash::ZERO);
+        let err = consensus.validate_header(&sealed).expect_err(
+            "pre-Prague1 header with prev_proposer_pubkey must be rejected by validate_header",
+        );
+        assert!(
+            err.to_string().contains("not allowed"),
+            "expected ProposerPubkeyNotAllowed, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_validate_header_rejects_post_prague1_missing_proposer_pubkey() {
+        let chain_spec = bepolia_chainspec();
+        let consensus = BerachainBeaconConsensus::new(chain_spec.clone());
+
+        // Bepolia activates Prague1 at 1_754_496_000; pick a timestamp safely past it.
+        let timestamp = 1_754_496_000;
+        let mut header = upstream_valid_header(timestamp, true);
+        header.prev_proposer_pubkey = None;
+
+        assert!(chain_spec.is_prague1_active_at_timestamp(header.timestamp));
+
+        let sealed = SealedHeader::new(header, BlockHash::ZERO);
+        let err = consensus.validate_header(&sealed).expect_err(
+            "post-Prague1 header missing prev_proposer_pubkey must be rejected by validate_header",
+        );
+        assert!(
+            err.to_string().contains("Previous proposer public key is required"),
+            "expected MissingProposerPubkey, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_validate_header_accepts_pre_prague1_no_proposer_pubkey() {
+        let chain_spec = bepolia_chainspec();
+        let consensus = BerachainBeaconConsensus::new(chain_spec.clone());
+
+        let header = upstream_valid_header(0, false);
+        assert!(header.prev_proposer_pubkey.is_none());
+
+        let sealed = SealedHeader::new(header, BlockHash::ZERO);
+        consensus
+            .validate_header(&sealed)
+            .expect("pre-Prague1 header without prev_proposer_pubkey should validate");
     }
 }

--- a/src/deposits.rs
+++ b/src/deposits.rs
@@ -1,0 +1,78 @@
+// Berachain uses a custom deposit contract with a different event signature than
+// the standard EIP-6110 deposit contract. This module replaces the default
+// reth_evm::eth::eip6110 deposit parsing while preserving the same
+// EIP-6110 convention: deposits are parsed from transaction logs and included
+// directly as deposit requests in the execution payload's requests list
+// (request type 0x00 per EIP-6110).
+use alloy_consensus::TxReceipt;
+use alloy_primitives::{Address, B256, Bytes, Log, b256};
+use alloy_sol_types::{SolEvent, sol};
+use reth_evm::block::BlockValidationError;
+
+sol! {
+    event Deposit(
+        bytes pubkey,
+        bytes credentials,
+        uint64 amount,
+        bytes signature,
+        uint64 index
+    );
+}
+
+/// keccak256("Deposit(bytes,bytes,uint64,bytes,uint64)")
+///
+/// Berachain uses a 5-field Deposit event that differs from Ethereum mainnet's
+/// deposit contract. This constant must stay in sync with the `sol!` definition
+/// above; see the `deposit_event_signature_matches_sol_type` test.
+pub const DEPOSIT_EVENT_SIGNATURE: B256 =
+    b256!("68af751683498a9f9be59fe8b0d52a64dd155255d85cdb29fea30b1e3f891d46");
+
+const DEPOSIT_BYTES_SIZE: usize = 48 + 32 + 8 + 96 + 8;
+
+fn accumulate_deposit_from_log(log: &Log<Deposit>, out: &mut Vec<u8>) {
+    out.reserve(DEPOSIT_BYTES_SIZE);
+    out.extend_from_slice(log.pubkey.as_ref());
+    out.extend_from_slice(log.credentials.as_ref());
+    out.extend_from_slice(&log.amount.to_le_bytes());
+    out.extend_from_slice(log.signature.as_ref());
+    out.extend_from_slice(&log.index.to_le_bytes());
+}
+
+pub fn parse_deposits_from_receipts<'a, I, R>(
+    address: Address,
+    receipts: I,
+) -> Result<Bytes, BlockValidationError>
+where
+    I: IntoIterator<Item = &'a R>,
+    R: TxReceipt<Log = Log> + 'a,
+{
+    let mut out = Vec::new();
+    for receipt in receipts {
+        for log in receipt.logs() {
+            if log.address != address {
+                continue;
+            }
+            if log.topics().first() != Some(&Deposit::SIGNATURE_HASH) {
+                continue;
+            }
+            let decoded = Deposit::decode_log(log)
+                .map_err(|err| BlockValidationError::DepositRequestDecode(err.to_string()))?;
+            accumulate_deposit_from_log(&decoded, &mut out);
+        }
+    }
+    Ok(out.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deposit_event_signature_matches_sol_type() {
+        assert_eq!(
+            DEPOSIT_EVENT_SIGNATURE,
+            Deposit::SIGNATURE_HASH,
+            "DEPOSIT_EVENT_SIGNATURE must match the keccak256 of the sol! Deposit event"
+        );
+    }
+}

--- a/src/engine/builder.rs
+++ b/src/engine/builder.rs
@@ -320,6 +320,8 @@ where
                 continue;
             }
 
+            // BRIP-0010 Osaka does not adopt EIP-7594 (PeerDAS); EIP-4844 sidecars remain the
+            // sole accepted format across forks.
             let blob_sidecar_result = 'sidecar: {
                 let Some(sidecar) =
                     pool.get_blob(*tx.hash()).map_err(PayloadBuilderError::other)?
@@ -327,16 +329,10 @@ where
                     break 'sidecar Err(Eip4844PoolTransactionError::MissingEip4844BlobSidecar);
                 };
 
-                if is_osaka {
-                    if sidecar.is_eip7594() {
-                        Ok(sidecar)
-                    } else {
-                        Err(Eip4844PoolTransactionError::UnexpectedEip4844SidecarAfterOsaka)
-                    }
-                } else if sidecar.is_eip4844() {
+                if sidecar.is_eip4844() {
                     Ok(sidecar)
                 } else {
-                    Err(Eip4844PoolTransactionError::UnexpectedEip7594SidecarBeforeOsaka)
+                    Err(Eip4844PoolTransactionError::Eip7594SidecarDisallowed)
                 }
             };
 

--- a/src/engine/payload.rs
+++ b/src/engine/payload.rs
@@ -288,9 +288,22 @@ impl TryFrom<BerachainBuiltPayload> for BerachainExecutionPayloadEnvelopeV4 {
     }
 }
 
-impl From<BerachainBuiltPayload> for ExecutionPayloadEnvelopeV5 {
-    fn from(_value: BerachainBuiltPayload) -> Self {
-        panic!("ExecutionPayloadV5 conversion not yet supported for Berachain")
+/// Error returned when a [`BerachainBuiltPayload`] is converted into an
+/// [`ExecutionPayloadEnvelopeV5`].
+///
+/// Berachain serves the Osaka payload via `engine_getPayloadV4P11`, so the V5
+/// envelope is never produced. The trait bound on [`reth_engine_primitives::EngineTypes`]
+/// requires the conversion to exist; this error makes the unsupported case
+/// explicit instead of panicking.
+#[derive(Debug, thiserror::Error)]
+#[error("ExecutionPayloadEnvelopeV5 is not supported on Berachain; use engine_getPayloadV4P11")]
+pub struct UnsupportedPayloadEnvelopeV5;
+
+impl TryFrom<BerachainBuiltPayload> for ExecutionPayloadEnvelopeV5 {
+    type Error = UnsupportedPayloadEnvelopeV5;
+
+    fn try_from(_value: BerachainBuiltPayload) -> Result<Self, Self::Error> {
+        Err(UnsupportedPayloadEnvelopeV5)
     }
 }
 
@@ -541,6 +554,38 @@ mod tests {
         assert!(
             envelope.execution_requests.is_empty(),
             "execution_requests must default to empty when payload has no requests"
+        );
+    }
+
+    #[test]
+    fn test_try_into_v5_returns_error_not_panic() {
+        let header = BerachainHeader {
+            prev_proposer_pubkey: None,
+            blob_gas_used: Some(0),
+            excess_blob_gas: Some(0),
+            ..Default::default()
+        };
+        let block = alloy_consensus::Block {
+            header,
+            body: alloy_consensus::BlockBody {
+                transactions: vec![],
+                ommers: vec![],
+                withdrawals: None,
+            },
+        };
+        let sealed = SealedBlock::new_unhashed(block);
+        let payload = BerachainBuiltPayload::new(
+            PayloadId::new([3; 8]),
+            std::sync::Arc::new(sealed),
+            U256::ZERO,
+            None,
+        );
+
+        let result: Result<ExecutionPayloadEnvelopeV5, UnsupportedPayloadEnvelopeV5> =
+            payload.try_into();
+        assert!(
+            matches!(result, Err(UnsupportedPayloadEnvelopeV5)),
+            "V5 conversion must return UnsupportedPayloadEnvelopeV5, never panic"
         );
     }
 }

--- a/src/engine/rpc.rs
+++ b/src/engine/rpc.rs
@@ -20,6 +20,7 @@ use alloy_rpc_types::engine::{
 
 use jsonrpsee_core::{RpcResult, server::RpcModule};
 use jsonrpsee_proc_macros::rpc;
+use metrics::Histogram;
 use reth::{
     api::NodeTypes,
     chainspec::EthereumHardforks,
@@ -34,8 +35,8 @@ use reth_node_core::version::{CLIENT_CODE, version_metadata};
 use reth_payload_primitives::{EngineObjectValidationError, PayloadAttributes, PayloadTypes};
 use reth_rpc_engine_api::{EngineApi, EngineApiError, EngineCapabilities};
 use reth_transaction_pool::TransactionPool;
-use std::sync::Arc;
-use tracing::{debug, trace};
+use std::{sync::Arc, time::Instant};
+use tracing::{debug, trace, warn};
 
 /// Builder for [`BerachainEngineApi`] implementation.
 #[derive(Debug, Default)]
@@ -66,6 +67,9 @@ where
     >,
     EV: PayloadValidatorBuilder<N>,
     EV::Validator: EngineApiValidator<<N::Types as NodeTypes>::Payload>,
+    <<<N::Types as NodeTypes>::Payload as PayloadTypes>::BuiltPayload as TryInto<
+        <<N::Types as NodeTypes>::Payload as EngineTypes>::ExecutionPayloadEnvelopeV4,
+    >>::Error: std::fmt::Debug,
 {
     type EngineApi = BerachainEngineApi<
         N::Provider,
@@ -98,7 +102,12 @@ where
             ctx.config.engine.accept_execution_requests_hash,
             ctx.node.network().clone(),
         );
-        Ok(BerachainEngineApi { inner, chain_spec: ctx.config.chain.clone() })
+        Ok(BerachainEngineApi {
+            inner,
+            chain_spec: ctx.config.chain.clone(),
+            payload_store: PayloadStore::new(ctx.node.payload_builder_handle().clone()),
+            get_payload_v4p11_latency: metrics::histogram!("engine.rpc.get_payload_v4p11"),
+        })
     }
 }
 
@@ -352,6 +361,11 @@ pub trait BerachainEngineApi<Engine: EngineTypes> {
 pub struct BerachainEngineApi<Provider, PayloadT: PayloadTypes, Pool, Validator, ChainSpec> {
     inner: EngineApi<Provider, PayloadT, Pool, Validator, ChainSpec>,
     chain_spec: Arc<ChainSpec>,
+    /// Direct handle to the payload builder so `getPayloadV4P11` can resolve payloads
+    /// without going through upstream's V4 timestamp validation, which rejects
+    /// post-Osaka calls.
+    payload_store: PayloadStore<PayloadT>,
+    get_payload_v4p11_latency: Histogram,
 }
 
 /// Validates Prague1 requirements for P11 methods
@@ -388,6 +402,7 @@ where
             ExecutionData = BerachainExecutionData,
             PayloadAttributes = BerachainPayloadAttributes,
         >,
+    <EngineT::BuiltPayload as TryInto<EngineT::ExecutionPayloadEnvelopeV4>>::Error: std::fmt::Debug,
     Pool: TransactionPool + 'static,
     Validator: EngineApiValidator<EngineT>,
     ChainSpec: EthereumHardforks + BerachainHardforks + Send + Sync + 'static,
@@ -587,7 +602,38 @@ where
         payload_id: PayloadId,
     ) -> RpcResult<EngineT::ExecutionPayloadEnvelopeV4> {
         trace!(target: "rpc::engine", "Serving engine_getPayloadV4P11");
-        Ok(self.inner.get_payload_v4_metered(payload_id).await?)
+        let start = Instant::now();
+
+        // V4P11 is the canonical post-Prague1 getPayload variant on Berachain across
+        // both Prague1 and Osaka. Resolve through the payload store directly because
+        // upstream's `get_payload_v4_metered` rejects retrievals once Osaka is active.
+        let result = match self.payload_store.resolve(payload_id).await {
+            None => Err(EngineApiError::UnknownPayload.into()),
+            Some(Ok(built)) => built.try_into().map_err(|err| {
+                warn!(
+                    target: "rpc::engine",
+                    ?payload_id,
+                    error = ?err,
+                    "Failed to convert payload for engine_getPayloadV4P11"
+                );
+                EngineApiError::Internal(Box::new(std::io::Error::other(format!(
+                    "failed to convert payload for engine_getPayloadV4P11: {err:?}"
+                ))))
+                .into()
+            }),
+            Some(Err(err)) => {
+                warn!(
+                    target: "rpc::engine",
+                    ?payload_id,
+                    error = ?err,
+                    "Failed to resolve payload for engine_getPayloadV4P11"
+                );
+                Err(EngineApiError::GetPayloadError(err).into())
+            }
+        };
+
+        self.get_payload_v4p11_latency.record(start.elapsed());
+        result
     }
 
     async fn get_payload_v5(

--- a/src/engine/rpc.rs
+++ b/src/engine/rpc.rs
@@ -46,6 +46,13 @@ pub struct BerachainEngineApiBuilder<EV> {
 pub const BERACHAIN_ADDITIONAL_CAPABILITIES: &[&str] =
     &["engine_newPayloadV4P11", "engine_forkchoiceUpdatedV3P11", "engine_getPayloadV4P11"];
 
+/// Capabilities inherited from upstream Reth that Berachain does not support.
+///
+/// Berachain serves the Osaka payload via `engine_getPayloadV4P11`, so the V5
+/// method is implemented but never advertised, and any direct call returns
+/// `UnsupportedFork`.
+pub const BERACHAIN_REMOVED_CAPABILITIES: &[&str] = &["engine_getPayloadV5"];
+
 impl<N, EV> EngineApiBuilder<N> for BerachainEngineApiBuilder<EV>
 where
     N: FullNodeComponents<
@@ -585,10 +592,13 @@ where
 
     async fn get_payload_v5(
         &self,
-        payload_id: PayloadId,
+        _payload_id: PayloadId,
     ) -> RpcResult<EngineT::ExecutionPayloadEnvelopeV5> {
         trace!(target: "rpc::engine", "Serving engine_getPayloadV5");
-        Ok(self.inner.get_payload_v5_metered(payload_id).await?)
+        Err(EngineApiError::EngineObjectValidationError(
+            EngineObjectValidationError::UnsupportedFork,
+        )
+        .into())
     }
 
     async fn get_payload_bodies_by_hash_v1(
@@ -618,6 +628,7 @@ where
 
     async fn exchange_capabilities(&self, _capabilities: Vec<String>) -> RpcResult<Vec<String>> {
         let mut caps = self.inner.capabilities().list();
+        caps.retain(|c| !BERACHAIN_REMOVED_CAPABILITIES.contains(&c.as_str()));
         for &cap in BERACHAIN_ADDITIONAL_CAPABILITIES {
             let s = cap.to_string();
             if !caps.contains(&s) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 
 pub mod chainspec;
 pub mod consensus;
+pub mod deposits;
 pub mod engine;
 pub mod evm;
 pub mod genesis;

--- a/src/node/evm/config.rs
+++ b/src/node/evm/config.rs
@@ -510,7 +510,9 @@ mod osaka_config_tests {
         let config =
             BerachainEvmConfig::new_with_evm_factory(chain_spec.clone(), BerachainEvmFactory);
 
-        let before_osaka = header_at(9_999_999_999_999_998);
+        // Bepolia activates Osaka at 1_779_897_600; pick the second just before that so
+        // we exercise "Osaka not yet active" on the real bepolia chainspec.
+        let before_osaka = header_at(1_779_897_599);
         let env = config.evm_env(&before_osaka).expect("evm_env");
         assert!(env.cfg_env.tx_gas_limit_cap.is_none());
         assert!(env.cfg_env.limit_contract_code_size.is_none());

--- a/src/node/evm/config.rs
+++ b/src/node/evm/config.rs
@@ -506,14 +506,12 @@ mod osaka_config_tests {
 
     #[test]
     fn test_osaka_inactive_before_activation_timestamp() {
-        // Sanity: without osakaTime configured, Osaka stays inactive and no caps apply.
         let chain_spec = bepolia_chainspec();
         let config =
             BerachainEvmConfig::new_with_evm_factory(chain_spec.clone(), BerachainEvmFactory);
 
-        let far_future = header_at(u64::MAX);
-        let env = config.evm_env(&far_future).expect("evm_env");
-        // Bepolia fixture does not configure osakaTime, so Osaka is never active.
+        let before_osaka = header_at(9_999_999_999_999_998);
+        let env = config.evm_env(&before_osaka).expect("evm_env");
         assert!(env.cfg_env.tx_gas_limit_cap.is_none());
         assert!(env.cfg_env.limit_contract_code_size.is_none());
         assert!(env.cfg_env.limit_contract_initcode_size.is_none());

--- a/src/node/evm/executor.rs
+++ b/src/node/evm/executor.rs
@@ -38,6 +38,7 @@ use reth_evm::{
     eth::{
         dao_fork, eip6110,
         receipt_builder::{ReceiptBuilder, ReceiptBuilderCtx},
+        spec::EthExecutorSpec,
     },
 };
 use std::{borrow::Cow, collections::HashMap, sync::Arc};
@@ -297,9 +298,12 @@ where
             .spec
             .is_prague_active_at_timestamp(self.evm.block().timestamp().saturating_to())
         {
-            // Collect all EIP-6110 deposits
+            let deposit_contract = self
+                .spec
+                .deposit_contract_address()
+                .unwrap_or(eip6110::MAINNET_DEPOSIT_CONTRACT_ADDRESS);
             let deposit_requests =
-                eip6110::parse_deposits_from_receipts(&self.spec, &self.receipts)?;
+                crate::deposits::parse_deposits_from_receipts(deposit_contract, &self.receipts)?;
 
             let mut requests = Requests::default();
 

--- a/src/pool/mod.rs
+++ b/src/pool/mod.rs
@@ -61,6 +61,9 @@ where
         let validator =
             TransactionValidationTaskExecutor::eth_builder(ctx.provider().clone(), evm_config)
                 .set_eip4844(!blobs_disabled)
+                // BRIP-0010 Osaka does not adopt EIP-7594 (PeerDAS); keep EIP-4844 sidecars
+                // accepted across forks and reject EIP-7594 v1 sidecars.
+                .no_eip7594()
                 .with_max_tx_input_bytes(ctx.config().txpool.max_tx_input_bytes)
                 .kzg_settings(ctx.kzg_settings()?)
                 .with_local_transactions_config(pool_config.local_transactions_config.clone())

--- a/tests/e2e/deposit_test.rs
+++ b/tests/e2e/deposit_test.rs
@@ -1,0 +1,191 @@
+use crate::e2e::{berachain_payload_attributes_generator, test_signer};
+use alloy_eips::Encodable2718;
+use alloy_genesis::{Genesis, GenesisAccount};
+use alloy_primitives::{Address, Bytes, TxKind, U256, address};
+use alloy_rpc_types_eth::{TransactionInput, TransactionRequest};
+use bera_reth::{chainspec::BerachainChainSpec, node::BerachainNode};
+use reth::tasks::Runtime;
+use reth_chainspec::EthChainSpec;
+use reth_cli::chainspec::parse_genesis;
+use reth_e2e_test_utils::{node::NodeTestContext, transaction::TransactionTestContext};
+use reth_node_builder::{NodeBuilder, NodeHandle};
+use reth_node_core::{args::RpcServerArgs, node_config::NodeConfig};
+use reth_payload_primitives::BuiltPayload;
+use std::sync::Arc;
+
+const DEPOSIT_CONTRACT: Address = address!("4242424242424242424242424242424242424242");
+const DEPOSIT_REQUEST_TYPE: u8 = 0x00;
+const DEPOSIT_SIZE: usize = 48 + 32 + 8 + 96 + 8;
+
+// Amount encoded in the mock event: 32 ETH in Gwei = 0x773594000
+const MOCK_AMOUNT_GWEI: u64 = 32_000_000_000;
+
+// Runtime bytecode for a contract that emits a hardcoded Berachain Deposit event when called.
+//
+// Event: Deposit(bytes pubkey, bytes credentials, uint64 amount, bytes signature, uint64 index)
+// Topic: keccak256("Deposit(bytes,bytes,uint64,bytes,uint64)")
+//      = 0x68af751683498a9f9be59fe8b0d52a64dd155255d85cdb29fea30b1e3f891d46
+//
+// Emits with: pubkey=[0;48], credentials=[0;32], amount=32_000_000_000, signature=[0;96], index=0
+//
+// ABI-encoded log data (14 words = 448 bytes):
+//   head[0] = 0xa0          (offset to pubkey data)
+//   head[1] = 0x100         (offset to credentials data)
+//   head[2] = 0x773594000   (amount in gwei)
+//   head[3] = 0x140         (offset to signature data)
+//   head[4] = 0x0           (index)
+//   pubkey length = 0x30
+//   pubkey data   = [0;64]  (48 bytes zero-padded to 64)
+//   cred length   = 0x20
+//   cred data     = [0;32]
+//   sig length    = 0x60
+//   sig data      = [0;96]
+const DEPOSIT_EMITTER_BYTECODE: &str = concat!(
+    // head[0] = 0xa0 at mem[0]
+    "7f00000000000000000000000000000000000000000000000000000000000000a0",
+    "6000",
+    "52",
+    // head[1] = 0x100 at mem[32]
+    "7f0000000000000000000000000000000000000000000000000000000000000100",
+    "6020",
+    "52",
+    // head[2] = 0x773594000 (32_000_000_000) at mem[64]
+    "7f0000000000000000000000000000000000000000000000000000000773594000",
+    "6040",
+    "52",
+    // head[3] = 0x140 at mem[96]
+    "7f0000000000000000000000000000000000000000000000000000000000000140",
+    "6060",
+    "52",
+    // head[4] = 0 (index) at mem[128] — zero, memory already zeroed, skip MSTORE
+    // pubkey length = 48 at mem[160=0xa0]
+    "6030",
+    "60a0",
+    "52",
+    // pubkey data [0;64] at mem[192..256] — zero, skip
+    // credentials length = 32 at mem[256=0x100]
+    "6020",
+    "610100",
+    "52",
+    // credentials data [0;32] at mem[288..320] — zero, skip
+    // signature length = 96 at mem[320=0x140]
+    "6060",
+    "610140",
+    "52",
+    // signature data [0;96] at mem[352..448] — zero, skip
+    // LOG1(offset=0, size=448=0x01c0, topic=0x68af...)
+    "7f68af751683498a9f9be59fe8b0d52a64dd155255d85cdb29fea30b1e3f891d46",
+    "6101c0", // PUSH2 448
+    "5f",     // PUSH0 (offset = 0)
+    "a1",     // LOG1
+    // RETURN
+    "5f",
+    "5f",
+    "f3",
+);
+
+async fn setup_deposit_test() -> eyre::Result<(Runtime, Arc<BerachainChainSpec>)> {
+    let runtime = Runtime::with_existing_handle(tokio::runtime::Handle::current())?;
+    let genesis_path = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/eth-genesis.json");
+    let genesis_json = std::fs::read_to_string(genesis_path)?;
+    let mut genesis: Genesis = parse_genesis(&genesis_json)?;
+    genesis.config.deposit_contract_address = Some(DEPOSIT_CONTRACT);
+    let bytecode = Bytes::from(alloy_primitives::hex::decode(DEPOSIT_EMITTER_BYTECODE).unwrap());
+    genesis
+        .alloc
+        .entry(DEPOSIT_CONTRACT)
+        .and_modify(|a| a.code = Some(bytecode.clone()))
+        .or_insert_with(|| GenesisAccount {
+            code: Some(bytecode),
+            nonce: Some(1),
+            ..Default::default()
+        });
+    let chain_spec = Arc::new(BerachainChainSpec::from(genesis));
+    Ok((runtime, chain_spec))
+}
+
+#[tokio::test]
+async fn test_eip6110_deposit_requests_active() -> eyre::Result<()> {
+    let (runtime, chain_spec) = setup_deposit_test().await?;
+    let node_config = NodeConfig::new(chain_spec.clone())
+        .with_unused_ports()
+        .with_rpc(RpcServerArgs::default().with_unused_ports().with_http());
+
+    let NodeHandle { node, node_exit_future: _ } = NodeBuilder::new(node_config)
+        .testing_node(runtime.clone())
+        .node(BerachainNode::default())
+        .launch()
+        .await?;
+
+    let mut ctx = NodeTestContext::new(node, berachain_payload_attributes_generator).await?;
+    let signer = test_signer()?;
+    let chain_id = chain_spec.chain_id();
+
+    let deposit_tx = TransactionRequest {
+        to: Some(TxKind::Call(DEPOSIT_CONTRACT)),
+        value: Some(U256::ZERO),
+        input: TransactionInput::default(),
+        gas: Some(100_000),
+        chain_id: Some(chain_id),
+        nonce: Some(0),
+        max_fee_per_gas: Some(10_000_000_000),
+        max_priority_fee_per_gas: Some(1_000_000_000),
+        ..Default::default()
+    };
+
+    let tx_bytes: Bytes =
+        TransactionTestContext::sign_tx(signer, deposit_tx).await.encoded_2718().into();
+    ctx.rpc.inject_tx(tx_bytes).await?;
+
+    let payload = ctx.advance_block().await?;
+
+    let requests = payload.requests().expect("requests must be present when Prague is active");
+    let deposit_request = requests
+        .iter()
+        .find(|r: &&Bytes| r.first() == Some(&DEPOSIT_REQUEST_TYPE))
+        .expect("block must contain deposit requests after a deposit transaction");
+
+    let deposit_data = &deposit_request[1..];
+    assert_eq!(
+        deposit_data.len(),
+        DEPOSIT_SIZE,
+        "deposit request must contain exactly one 192-byte deposit"
+    );
+
+    let pubkey_bytes = &deposit_data[..48];
+    let amount_bytes: [u8; 8] = deposit_data[48 + 32..48 + 32 + 8].try_into().unwrap();
+    let amount_gwei = u64::from_le_bytes(amount_bytes);
+
+    assert_eq!(pubkey_bytes, &[0u8; 48], "pubkey must match emitted deposit");
+    assert_eq!(amount_gwei, MOCK_AMOUNT_GWEI, "amount must be 32 ETH in Gwei");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_eip6110_no_deposits_without_deposit_tx() -> eyre::Result<()> {
+    let (runtime, chain_spec) = setup_deposit_test().await?;
+    let node_config = NodeConfig::new(chain_spec.clone())
+        .with_unused_ports()
+        .with_rpc(RpcServerArgs::default().with_unused_ports().with_http());
+
+    let NodeHandle { node, node_exit_future: _ } = NodeBuilder::new(node_config)
+        .testing_node(runtime.clone())
+        .node(BerachainNode::default())
+        .launch()
+        .await?;
+
+    let mut ctx = NodeTestContext::new(node, berachain_payload_attributes_generator).await?;
+
+    let payload = ctx.advance_block().await?;
+
+    let requests = payload.requests().expect("requests must be present when Prague is active");
+    let deposit_request =
+        requests.iter().find(|r: &&Bytes| r.first() == Some(&DEPOSIT_REQUEST_TYPE));
+    assert!(
+        deposit_request.is_none(),
+        "block without deposit transactions must not contain deposit requests"
+    );
+
+    Ok(())
+}

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -12,6 +12,7 @@ use reth_payload_primitives::PayloadBuilderAttributes;
 use std::{str::FromStr, sync::Arc};
 
 pub mod coinbase_system_state_change_test;
+pub mod deposit_test;
 pub mod gas_limit_regression_test;
 pub mod osaka_blob_test;
 pub mod osaka_engine_api_test;

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -13,6 +13,8 @@ use std::{str::FromStr, sync::Arc};
 
 pub mod coinbase_system_state_change_test;
 pub mod gas_limit_regression_test;
+pub mod osaka_blob_test;
+pub mod osaka_engine_api_test;
 pub mod pol_revert_test;
 pub mod prague3_empty_block_test;
 pub mod transaction_tests;

--- a/tests/e2e/osaka_blob_test.rs
+++ b/tests/e2e/osaka_blob_test.rs
@@ -1,0 +1,56 @@
+//! Verifies EIP-4844 blob transactions are accepted and included in blocks once Osaka is active.
+
+use crate::e2e::{berachain_payload_attributes_generator, test_signer};
+use bera_reth::{chainspec::BerachainChainSpec, node::BerachainNode};
+use reth::tasks::Runtime;
+use reth_chainspec::EthChainSpec;
+use reth_cli::chainspec::parse_genesis;
+use reth_e2e_test_utils::{node::NodeTestContext, transaction::TransactionTestContext};
+use reth_node_builder::{NodeBuilder, NodeHandle};
+use reth_node_core::{args::RpcServerArgs, node_config::NodeConfig};
+use reth_payload_primitives::BuiltPayload;
+use std::sync::Arc;
+
+#[tokio::test]
+async fn test_eip4844_blob_tx_accepted_post_osaka() -> eyre::Result<()> {
+    let runtime = Runtime::with_existing_handle(tokio::runtime::Handle::current())?;
+
+    let genesis_path = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/eth-genesis.json");
+    let genesis_json = std::fs::read_to_string(genesis_path)?;
+    let genesis = parse_genesis(&genesis_json)?;
+    let chain_spec = Arc::new(BerachainChainSpec::from(genesis));
+    let chain_id = chain_spec.chain_id();
+
+    let node_config = NodeConfig::new(chain_spec)
+        .with_unused_ports()
+        .with_rpc(RpcServerArgs::default().with_unused_ports().with_http());
+
+    let NodeHandle { node, node_exit_future: _ } = NodeBuilder::new(node_config)
+        .testing_node(runtime.clone())
+        .node(BerachainNode::default())
+        .launch()
+        .await?;
+
+    let mut ctx = NodeTestContext::new(node, berachain_payload_attributes_generator).await?;
+    let signer = test_signer()?;
+
+    let blob_tx_bytes = TransactionTestContext::tx_with_blobs_bytes(chain_id, signer).await?;
+
+    let blob_tx_hash = ctx
+        .rpc
+        .inject_tx(blob_tx_bytes)
+        .await
+        .map_err(|err| eyre::eyre!("blob tx rejected by RPC under Osaka: {err}"))?;
+
+    let payload = ctx.advance_block().await?;
+    let block = payload.block();
+    let included = block.body().transactions.iter().any(|tx| *tx.hash() == blob_tx_hash);
+
+    assert!(
+        included,
+        "EIP-4844 blob tx {blob_tx_hash:?} should be included in block {} after Osaka activation",
+        block.number
+    );
+
+    Ok(())
+}

--- a/tests/e2e/osaka_engine_api_test.rs
+++ b/tests/e2e/osaka_engine_api_test.rs
@@ -1,0 +1,60 @@
+//! Verifies Berachain serves `engine_getPayloadV4P11` post-Osaka.
+//!
+//! BeaconKit calls `getPayloadV4P11` for both Prague1 and Osaka payloads. Upstream reth's
+//! V4 metered handler rejects retrievals once Osaka is active, so without the bera-reth
+//! override the call returns `-38005 Unsupported fork`.
+
+use crate::e2e::berachain_payload_attributes_generator;
+use bera_reth::{chainspec::BerachainChainSpec, node::BerachainNode};
+use jsonrpsee::{core::client::ClientT, rpc_params};
+use reth::tasks::Runtime;
+use reth_cli::chainspec::parse_genesis;
+use reth_e2e_test_utils::node::NodeTestContext;
+use reth_node_builder::{NodeBuilder, NodeHandle};
+use reth_node_core::{args::RpcServerArgs, node_config::NodeConfig};
+use reth_payload_primitives::PayloadBuilderAttributes;
+use serde_json::Value;
+use std::sync::Arc;
+
+#[tokio::test]
+async fn test_get_payload_v4_p11_works_post_osaka() -> eyre::Result<()> {
+    let runtime = Runtime::with_existing_handle(tokio::runtime::Handle::current())?;
+
+    let genesis_path = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/eth-genesis.json");
+    let genesis_json = std::fs::read_to_string(genesis_path)?;
+    let genesis = parse_genesis(&genesis_json)?;
+    let chain_spec = Arc::new(BerachainChainSpec::from(genesis));
+
+    let node_config = NodeConfig::new(chain_spec)
+        .with_unused_ports()
+        .with_rpc(RpcServerArgs::default().with_unused_ports().with_http());
+
+    let NodeHandle { node, node_exit_future: _ } = NodeBuilder::new(node_config)
+        .testing_node(runtime.clone())
+        .node(BerachainNode::default())
+        .launch()
+        .await?;
+
+    let mut ctx = NodeTestContext::new(node, berachain_payload_attributes_generator).await?;
+
+    // Trigger a payload build via the local builder handle so we get a valid payload_id.
+    let attrs = ctx.payload.new_payload().await?;
+    let payload_id = attrs.payload_id();
+    ctx.payload.wait_for_built_payload(payload_id).await;
+
+    // Call engine_getPayloadV4P11 over the auth RPC. Pre-fix this returns
+    // `-38005 Unsupported fork` because upstream's V4 metered handler rejects
+    // retrievals when the payload's timestamp is at or after Osaka activation.
+    let auth_client = ctx.inner.auth_server_handle().http_client();
+    let envelope: Value = auth_client
+        .request("engine_getPayloadV4P11", rpc_params![payload_id])
+        .await
+        .map_err(|err| eyre::eyre!("engine_getPayloadV4P11 failed post-Osaka: {err}"))?;
+
+    assert!(
+        envelope.get("executionPayload").is_some(),
+        "expected executionPayload field in V4P11 response, got {envelope}"
+    );
+
+    Ok(())
+}

--- a/tests/fixtures/bepolia-genesis.json
+++ b/tests/fixtures/bepolia-genesis.json
@@ -82,6 +82,7 @@
     "petersburgBlock": 0,
     "shanghaiTime": 0,
     "pragueTime": 1746633600,
+    "osakaTime": 9999999999999999,
     "terminalTotalDifficulty": 0,
     "terminalTotalDifficultyPassed": true,
     "blobSchedule": {
@@ -91,6 +92,11 @@
         "baseFeeUpdateFraction": 3338477
       },
       "prague": {
+        "target": 3,
+        "max": 6,
+        "baseFeeUpdateFraction": 3338477
+      },
+      "osaka": {
         "target": 3,
         "max": 6,
         "baseFeeUpdateFraction": 3338477

--- a/tests/fixtures/bepolia-genesis.json
+++ b/tests/fixtures/bepolia-genesis.json
@@ -68,6 +68,7 @@
     "constantinopleBlock": 0,
     "daoForkBlock": 0,
     "daoForkSupport": true,
+    "depositContractAddress": "0x4242424242424242424242424242424242424242",
     "eip150Block": 0,
     "eip155Block": 0,
     "eip158Block": 0,

--- a/tests/fixtures/bepolia-genesis.json
+++ b/tests/fixtures/bepolia-genesis.json
@@ -82,7 +82,7 @@
     "petersburgBlock": 0,
     "shanghaiTime": 0,
     "pragueTime": 1746633600,
-    "osakaTime": 9999999999999999,
+    "osakaTime": 1779897600,
     "terminalTotalDifficulty": 0,
     "terminalTotalDifficultyPassed": true,
     "blobSchedule": {

--- a/tests/fixtures/eth-genesis.json
+++ b/tests/fixtures/eth-genesis.json
@@ -381,6 +381,11 @@
         "baseFeeUpdateFraction": 3338477,
         "max": 6,
         "target": 3
+      },
+      "osaka": {
+        "baseFeeUpdateFraction": 3338477,
+        "max": 6,
+        "target": 3
       }
     },
     "byzantiumBlock": 0,
@@ -399,6 +404,7 @@
     "londonBlock": 0,
     "mergeNetsplitBlock": 0,
     "muirGlacierBlock": 0,
+    "osakaTime": 0,
     "petersburgBlock": 0,
     "pragueTime": 0,
     "shanghaiTime": 0,


### PR DESCRIPTION
This PR merges `main` into `preconf-dev` to pick up the V4P11 Osaka payload fix (#248) and other recent main commits needed for testing Fulu fork transitions with preconfs.

```bash
cd ~/workspace/bera-reth
git fetch origin
git pull origin preconf-dev
git checkout -b merge-main-into-preconf-dev
git merge origin/main
# handle conflicts...
cargo check
git merge --continue
git push -u origin merge-main-into-preconf-dev
```