### PR TITLE
fix(eip6110): fix deposit request inclusion gate

### DIFF
--- a/src/node/evm/executor.rs
+++ b/src/node/evm/executor.rs
@@ -296,7 +296,7 @@ where
     > {
         let requests = if self
             .spec
-            .is_prague_active_at_timestamp(self.evm.block().timestamp().saturating_to())
+            .is_osaka_active_at_timestamp(self.evm.block().timestamp().saturating_to())
         {
             let deposit_contract = self
                 .spec

--- a/src/node/evm/executor.rs
+++ b/src/node/evm/executor.rs
@@ -294,23 +294,33 @@ where
         (Self::Evm, BlockExecutionResult<<BerachainReceiptBuilder as ReceiptBuilder>::Receipt>),
         BlockExecutionError,
     > {
-        let requests = if self
-            .spec
-            .is_osaka_active_at_timestamp(self.evm.block().timestamp().saturating_to())
-        {
-            let deposit_contract = self
-                .spec
-                .deposit_contract_address()
-                .unwrap_or(eip6110::MAINNET_DEPOSIT_CONTRACT_ADDRESS);
-            let deposit_requests =
-                crate::deposits::parse_deposits_from_receipts(deposit_contract, &self.receipts)?;
-
+        let timestamp = self.evm.block().timestamp().saturating_to();
+        let requests = if self.spec.is_prague_active_at_timestamp(timestamp) {
             let mut requests = Requests::default();
 
-            if !deposit_requests.is_empty() {
-                requests.push_request_with_type(eip6110::DEPOSIT_REQUEST_TYPE, deposit_requests);
+            // EIP-6110 deposit requests are sourced from the execution layer only once Osaka is
+            // active. Before Osaka the consensus layer still ingests deposits from the deposit
+            // contract logs, so emitting them here would double count them.
+            if self.spec.is_osaka_active_at_timestamp(timestamp) {
+                let deposit_contract = self
+                    .spec
+                    .deposit_contract_address()
+                    .unwrap_or(eip6110::MAINNET_DEPOSIT_CONTRACT_ADDRESS);
+                let deposit_requests = crate::deposits::parse_deposits_from_receipts(
+                    deposit_contract,
+                    &self.receipts,
+                )?;
+
+                if !deposit_requests.is_empty() {
+                    requests
+                        .push_request_with_type(eip6110::DEPOSIT_REQUEST_TYPE, deposit_requests);
+                }
             }
 
+            // EIP-7002 withdrawal and EIP-7251 consolidation requests are part of Prague and must
+            // run their system-contract calls every block from Prague onward. Gating these behind
+            // Osaka changes the post-state of pre-Osaka blocks (e.g. the excess-requests slot is
+            // never cleared), which breaks re-execution of historical blocks.
             requests.extend(self.system_caller.apply_post_execution_changes(&mut self.evm)?);
             requests
         } else {

--- a/tests/e2e/deposit_test.rs
+++ b/tests/e2e/deposit_test.rs
@@ -23,6 +23,10 @@ const MOCK_AMOUNT_GWEI: u64 = 32_000_000_000;
 // A time in the future for testing deposit requests before Osaka activation.
 const OSAKA_TIME_FUTURE: u64 = 2_000_000_000;
 
+// Genesis timestamp from reth's e2e `PayloadTestContext`.
+// Used to place an Osaka activation at E2E_BASE_TIMESTAMP + N.
+const E2E_BASE_TIMESTAMP: u64 = 1_710_338_135;
+
 // Runtime bytecode for a contract that emits a hardcoded Berachain Deposit event when called.
 //
 // Event: Deposit(bytes pubkey, bytes credentials, uint64 amount, bytes signature, uint64 index)
@@ -248,6 +252,98 @@ async fn test_eip6110_no_deposit_requests_before_osaka() -> eyre::Result<()> {
         requests.is_empty(),
         "deposit requests must be empty before Osaka even when a deposit event is emitted"
     );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_eip6110_deposit_requests_across_osaka_boundary() -> eyre::Result<()> {
+    // Activate Osaka a few blocks after genesis.
+    let osaka_time = E2E_BASE_TIMESTAMP + 3;
+    let (runtime, chain_spec) = setup_deposit_test_with_osaka(Some(osaka_time)).await?;
+    let node_config = NodeConfig::new(chain_spec.clone())
+        .with_unused_ports()
+        .with_rpc(RpcServerArgs::default().with_unused_ports().with_http());
+
+    let NodeHandle { node, node_exit_future: _ } = NodeBuilder::new(node_config)
+        .testing_node(runtime.clone())
+        .node(BerachainNode::default())
+        .launch()
+        .await?;
+
+    let mut ctx = NodeTestContext::new(node, berachain_payload_attributes_generator).await?;
+    let signer = test_signer()?;
+    let chain_id = chain_spec.chain_id();
+
+    let make_deposit_tx = |nonce: u64| TransactionRequest {
+        to: Some(TxKind::Call(DEPOSIT_CONTRACT)),
+        value: Some(U256::ZERO),
+        input: TransactionInput::default(),
+        gas: Some(100_000),
+        chain_id: Some(chain_id),
+        nonce: Some(nonce),
+        max_fee_per_gas: Some(10_000_000_000),
+        max_priority_fee_per_gas: Some(1_000_000_000),
+        ..Default::default()
+    };
+
+    // Before Osaka: the deposit event is emitted but must not yield a request.
+    let tx_bytes: Bytes = TransactionTestContext::sign_tx(signer.clone(), make_deposit_tx(0))
+        .await
+        .encoded_2718()
+        .into();
+    let pre_tx_hash = ctx.rpc.inject_tx(tx_bytes).await?;
+    let payload = ctx.advance_block().await?;
+    let block = payload.block();
+    assert!(
+        block.timestamp < osaka_time,
+        "first deposit must land before Osaka (timestamp {}, osaka {osaka_time})",
+        block.timestamp
+    );
+    assert!(
+        block.body().transactions.iter().any(|tx| *tx.hash() == pre_tx_hash),
+        "pre-Osaka deposit transaction must be included so its event is emitted"
+    );
+    let requests = payload.requests().expect("requests must be present when Prague is active");
+    assert!(requests.is_empty(), "deposit requests must be empty before Osaka");
+
+    // Advance plain blocks until Osaka activates.
+    let mut payload = payload;
+    while payload.block().timestamp < osaka_time {
+        payload = ctx.advance_block().await?;
+    }
+
+    // After Osaka: the same deposit event must now yield a deposit request.
+    let tx_bytes: Bytes =
+        TransactionTestContext::sign_tx(signer, make_deposit_tx(1)).await.encoded_2718().into();
+    let post_tx_hash = ctx.rpc.inject_tx(tx_bytes).await?;
+    let payload = ctx.advance_block().await?;
+    let block = payload.block();
+    assert!(
+        block.timestamp >= osaka_time,
+        "second deposit must land at or after Osaka (timestamp {}, osaka {osaka_time})",
+        block.timestamp
+    );
+    assert!(
+        block.body().transactions.iter().any(|tx| *tx.hash() == post_tx_hash),
+        "post-Osaka deposit transaction must be included"
+    );
+
+    let requests = payload.requests().expect("requests must be present when Prague is active");
+    let deposit_request = requests
+        .iter()
+        .find(|r: &&Bytes| r.first() == Some(&DEPOSIT_REQUEST_TYPE))
+        .expect("block must contain deposit requests after Osaka activation");
+
+    let deposit_data = &deposit_request[1..];
+    assert_eq!(
+        deposit_data.len(),
+        DEPOSIT_SIZE,
+        "deposit request must contain exactly one 192-byte deposit"
+    );
+    let amount_bytes: [u8; 8] = deposit_data[48 + 32..48 + 32 + 8].try_into().unwrap();
+    let amount_gwei = u64::from_le_bytes(amount_bytes);
+    assert_eq!(amount_gwei, MOCK_AMOUNT_GWEI, "amount must be 32 ETH in Gwei");
 
     Ok(())
 }

--- a/tests/e2e/deposit_test.rs
+++ b/tests/e2e/deposit_test.rs
@@ -259,7 +259,10 @@ async fn test_eip6110_no_deposit_requests_before_osaka() -> eyre::Result<()> {
 #[tokio::test]
 async fn test_eip6110_deposit_requests_across_osaka_boundary() -> eyre::Result<()> {
     // Activate Osaka a few blocks after genesis.
-    let osaka_time = E2E_BASE_TIMESTAMP + 3;
+    // Last pre-Osaka block is at osaka_time - 1 (= E2E_BASE_TIMESTAMP + 1, first block after
+    // genesis) and the first Osaka block at osaka_time (= E2E_BASE_TIMESTAMP + 2, second block
+    // after genesis).
+    let osaka_time = E2E_BASE_TIMESTAMP + 2;
     let (runtime, chain_spec) = setup_deposit_test_with_osaka(Some(osaka_time)).await?;
     let node_config = NodeConfig::new(chain_spec.clone())
         .with_unused_ports()
@@ -287,7 +290,7 @@ async fn test_eip6110_deposit_requests_across_osaka_boundary() -> eyre::Result<(
         ..Default::default()
     };
 
-    // Before Osaka: the deposit event is emitted but must not yield a request.
+    // Last pre-Osaka block: the deposit event is emitted but must not yield a request.
     let tx_bytes: Bytes = TransactionTestContext::sign_tx(signer.clone(), make_deposit_tx(0))
         .await
         .encoded_2718()
@@ -295,35 +298,21 @@ async fn test_eip6110_deposit_requests_across_osaka_boundary() -> eyre::Result<(
     let pre_tx_hash = ctx.rpc.inject_tx(tx_bytes).await?;
     let payload = ctx.advance_block().await?;
     let block = payload.block();
-    assert!(
-        block.timestamp < osaka_time,
-        "first deposit must land before Osaka (timestamp {}, osaka {osaka_time})",
-        block.timestamp
-    );
+    assert_eq!(block.timestamp, osaka_time - 1, "deposit must land on the last pre-Osaka block");
     assert!(
         block.body().transactions.iter().any(|tx| *tx.hash() == pre_tx_hash),
         "pre-Osaka deposit transaction must be included so its event is emitted"
     );
     let requests = payload.requests().expect("requests must be present when Prague is active");
-    assert!(requests.is_empty(), "deposit requests must be empty before Osaka");
+    assert!(requests.is_empty(), "deposit requests must be empty in the last pre-Osaka block");
 
-    // Advance plain blocks until Osaka activates.
-    let mut payload = payload;
-    while payload.block().timestamp < osaka_time {
-        payload = ctx.advance_block().await?;
-    }
-
-    // After Osaka: the same deposit event must now yield a deposit request.
+    // First Osaka block: the same deposit event must now yield a deposit request.
     let tx_bytes: Bytes =
         TransactionTestContext::sign_tx(signer, make_deposit_tx(1)).await.encoded_2718().into();
     let post_tx_hash = ctx.rpc.inject_tx(tx_bytes).await?;
     let payload = ctx.advance_block().await?;
     let block = payload.block();
-    assert!(
-        block.timestamp >= osaka_time,
-        "second deposit must land at or after Osaka (timestamp {}, osaka {osaka_time})",
-        block.timestamp
-    );
+    assert_eq!(block.timestamp, osaka_time, "deposit must land on the first Osaka block");
     assert!(
         block.body().transactions.iter().any(|tx| *tx.hash() == post_tx_hash),
         "post-Osaka deposit transaction must be included"

--- a/tests/e2e/deposit_test.rs
+++ b/tests/e2e/deposit_test.rs
@@ -20,6 +20,9 @@ const DEPOSIT_SIZE: usize = 48 + 32 + 8 + 96 + 8;
 // Amount encoded in the mock event: 32 ETH in Gwei = 0x773594000
 const MOCK_AMOUNT_GWEI: u64 = 32_000_000_000;
 
+// A time in the future for testing deposit requests before Osaka activation.
+const OSAKA_TIME_FUTURE: u64 = 2_000_000_000;
+
 // Runtime bytecode for a contract that emits a hardcoded Berachain Deposit event when called.
 //
 // Event: Deposit(bytes pubkey, bytes credentials, uint64 amount, bytes signature, uint64 index)
@@ -85,11 +88,20 @@ const DEPOSIT_EMITTER_BYTECODE: &str = concat!(
 );
 
 async fn setup_deposit_test() -> eyre::Result<(Runtime, Arc<BerachainChainSpec>)> {
+    setup_deposit_test_with_osaka(None).await
+}
+
+async fn setup_deposit_test_with_osaka(
+    osaka_time: Option<u64>,
+) -> eyre::Result<(Runtime, Arc<BerachainChainSpec>)> {
     let runtime = Runtime::with_existing_handle(tokio::runtime::Handle::current())?;
     let genesis_path = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/eth-genesis.json");
     let genesis_json = std::fs::read_to_string(genesis_path)?;
     let mut genesis: Genesis = parse_genesis(&genesis_json)?;
     genesis.config.deposit_contract_address = Some(DEPOSIT_CONTRACT);
+    if let Some(osaka_time) = osaka_time {
+        genesis.config.osaka_time = Some(osaka_time);
+    }
     let bytecode = Bytes::from(alloy_primitives::hex::decode(DEPOSIT_EMITTER_BYTECODE).unwrap());
     genesis
         .alloc
@@ -185,6 +197,56 @@ async fn test_eip6110_no_deposits_without_deposit_tx() -> eyre::Result<()> {
     assert!(
         deposit_request.is_none(),
         "block without deposit transactions must not contain deposit requests"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_eip6110_no_deposit_requests_before_osaka() -> eyre::Result<()> {
+    let (runtime, chain_spec) = setup_deposit_test_with_osaka(Some(OSAKA_TIME_FUTURE)).await?;
+    let node_config = NodeConfig::new(chain_spec.clone())
+        .with_unused_ports()
+        .with_rpc(RpcServerArgs::default().with_unused_ports().with_http());
+
+    let NodeHandle { node, node_exit_future: _ } = NodeBuilder::new(node_config)
+        .testing_node(runtime.clone())
+        .node(BerachainNode::default())
+        .launch()
+        .await?;
+
+    let mut ctx = NodeTestContext::new(node, berachain_payload_attributes_generator).await?;
+    let signer = test_signer()?;
+    let chain_id = chain_spec.chain_id();
+
+    let deposit_tx = TransactionRequest {
+        to: Some(TxKind::Call(DEPOSIT_CONTRACT)),
+        value: Some(U256::ZERO),
+        input: TransactionInput::default(),
+        gas: Some(100_000),
+        chain_id: Some(chain_id),
+        nonce: Some(0),
+        max_fee_per_gas: Some(10_000_000_000),
+        max_priority_fee_per_gas: Some(1_000_000_000),
+        ..Default::default()
+    };
+
+    let tx_bytes: Bytes =
+        TransactionTestContext::sign_tx(signer, deposit_tx).await.encoded_2718().into();
+    let deposit_tx_hash = ctx.rpc.inject_tx(tx_bytes).await?;
+
+    let payload = ctx.advance_block().await?;
+
+    let block = payload.block();
+    assert!(
+        block.body().transactions.iter().any(|tx| *tx.hash() == deposit_tx_hash),
+        "deposit transaction must be included so its deposit event is emitted before Osaka"
+    );
+
+    let requests = payload.requests().expect("requests must be present when Prague is active");
+    assert!(
+        requests.is_empty(),
+        "deposit requests must be empty before Osaka even when a deposit event is emitted"
     );
 
     Ok(())


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deposit requests are now included only once the Osaka protocol activation time is reached (respecting the Osaka activation boundary).

* **Tests**
  * Added end-to-end tests covering deposit request behavior before, across, and after Osaka activation.
  * Added a test harness helper to control Osaka timing for these scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->