### PR TITLE
chore(ci): pin cross-rs/cross commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,10 +89,11 @@ jobs:
         with:
           toolchain: stable
           target: ${{ matrix.configs.target }}
-      - name: Install cross main
+      - name: Install cross
         if: runner.os == 'Linux'
+        # Pinned to a cross main commit (last release v0.2.5 is too stale); bump deliberately.
         run: |
-          cargo install cross --git https://github.com/cross-rs/cross
+          cargo install cross --locked --git https://github.com/cross-rs/cross --rev 29d00c7803f221f1b3f35e561b03792368fb8339 # main @ 2026-06-06
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           cache-on-failure: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Linux cross-compilation setup in the release workflow to pin a specific version of the build tool, improving build reproducibility and consistency across releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->