### PR TITLE
test(forks): update with new osaka fork time

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,6 +160,20 @@ jobs:
           echo "CHANGELOG<<EOF" >> $GITHUB_OUTPUT
           echo "$(git log --pretty=format:"- %s" $(git describe --tags --abbrev=0 ${{ env.VERSION }}^)..${{ env.VERSION }})" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
+      - name: Import GPG key and read fingerprint
+        id: gpg
+        env:
+          GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
+        run: |
+          echo -n "$GPG_SIGNING_KEY" | base64 --decode | gpg --batch --import
+          raw=$(gpg --with-colons --fingerprint core@berachain.com | awk -F: '/^fpr:/ {print $10; exit}')
+          if [[ -z "$raw" ]]; then
+            echo "ERROR: could not read GPG fingerprint from imported key" >&2
+            exit 1
+          fi
+          formatted=$(echo "$raw" | sed -E 's/(.{4})/\1 /g; s/ $//')
+          echo "fingerprint=$formatted" >> "$GITHUB_OUTPUT"
+          echo "Release signing key fingerprint: $formatted"
       - name: Create release draft
         env:
           GITHUB_USER: ${{ github.repository_owner }}
@@ -210,7 +224,7 @@ jobs:
 
           ## Binaries
 
-          The binaries are signed with the PGP key: `9242 626B 8926 378A EA33 82A7 11BD B71D C9ED AE7B`
+          The binaries are signed with the PGP key: `${{ steps.gpg.outputs.fingerprint }}`
 
           ### Bera-Reth
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1449,7 +1449,7 @@ checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
 name = "bera-reth"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bera-reth"
-version = "1.4.0"
+version = "1.4.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/src/chainspec/mod.rs
+++ b/src/chainspec/mod.rs
@@ -2326,7 +2326,7 @@ mod tests {
         assert_eq!(fork_id_prague2.hash, ForkHash([0xcb, 0xbf, 0x6c, 0x9f]));
         assert_eq!(fork_id_prague3.hash, ForkHash([0x64, 0x94, 0xa1, 0x76]));
         assert_eq!(fork_id_prague4.hash, ForkHash([0x70, 0x1a, 0x09, 0x7f]));
-        assert_eq!(fork_id_future.hash, ForkHash([0x31, 0xd4, 0x38, 0xd0]));
+        assert_eq!(fork_id_future.hash, ForkHash([0xbb, 0x99, 0xd3, 0xeb]));
     }
 
     #[test]

--- a/src/chainspec/mod.rs
+++ b/src/chainspec/mod.rs
@@ -2315,10 +2315,10 @@ mod tests {
         assert_eq!(fork_id_prague1.next, 1759248000, "next fork should be Prague2");
         assert_eq!(fork_id_prague2.next, 1762164459, "next fork should be Prague3");
         assert_eq!(fork_id_prague3.next, 1762963200, "next fork should be Prague4");
-        assert_eq!(fork_id_prague4.next, 1782316800, "next fork should be Osaka");
+        assert_eq!(fork_id_prague4.next, 1783526400, "next fork should be Osaka");
         assert_eq!(fork_id_future.next, 0, "no next fork in far future");
 
-        // Expected fork hash values for mainnet (matching bera-geth test values)
+        // Expected fork hash values for mainnet
         assert_eq!(fork_id_genesis.hash, ForkHash([0xbb, 0x6c, 0x8b, 0xc0]));
         assert_eq!(fork_id_before_prague.hash, ForkHash([0xbb, 0x6c, 0x8b, 0xc0]));
         assert_eq!(fork_id_prague.hash, ForkHash([0x3f, 0x78, 0xb1, 0x27]));


### PR DESCRIPTION
New fusaka fork time

**Unix Timestamp: 1783526400
GMT: Wed Jul 08 2026 16:00:00 GMT+0000**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated network configuration parameters for blockchain fork activation timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->