### PR TITLE
feat: osaka1 fork to floor the base fee and blob fee

### DIFF
--- a/src/chainspec/mod.rs
+++ b/src/chainspec/mod.rs
@@ -13,7 +13,7 @@ use alloy_eips::{
 };
 use alloy_genesis::Genesis;
 use alloy_primitives::Sealable;
-use derive_more::{Constructor, Into};
+use derive_more::Into;
 use reth::{
     chainspec::{
         BaseFeeParams, BaseFeeParamsKind, Chain, ChainHardforks, EthereumHardfork,
@@ -43,7 +43,7 @@ const BEPOLIA_ETH_GENESIS_JSON: &str =
     include_str!(concat!(env!("OUT_DIR"), "/bepolia-eth-genesis.json"));
 
 /// Berachain chain specification wrapping Reth's ChainSpec with Berachain hardforks
-#[derive(Debug, Clone, Into, Constructor, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Into, PartialEq, Eq, Default)]
 pub struct BerachainChainSpec {
     /// The underlying Reth chain specification
     pub inner: ChainSpec,
@@ -58,6 +58,10 @@ pub struct BerachainChainSpec {
     pub prague3_config: Option<Prague3Config>,
     /// Prague4 configuration (if configured)
     pub prague4_config: Option<Prague4Config>,
+    /// The minimum base fee in wei for Osaka1 (0 if not configured)
+    pub osaka1_minimum_base_fee: u64,
+    /// The minimum blob base fee in wei for Osaka1 (0 = keep the EIP-4844 default of 1 wei)
+    pub osaka1_min_blob_base_fee: u64,
 }
 
 impl BerachainChainSpec {
@@ -283,7 +287,13 @@ impl EthChainSpec for BerachainChainSpec {
     }
 
     fn blob_params_at_timestamp(&self, timestamp: u64) -> Option<alloy_eips::eip7840::BlobParams> {
-        self.inner.blob_params_at_timestamp(timestamp)
+        let mut params = self.inner.blob_params_at_timestamp(timestamp)?;
+        // Osaka1 raises the minimum blob base fee (anti-spam). Setting min_blob_fee lifts the
+        // EIP-4844 blob fee curve so the at-target blob base fee equals this floor.
+        if self.is_osaka1_active_at_timestamp(timestamp) && self.osaka1_min_blob_base_fee > 0 {
+            params.min_blob_fee = self.osaka1_min_blob_base_fee as u128;
+        }
+        Some(params)
     }
 
     fn deposit_contract(&self) -> Option<&DepositContract> {
@@ -349,8 +359,17 @@ impl EthChainSpec for BerachainChainSpec {
             String::new()
         };
 
+        let osaka1_details = match self.fork(BerachainHardfork::Osaka1) {
+            ForkCondition::Timestamp(time) => format!(
+                "\nBerachain Osaka1 configuration: {{time={time}, min_base_fee={} gwei, min_blob_base_fee={} gwei}}",
+                self.osaka1_minimum_base_fee / 1_000_000_000,
+                self.osaka1_min_blob_base_fee.max(1) as f64 / 1_000_000_000.0,
+            ),
+            _ => String::new(),
+        };
+
         Box::new(format!(
-            "{inner_display}{prague1_details}{prague2_details}{prague3_details}{prague4_details}"
+            "{inner_display}{prague1_details}{prague2_details}{prague3_details}{prague4_details}{osaka1_details}"
         ))
     }
 
@@ -387,8 +406,11 @@ impl EthChainSpec for BerachainChainSpec {
             self.base_fee_params_at_timestamp(parent.timestamp()),
         );
 
-        // Prague2 supersedes Prague1 - check Prague2 first
-        let min_base_fee = if self.is_prague2_active_at_timestamp(parent.timestamp()) {
+        // Later forks supersede earlier ones - check in reverse chronological order.
+        // Prague3/Prague4 do not change the floor, so they inherit Prague2's value.
+        let min_base_fee = if self.is_osaka1_active_at_timestamp(parent.timestamp()) {
+            self.osaka1_minimum_base_fee
+        } else if self.is_prague2_active_at_timestamp(parent.timestamp()) {
             self.prague2_minimum_base_fee
         } else if self.is_prague1_active_at_timestamp(parent.timestamp()) {
             self.prague1_minimum_base_fee
@@ -481,6 +503,8 @@ impl BerachainChainSpec {
             prague2_minimum_base_fee: 0,
             prague3_config: None,
             prague4_config: None,
+            osaka1_minimum_base_fee: 0,
+            osaka1_min_blob_base_fee: 0,
         }
     }
 }
@@ -503,6 +527,7 @@ impl From<Genesis> for BerachainChainSpec {
         let prague2_config_opt = berachain_genesis_config.prague2;
         let prague3_config_opt = berachain_genesis_config.prague3;
         let prague4_config_opt = berachain_genesis_config.prague4;
+        let osaka1_config_opt = berachain_genesis_config.osaka1;
 
         // Both Prague1 and Prague2 are required for Berachain genesis
         let (prague1_config, prague2_config) = match (prague1_config_opt, prague2_config_opt) {
@@ -623,6 +648,27 @@ impl From<Genesis> for BerachainChainSpec {
             }
         }
 
+        // Validate Osaka1 ordering if configured. Osaka1 activates after Osaka, so its
+        // predecessor is Osaka if set, else the latest Berachain fork (Prague4/3/2).
+        if let Some(osaka1_config) = osaka1_config_opt.as_ref() {
+            let (predecessor_name, predecessor_time) =
+                if let Some(osaka_time) = genesis.config.osaka_time {
+                    ("Osaka", osaka_time)
+                } else if let Some(p4) = prague4_config_opt.as_ref() {
+                    ("Prague4", p4.time)
+                } else if let Some(p3) = prague3_config_opt.as_ref() {
+                    ("Prague3", p3.time)
+                } else {
+                    ("Prague2", prague2_config.time)
+                };
+            if osaka1_config.time < predecessor_time {
+                panic!(
+                    "Osaka1 hardfork must activate at or after {predecessor_name} hardfork. {predecessor_name} time: {predecessor_time}, Osaka1 time: {}.",
+                    osaka1_config.time
+                );
+            }
+        }
+
         // Berachain networks don't support proof-of-work or non-genesis merge
         if let Some(ttd) = genesis.config.terminal_total_difficulty {
             if !ttd.is_zero() {
@@ -716,6 +762,14 @@ impl From<Genesis> for BerachainChainSpec {
             hardforks.push((EthereumHardfork::Osaka.boxed(), ForkCondition::Timestamp(osaka_time)));
         }
 
+        // Add Osaka1 if configured (activates after Osaka; enforced by validation above)
+        if let Some(osaka1_config) = osaka1_config_opt.as_ref() {
+            hardforks.push((
+                BerachainHardfork::Osaka1.boxed(),
+                ForkCondition::Timestamp(osaka1_config.time),
+            ));
+        }
+
         let paris_block_and_final_difficulty =
             Some((0, genesis.config.terminal_total_difficulty.unwrap()));
 
@@ -783,10 +837,14 @@ impl From<Genesis> for BerachainChainSpec {
             genesis_header.prev_proposer_pubkey = Some(BlsPublicKey::ZERO);
         }
 
-        // Extract configuration values from Prague1 and Prague2 configs
+        // Extract configuration values from Prague1, Prague2 and Osaka1 configs
         let pol_contract_address = prague1_config.pol_distributor_address;
         let prague1_minimum_base_fee = prague1_config.minimum_base_fee_wei;
         let prague2_minimum_base_fee = prague2_config.minimum_base_fee_wei;
+        let osaka1_minimum_base_fee =
+            osaka1_config_opt.as_ref().map(|cfg| cfg.minimum_base_fee_wei).unwrap_or(0);
+        let osaka1_min_blob_base_fee =
+            osaka1_config_opt.as_ref().map(|cfg| cfg.minimum_blob_base_fee_wei).unwrap_or(0);
 
         Self {
             inner,
@@ -796,6 +854,8 @@ impl From<Genesis> for BerachainChainSpec {
             prague2_minimum_base_fee,
             prague3_config: prague3_config_opt,
             prague4_config: prague4_config_opt,
+            osaka1_minimum_base_fee,
+            osaka1_min_blob_base_fee,
         }
     }
 }
@@ -805,8 +865,45 @@ mod tests {
     use super::*;
     use alloy_genesis::Genesis;
     use alloy_primitives::address;
-    use jsonrpsee_core::__reexports::serde_json::json;
+    use jsonrpsee_core::__reexports::serde_json::{Value, json};
     use reth_chainspec::ForkHash;
+
+    /// Build a chain spec with Prague1/Prague2/Osaka1 configured for the Osaka1 tests. Prague1
+    /// activates at `prague1_time`, Prague2 at `prague2_time`, Osaka at `osaka_time` (if any),
+    /// and Osaka1 per the `osaka1` config object.
+    fn osaka1_test_spec(
+        prague1_time: u64,
+        prague2_time: u64,
+        osaka_time: Option<u64>,
+        osaka1: Value,
+    ) -> BerachainChainSpec {
+        let mut genesis = Genesis::default();
+        genesis.config.london_block = Some(0);
+        genesis.config.cancun_time = Some(0);
+        genesis.config.prague_time = Some(prague1_time);
+        genesis.config.osaka_time = osaka_time;
+        genesis.config.terminal_total_difficulty = Some(U256::ZERO);
+        let extra_fields_json = json!({
+            "berachain": {
+                "prague1": {
+                    "time": prague1_time,
+                    "baseFeeChangeDenominator": 48,
+                    "minimumBaseFeeWei": 1000000000,
+                    "polDistributorAddress": "0x4200000000000000000000000000000000000042"
+                },
+                "prague2": { "time": prague2_time, "minimumBaseFeeWei": 0 },
+                "osaka1": osaka1
+            }
+        });
+        genesis.config.extra_fields =
+            reth::rpc::types::serde_helpers::OtherFields::try_from(extra_fields_json).unwrap();
+        BerachainChainSpec::from(genesis)
+    }
+
+    /// Parent header at `timestamp` with a sub-gwei base fee, used to probe the base-fee floor.
+    fn header_at(timestamp: u64) -> BerachainHeader {
+        BerachainHeader { timestamp, base_fee_per_gas: Some(100_000_000), ..Default::default() }
+    }
 
     #[test]
     fn test_builtin_genesis_deposit_contract() {
@@ -1162,6 +1259,85 @@ mod tests {
 
         let next_base_fee = chain_spec.next_block_base_fee(&parent_header, 0).unwrap();
         assert_eq!(next_base_fee, prague2_base_fee);
+    }
+
+    #[test]
+    fn test_next_block_base_fee_osaka1_floor() {
+        let osaka1_base_fee = 10_000_000_000u64; // 10 gwei
+        // Osaka1 activates after Osaka on mainnet.
+        let spec = osaka1_test_spec(
+            1000,
+            2000,
+            Some(2500),
+            json!({ "time": 3000, "minimumBaseFeeWei": osaka1_base_fee }),
+        );
+
+        // Stored floor and activation boundary.
+        assert_eq!(spec.osaka1_minimum_base_fee, osaka1_base_fee);
+        assert!(!spec.is_osaka1_active_at_timestamp(2999));
+        assert!(spec.is_osaka1_active_at_timestamp(3000));
+
+        // Between Prague2 and Osaka1 the floor is Prague2's 0, so a sub-gwei base fee is allowed.
+        assert!(spec.next_block_base_fee(&header_at(2999), 0).unwrap() < 1_000_000_000);
+
+        // At and after Osaka1 the base fee is floored at 10 gwei.
+        assert_eq!(spec.next_block_base_fee(&header_at(3000), 0).unwrap(), osaka1_base_fee);
+        assert_eq!(spec.next_block_base_fee(&header_at(5000), 0).unwrap(), osaka1_base_fee);
+    }
+
+    #[test]
+    fn test_blob_params_osaka1_min_blob_fee() {
+        // With a blob floor: EIP-4844 default (1 wei) before Osaka1, raised to 10 gwei at/after.
+        let spec = osaka1_test_spec(
+            1000,
+            2000,
+            Some(2500),
+            json!({
+                "time": 3000,
+                "minimumBaseFeeWei": 10000000000i64,
+                "minimumBlobBaseFeeWei": 10000000000i64
+            }),
+        );
+        assert_eq!(spec.osaka1_min_blob_base_fee, 10_000_000_000);
+        assert_eq!(spec.blob_params_at_timestamp(2999).unwrap().min_blob_fee, 1);
+        let after = spec.blob_params_at_timestamp(3000).unwrap();
+        assert_eq!(after.min_blob_fee, 10_000_000_000);
+        assert_eq!(after.calc_blob_fee(0), 10_000_000_000);
+
+        // Without a blob floor: the 0 value must skip the override, never set min_blob_fee=0, so
+        // the EIP-4844 default (1 wei) is left untouched even after activation.
+        let spec = osaka1_test_spec(
+            1000,
+            2000,
+            Some(2500),
+            json!({ "time": 3000, "minimumBaseFeeWei": 10000000000i64 }),
+        );
+        assert_eq!(spec.osaka1_min_blob_base_fee, 0);
+        assert_eq!(spec.blob_params_at_timestamp(5000).unwrap().min_blob_fee, 1);
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "Osaka1 hardfork must activate at or after Osaka hardfork. Osaka time: 3000, Osaka1 time: 2500."
+    )]
+    fn test_panic_on_osaka1_before_osaka() {
+        osaka1_test_spec(
+            0,
+            1000,
+            Some(3000),
+            json!({ "time": 2500, "minimumBaseFeeWei": 10000000000i64 }),
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "Osaka1 hardfork must activate at or after Prague2 hardfork")]
+    fn test_panic_on_osaka1_before_prague2() {
+        osaka1_test_spec(
+            0,
+            2000,
+            None,
+            json!({ "time": 1000, "minimumBaseFeeWei": 10000000000i64 }),
+        );
     }
 
     #[test]
@@ -2269,7 +2445,7 @@ mod tests {
             timestamp: 1762963200,
         };
 
-        // After all configured forks, including Osaka
+        // After all configured forks, including Osaka and Osaka1
         let head_far_future = Head {
             number: 1000,
             hash: B256::ZERO,
@@ -2326,7 +2502,7 @@ mod tests {
         assert_eq!(fork_id_prague2.hash, ForkHash([0xcb, 0xbf, 0x6c, 0x9f]));
         assert_eq!(fork_id_prague3.hash, ForkHash([0x64, 0x94, 0xa1, 0x76]));
         assert_eq!(fork_id_prague4.hash, ForkHash([0x70, 0x1a, 0x09, 0x7f]));
-        assert_eq!(fork_id_future.hash, ForkHash([0xbb, 0x99, 0xd3, 0xeb]));
+        assert_eq!(fork_id_future.hash, ForkHash([0x16, 0x66, 0xea, 0xde]));
     }
 
     #[test]
@@ -2340,7 +2516,7 @@ mod tests {
 
         let latest_fork_id = spec.latest_fork_id();
 
-        // Create a head after all configured Bepolia forks, including Osaka.
+        // Create a head after all configured Bepolia forks, including Osaka and Osaka1.
         let head_final = Head {
             number: 100,
             hash: B256::ZERO,
@@ -2356,8 +2532,8 @@ mod tests {
         );
         assert_eq!(latest_fork_id.next, 0, "latest fork should have no next fork");
 
-        // Verify this matches the final Osaka state.
-        assert_eq!(latest_fork_id.hash, ForkHash([0x79, 0x16, 0x74, 0x96]));
+        // Verify this matches the final Osaka1 state.
+        assert_eq!(latest_fork_id.hash, ForkHash([0xdf, 0x0c, 0x9e, 0xc9]));
     }
 
     #[test]

--- a/src/chainspec/mod.rs
+++ b/src/chainspec/mod.rs
@@ -2321,34 +2321,48 @@ mod tests {
             timestamp: 1758124800,
         };
 
+        // Osaka active, before Osaka1
+        let head_osaka_active = Head {
+            number: 100,
+            hash: B256::ZERO,
+            difficulty: Default::default(),
+            total_difficulty: Default::default(),
+            timestamp: 1779897600,
+        };
+
         let fork_id_before_prague = spec.fork_id(&head_before_prague);
         let fork_id_prague = spec.fork_id(&head_prague_active);
         let fork_id_prague1 = spec.fork_id(&head_prague1_active);
         let fork_id_prague2 = spec.fork_id(&head_prague2_active);
+        let fork_id_osaka = spec.fork_id(&head_osaka_active);
 
         // Test fork_filter at each stage
         let fork_filter_before_prague = spec.fork_filter(head_before_prague);
         let fork_filter_prague = spec.fork_filter(head_prague_active);
         let fork_filter_prague1 = spec.fork_filter(head_prague1_active);
         let fork_filter_prague2 = spec.fork_filter(head_prague2_active);
+        let fork_filter_osaka = spec.fork_filter(head_osaka_active);
 
         // Verify fork_filter.current() matches fork_id() at each stage
         assert_eq!(fork_filter_before_prague.current(), fork_id_before_prague);
         assert_eq!(fork_filter_prague.current(), fork_id_prague);
         assert_eq!(fork_filter_prague1.current(), fork_id_prague1);
         assert_eq!(fork_filter_prague2.current(), fork_id_prague2);
+        assert_eq!(fork_filter_osaka.current(), fork_id_osaka);
 
         // Verify next fork schedule matches Bepolia configuration
         assert_eq!(fork_id_before_prague.next, 1746633600, "next fork should be Prague");
         assert_eq!(fork_id_prague.next, 1754496000, "next fork should be Prague1");
         assert_eq!(fork_id_prague1.next, 1758124800, "next fork should be Prague2");
         assert_eq!(fork_id_prague2.next, 1779897600, "next fork should be Osaka");
+        assert_eq!(fork_id_osaka.next, 1784736000, "next fork should be Osaka1");
 
         // Expected fork hash values for Bepolia (matching bera-geth test values)
         assert_eq!(fork_id_before_prague.hash, ForkHash([0xae, 0x79, 0x53, 0x0c]));
         assert_eq!(fork_id_prague.hash, ForkHash([0xd0, 0x7d, 0x9f, 0x27]));
         assert_eq!(fork_id_prague1.hash, ForkHash([0x33, 0x15, 0x3c, 0x0a]));
         assert_eq!(fork_id_prague2.hash, ForkHash([0x2e, 0xdd, 0x8d, 0x57]));
+        assert_eq!(fork_id_osaka.hash, ForkHash([0x79, 0x16, 0x74, 0x96]));
     }
 
     #[test]
@@ -2529,7 +2543,7 @@ mod tests {
         assert_eq!(latest_fork_id.next, 0, "latest fork should have no next fork");
 
         // Verify this matches the final Osaka1 state.
-        assert_eq!(latest_fork_id.hash, ForkHash([0xdf, 0x0c, 0x9e, 0xc9]));
+        assert_eq!(latest_fork_id.hash, ForkHash([0x26, 0x57, 0x61, 0xfd]));
     }
 
     #[test]

--- a/src/chainspec/mod.rs
+++ b/src/chainspec/mod.rs
@@ -60,7 +60,7 @@ pub struct BerachainChainSpec {
     pub prague4_config: Option<Prague4Config>,
     /// The minimum base fee in wei for Osaka1 (0 if not configured)
     pub osaka1_minimum_base_fee: u64,
-    /// The minimum blob base fee in wei for Osaka1 (0 = keep the EIP-4844 default of 1 wei)
+    /// The minimum blob base fee in wei for Osaka1 (0 if not configured)
     pub osaka1_min_blob_base_fee: u64,
 }
 
@@ -290,7 +290,7 @@ impl EthChainSpec for BerachainChainSpec {
         let mut params = self.inner.blob_params_at_timestamp(timestamp)?;
         // Osaka1 raises the minimum blob base fee (anti-spam). Setting min_blob_fee lifts the
         // EIP-4844 blob fee curve so the at-target blob base fee equals this floor.
-        if self.is_osaka1_active_at_timestamp(timestamp) && self.osaka1_min_blob_base_fee > 0 {
+        if self.is_osaka1_active_at_timestamp(timestamp) {
             params.min_blob_fee = self.osaka1_min_blob_base_fee as u128;
         }
         Some(params)
@@ -363,7 +363,7 @@ impl EthChainSpec for BerachainChainSpec {
             ForkCondition::Timestamp(time) => format!(
                 "\nBerachain Osaka1 configuration: {{time={time}, min_base_fee={} gwei, min_blob_base_fee={} gwei}}",
                 self.osaka1_minimum_base_fee / 1_000_000_000,
-                self.osaka1_min_blob_base_fee.max(1) as f64 / 1_000_000_000.0,
+                self.osaka1_min_blob_base_fee as f64 / 1_000_000_000.0,
             ),
             _ => String::new(),
         };
@@ -648,24 +648,17 @@ impl From<Genesis> for BerachainChainSpec {
             }
         }
 
-        // Validate Osaka1 ordering if configured. Osaka1 activates after Osaka, so its
-        // predecessor is Osaka if set, else the latest Berachain fork (Prague4/3/2).
+        // Validate Osaka1 ordering if configured (Osaka1 must come at or after Osaka)
         if let Some(osaka1_config) = osaka1_config_opt.as_ref() {
-            let (predecessor_name, predecessor_time) =
-                if let Some(osaka_time) = genesis.config.osaka_time {
-                    ("Osaka", osaka_time)
-                } else if let Some(p4) = prague4_config_opt.as_ref() {
-                    ("Prague4", p4.time)
-                } else if let Some(p3) = prague3_config_opt.as_ref() {
-                    ("Prague3", p3.time)
-                } else {
-                    ("Prague2", prague2_config.time)
-                };
-            if osaka1_config.time < predecessor_time {
-                panic!(
-                    "Osaka1 hardfork must activate at or after {predecessor_name} hardfork. {predecessor_name} time: {predecessor_time}, Osaka1 time: {}.",
-                    osaka1_config.time
-                );
+            match genesis.config.osaka_time {
+                Some(osaka_time) if osaka1_config.time < osaka_time => {
+                    panic!(
+                        "Osaka1 hardfork must activate at or after Osaka hardfork. Osaka time: {osaka_time}, Osaka1 time: {}.",
+                        osaka1_config.time
+                    );
+                }
+                None => panic!("Osaka1 hardfork requires Osaka hardfork to be configured"),
+                _ => {}
             }
         }
 
@@ -1269,7 +1262,7 @@ mod tests {
             1000,
             2000,
             Some(2500),
-            json!({ "time": 3000, "minimumBaseFeeWei": osaka1_base_fee }),
+            json!({ "time": 3000, "minimumBaseFeeWei": osaka1_base_fee, "minimumBlobBaseFeeWei": osaka1_base_fee }),
         );
 
         // Stored floor and activation boundary.
@@ -1287,7 +1280,7 @@ mod tests {
 
     #[test]
     fn test_blob_params_osaka1_min_blob_fee() {
-        // With a blob floor: EIP-4844 default (1 wei) before Osaka1, raised to 10 gwei at/after.
+        // EIP-4844 default (1 wei) before Osaka1, raised to the configured floor at/after.
         let spec = osaka1_test_spec(
             1000,
             2000,
@@ -1303,17 +1296,6 @@ mod tests {
         let after = spec.blob_params_at_timestamp(3000).unwrap();
         assert_eq!(after.min_blob_fee, 10_000_000_000);
         assert_eq!(after.calc_blob_fee(0), 10_000_000_000);
-
-        // Without a blob floor: the 0 value must skip the override, never set min_blob_fee=0, so
-        // the EIP-4844 default (1 wei) is left untouched even after activation.
-        let spec = osaka1_test_spec(
-            1000,
-            2000,
-            Some(2500),
-            json!({ "time": 3000, "minimumBaseFeeWei": 10000000000i64 }),
-        );
-        assert_eq!(spec.osaka1_min_blob_base_fee, 0);
-        assert_eq!(spec.blob_params_at_timestamp(5000).unwrap().min_blob_fee, 1);
     }
 
     #[test]
@@ -1325,18 +1307,18 @@ mod tests {
             0,
             1000,
             Some(3000),
-            json!({ "time": 2500, "minimumBaseFeeWei": 10000000000i64 }),
+            json!({ "time": 2500, "minimumBaseFeeWei": 10000000000i64, "minimumBlobBaseFeeWei": 10000000000i64 }),
         );
     }
 
     #[test]
-    #[should_panic(expected = "Osaka1 hardfork must activate at or after Prague2 hardfork")]
-    fn test_panic_on_osaka1_before_prague2() {
+    #[should_panic(expected = "Osaka1 hardfork requires Osaka hardfork to be configured")]
+    fn test_panic_on_osaka1_without_osaka() {
         osaka1_test_spec(
             0,
             2000,
             None,
-            json!({ "time": 1000, "minimumBaseFeeWei": 10000000000i64 }),
+            json!({ "time": 3000, "minimumBaseFeeWei": 10000000000i64, "minimumBlobBaseFeeWei": 10000000000i64 }),
         );
     }
 
@@ -2445,6 +2427,15 @@ mod tests {
             timestamp: 1762963200,
         };
 
+        // Osaka active, before Osaka1
+        let head_osaka_active = Head {
+            number: 100,
+            hash: B256::ZERO,
+            difficulty: Default::default(),
+            total_difficulty: Default::default(),
+            timestamp: 1783526400,
+        };
+
         // After all configured forks, including Osaka and Osaka1
         let head_far_future = Head {
             number: 1000,
@@ -2462,6 +2453,7 @@ mod tests {
         let fork_id_prague2 = spec.fork_id(&head_prague2_active);
         let fork_id_prague3 = spec.fork_id(&head_prague3_active);
         let fork_id_prague4 = spec.fork_id(&head_prague4_active);
+        let fork_id_osaka = spec.fork_id(&head_osaka_active);
         let fork_id_future = spec.fork_id(&head_far_future);
 
         // Test fork_filter at each stage
@@ -2472,6 +2464,7 @@ mod tests {
         let fork_filter_prague2 = spec.fork_filter(head_prague2_active);
         let fork_filter_prague3 = spec.fork_filter(head_prague3_active);
         let fork_filter_prague4 = spec.fork_filter(head_prague4_active);
+        let fork_filter_osaka = spec.fork_filter(head_osaka_active);
         let fork_filter_future = spec.fork_filter(head_far_future);
 
         // Verify fork_filter.current() matches fork_id() at each stage
@@ -2482,6 +2475,7 @@ mod tests {
         assert_eq!(fork_filter_prague2.current(), fork_id_prague2);
         assert_eq!(fork_filter_prague3.current(), fork_id_prague3);
         assert_eq!(fork_filter_prague4.current(), fork_id_prague4);
+        assert_eq!(fork_filter_osaka.current(), fork_id_osaka);
         assert_eq!(fork_filter_future.current(), fork_id_future);
 
         // Verify next fork schedule matches mainnet configuration
@@ -2492,6 +2486,7 @@ mod tests {
         assert_eq!(fork_id_prague2.next, 1762164459, "next fork should be Prague3");
         assert_eq!(fork_id_prague3.next, 1762963200, "next fork should be Prague4");
         assert_eq!(fork_id_prague4.next, 1783526400, "next fork should be Osaka");
+        assert_eq!(fork_id_osaka.next, 9999999999, "next fork should be Osaka1");
         assert_eq!(fork_id_future.next, 0, "no next fork in far future");
 
         // Expected fork hash values for mainnet
@@ -2502,6 +2497,7 @@ mod tests {
         assert_eq!(fork_id_prague2.hash, ForkHash([0xcb, 0xbf, 0x6c, 0x9f]));
         assert_eq!(fork_id_prague3.hash, ForkHash([0x64, 0x94, 0xa1, 0x76]));
         assert_eq!(fork_id_prague4.hash, ForkHash([0x70, 0x1a, 0x09, 0x7f]));
+        assert_eq!(fork_id_osaka.hash, ForkHash([0xbb, 0x99, 0xd3, 0xeb]));
         assert_eq!(fork_id_future.hash, ForkHash([0x16, 0x66, 0xea, 0xde]));
     }
 

--- a/src/chainspec/mod.rs
+++ b/src/chainspec/mod.rs
@@ -61,7 +61,7 @@ pub struct BerachainChainSpec {
     /// The minimum base fee in wei for Osaka1 (0 if not configured)
     pub osaka1_minimum_base_fee: u64,
     /// The minimum blob base fee in wei for Osaka1 (0 if not configured)
-    pub osaka1_min_blob_base_fee: u64,
+    pub osaka1_minimum_blob_base_fee: u64,
 }
 
 impl BerachainChainSpec {
@@ -291,7 +291,7 @@ impl EthChainSpec for BerachainChainSpec {
         // Osaka1 raises the minimum blob base fee (anti-spam). Setting min_blob_fee lifts the
         // EIP-4844 blob fee curve so the at-target blob base fee equals this floor.
         if self.is_osaka1_active_at_timestamp(timestamp) {
-            params.min_blob_fee = self.osaka1_min_blob_base_fee as u128;
+            params.min_blob_fee = self.osaka1_minimum_blob_base_fee as u128;
         }
         Some(params)
     }
@@ -362,7 +362,7 @@ impl EthChainSpec for BerachainChainSpec {
         let osaka1_details = match self.fork(BerachainHardfork::Osaka1) {
             ForkCondition::Timestamp(time) => format!(
                 "\nBerachain Osaka1 configuration: {{time={time}, min_base_fee_wei={}, min_blob_base_fee_wei={}}}",
-                self.osaka1_minimum_base_fee, self.osaka1_min_blob_base_fee,
+                self.osaka1_minimum_base_fee, self.osaka1_minimum_blob_base_fee,
             ),
             _ => String::new(),
         };
@@ -503,7 +503,7 @@ impl BerachainChainSpec {
             prague3_config: None,
             prague4_config: None,
             osaka1_minimum_base_fee: 0,
-            osaka1_min_blob_base_fee: 0,
+            osaka1_minimum_blob_base_fee: 0,
         }
     }
 }
@@ -835,7 +835,7 @@ impl From<Genesis> for BerachainChainSpec {
         let prague2_minimum_base_fee = prague2_config.minimum_base_fee_wei;
         let osaka1_minimum_base_fee =
             osaka1_config_opt.as_ref().map(|cfg| cfg.minimum_base_fee_wei).unwrap_or(0);
-        let osaka1_min_blob_base_fee =
+        let osaka1_minimum_blob_base_fee =
             osaka1_config_opt.as_ref().map(|cfg| cfg.minimum_blob_base_fee_wei).unwrap_or(0);
 
         Self {
@@ -847,7 +847,7 @@ impl From<Genesis> for BerachainChainSpec {
             prague3_config: prague3_config_opt,
             prague4_config: prague4_config_opt,
             osaka1_minimum_base_fee,
-            osaka1_min_blob_base_fee,
+            osaka1_minimum_blob_base_fee,
         }
     }
 }
@@ -1290,7 +1290,7 @@ mod tests {
                 "minimumBlobBaseFeeWei": 1000000000i64
             }),
         );
-        assert_eq!(spec.osaka1_min_blob_base_fee, 1_000_000_000);
+        assert_eq!(spec.osaka1_minimum_blob_base_fee, 1_000_000_000);
         assert_eq!(spec.blob_params_at_timestamp(2999).unwrap().min_blob_fee, 1);
         let after = spec.blob_params_at_timestamp(3000).unwrap();
         assert_eq!(after.min_blob_fee, 1_000_000_000);

--- a/src/chainspec/mod.rs
+++ b/src/chainspec/mod.rs
@@ -1256,7 +1256,7 @@ mod tests {
 
     #[test]
     fn test_next_block_base_fee_osaka1_floor() {
-        let osaka1_base_fee = 10_000_000_000u64; // 10 gwei
+        let osaka1_base_fee = 1_000_000_000u64; // 1 gwei
         // Osaka1 activates after Osaka on mainnet.
         let spec = osaka1_test_spec(
             1000,
@@ -1273,7 +1273,7 @@ mod tests {
         // Between Prague2 and Osaka1 the floor is Prague2's 0, so a sub-gwei base fee is allowed.
         assert!(spec.next_block_base_fee(&header_at(2999), 0).unwrap() < 1_000_000_000);
 
-        // At and after Osaka1 the base fee is floored at 10 gwei.
+        // At and after Osaka1 the base fee is floored at 1 gwei.
         assert_eq!(spec.next_block_base_fee(&header_at(3000), 0).unwrap(), osaka1_base_fee);
         assert_eq!(spec.next_block_base_fee(&header_at(5000), 0).unwrap(), osaka1_base_fee);
     }
@@ -1287,15 +1287,15 @@ mod tests {
             Some(2500),
             json!({
                 "time": 3000,
-                "minimumBaseFeeWei": 10000000000i64,
-                "minimumBlobBaseFeeWei": 10000000000i64
+                "minimumBaseFeeWei": 1000000000i64,
+                "minimumBlobBaseFeeWei": 1000000000i64
             }),
         );
-        assert_eq!(spec.osaka1_min_blob_base_fee, 10_000_000_000);
+        assert_eq!(spec.osaka1_min_blob_base_fee, 1_000_000_000);
         assert_eq!(spec.blob_params_at_timestamp(2999).unwrap().min_blob_fee, 1);
         let after = spec.blob_params_at_timestamp(3000).unwrap();
-        assert_eq!(after.min_blob_fee, 10_000_000_000);
-        assert_eq!(after.calc_blob_fee(0), 10_000_000_000);
+        assert_eq!(after.min_blob_fee, 1_000_000_000);
+        assert_eq!(after.calc_blob_fee(0), 1_000_000_000);
     }
 
     #[test]
@@ -1307,7 +1307,7 @@ mod tests {
             0,
             1000,
             Some(3000),
-            json!({ "time": 2500, "minimumBaseFeeWei": 10000000000i64, "minimumBlobBaseFeeWei": 10000000000i64 }),
+            json!({ "time": 2500, "minimumBaseFeeWei": 1000000000i64, "minimumBlobBaseFeeWei": 1000000000i64 }),
         );
     }
 
@@ -1318,7 +1318,7 @@ mod tests {
             0,
             2000,
             None,
-            json!({ "time": 3000, "minimumBaseFeeWei": 10000000000i64, "minimumBlobBaseFeeWei": 10000000000i64 }),
+            json!({ "time": 3000, "minimumBaseFeeWei": 1000000000i64, "minimumBlobBaseFeeWei": 1000000000i64 }),
         );
     }
 

--- a/src/chainspec/mod.rs
+++ b/src/chainspec/mod.rs
@@ -361,9 +361,8 @@ impl EthChainSpec for BerachainChainSpec {
 
         let osaka1_details = match self.fork(BerachainHardfork::Osaka1) {
             ForkCondition::Timestamp(time) => format!(
-                "\nBerachain Osaka1 configuration: {{time={time}, min_base_fee={} gwei, min_blob_base_fee={} gwei}}",
-                self.osaka1_minimum_base_fee / 1_000_000_000,
-                self.osaka1_min_blob_base_fee as f64 / 1_000_000_000.0,
+                "\nBerachain Osaka1 configuration: {{time={time}, min_base_fee_wei={}, min_blob_base_fee_wei={}}}",
+                self.osaka1_minimum_base_fee, self.osaka1_min_blob_base_fee,
             ),
             _ => String::new(),
         };

--- a/src/genesis/config.rs
+++ b/src/genesis/config.rs
@@ -55,9 +55,8 @@ pub struct Prague4Config {
 pub struct Osaka1Config {
     /// Unix timestamp when Osaka1 activates
     pub time: u64,
-    /// Minimum base fee in wei enforced after activation (0 disables the floor)
+    /// Minimum base fee in wei enforced after activation
     pub minimum_base_fee_wei: u64,
-    /// Minimum blob base fee in wei enforced after activation (0 keeps the EIP-4844 default)
-    #[serde(default)]
+    /// Minimum blob base fee in wei enforced after activation
     pub minimum_blob_base_fee_wei: u64,
 }

--- a/src/genesis/config.rs
+++ b/src/genesis/config.rs
@@ -48,3 +48,16 @@ pub struct Prague4Config {
     /// Unix timestamp when Prague4 activates (ending Prague3 restrictions)
     pub time: u64,
 }
+
+/// Configuration for Osaka1 hardfork activation
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Osaka1Config {
+    /// Unix timestamp when Osaka1 activates
+    pub time: u64,
+    /// Minimum base fee in wei enforced after activation (0 disables the floor)
+    pub minimum_base_fee_wei: u64,
+    /// Minimum blob base fee in wei enforced after activation (0 keeps the EIP-4844 default)
+    #[serde(default)]
+    pub minimum_blob_base_fee_wei: u64,
+}

--- a/src/genesis/mod.rs
+++ b/src/genesis/mod.rs
@@ -7,7 +7,7 @@ use reth::{revm::primitives::address, rpc::types::serde_helpers::OtherFields};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-pub use config::{Prague1Config, Prague2Config, Prague3Config, Prague4Config};
+pub use config::{Osaka1Config, Prague1Config, Prague2Config, Prague3Config, Prague4Config};
 
 /// Errors for Berachain genesis configuration parsing
 #[derive(Debug, Error)]
@@ -37,6 +37,8 @@ pub struct BerachainGenesisConfig {
     pub prague3: Option<Prague3Config>,
     /// Configuration for the Prague4 hardfork, which ends Prague3 restrictions
     pub prague4: Option<Prague4Config>,
+    /// Configuration for the Osaka1 hardfork, which raises the minimum base fee floor
+    pub osaka1: Option<Osaka1Config>,
 }
 
 impl Default for BerachainGenesisConfig {
@@ -55,6 +57,7 @@ impl Default for BerachainGenesisConfig {
             }),
             prague3: None, // Not activated by default
             prague4: None, // Not activated by default
+            osaka1: None,  // Not activated by default
         }
     }
 }
@@ -119,7 +122,13 @@ impl TryFrom<&OtherFields> for BerachainGenesisConfig {
                 Ok(cfg)
             }
             Some(Err(e)) => Err(BerachainConfigError::InvalidConfig(e)),
-            None => Ok(Self { prague1: None, prague2: None, prague3: None, prague4: None }),
+            None => Ok(Self {
+                prague1: None,
+                prague2: None,
+                prague3: None,
+                prague4: None,
+                osaka1: None,
+            }),
         }
     }
 }
@@ -208,6 +217,40 @@ mod tests {
         assert_eq!(prague2_config.minimum_base_fee_wei, 0);
 
         assert!(cfg.is_berachain());
+    }
+
+    #[test]
+    fn test_genesis_config_valid_osaka1() {
+        let json = r#"
+        {
+          "berachain": {
+            "prague1": {
+                "time": 1620000000,
+                "baseFeeChangeDenominator": 48,
+                "minimumBaseFeeWei": 1000000000,
+                "polDistributorAddress": "0x4200000000000000000000000000000000000042"
+            },
+            "prague2": {
+                "time": 1720000000,
+                "minimumBaseFeeWei": 0
+            },
+            "osaka1": {
+                "time": 1820000000,
+                "minimumBaseFeeWei": 10000000000
+            }
+          }
+        }
+        "#;
+
+        let v: Value = serde_json::from_str(json).unwrap();
+        let other_fields = OtherFields::try_from(v).expect("must be a valid genesis config");
+
+        let cfg = BerachainGenesisConfig::try_from(&other_fields)
+            .expect("berachain field must deserialize");
+
+        let osaka1_config = cfg.osaka1.expect("Osaka1 should be configured");
+        assert_eq!(osaka1_config.time, 1820000000);
+        assert_eq!(osaka1_config.minimum_base_fee_wei, 10000000000);
     }
 
     #[test]

--- a/src/genesis/mod.rs
+++ b/src/genesis/mod.rs
@@ -119,6 +119,20 @@ impl TryFrom<&OtherFields> for BerachainGenesisConfig {
                     }
                 }
 
+                // Both Osaka1 floors are consensus-critical; a zero value is a misconfiguration,
+                // not "no floor" (0 would drop the blob base fee below the EIP-4844 minimum).
+                if let Some(osaka1_config) = cfg.osaka1.as_ref() &&
+                    (osaka1_config.minimum_base_fee_wei == 0 ||
+                        osaka1_config.minimum_blob_base_fee_wei == 0)
+                {
+                    return Err(BerachainConfigError::InvalidConfig(serde_json::Error::io(
+                        std::io::Error::new(
+                            std::io::ErrorKind::InvalidData,
+                            "Osaka1 hardfork requires a non-zero minimum base fee and minimum blob base fee",
+                        ),
+                    )));
+                }
+
                 Ok(cfg)
             }
             Some(Err(e)) => Err(BerachainConfigError::InvalidConfig(e)),
@@ -136,8 +150,31 @@ impl TryFrom<&OtherFields> for BerachainGenesisConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use jsonrpsee_core::__reexports::serde_json::Value;
+    use jsonrpsee_core::__reexports::serde_json::{Value, json};
     use reth::rpc::types::serde_helpers::OtherFields;
+
+    /// Parses a genesis config with valid Prague1/Prague2 sections and the given `osaka1` value.
+    fn parse_config_with_osaka1(
+        osaka1: Value,
+    ) -> Result<BerachainGenesisConfig, BerachainConfigError> {
+        let json = json!({
+          "berachain": {
+            "prague1": {
+                "time": 1620000000,
+                "baseFeeChangeDenominator": 48,
+                "minimumBaseFeeWei": 1000000000,
+                "polDistributorAddress": "0x4200000000000000000000000000000000000042"
+            },
+            "prague2": {
+                "time": 1720000000,
+                "minimumBaseFeeWei": 0
+            },
+            "osaka1": osaka1
+          }
+        });
+        let other_fields = OtherFields::try_from(json).expect("must be a valid genesis config");
+        BerachainGenesisConfig::try_from(&other_fields)
+    }
 
     #[test]
     fn test_genesis_config_missing_berachain_field() {
@@ -221,36 +258,40 @@ mod tests {
 
     #[test]
     fn test_genesis_config_valid_osaka1() {
-        let json = r#"
-        {
-          "berachain": {
-            "prague1": {
-                "time": 1620000000,
-                "baseFeeChangeDenominator": 48,
-                "minimumBaseFeeWei": 1000000000,
-                "polDistributorAddress": "0x4200000000000000000000000000000000000042"
-            },
-            "prague2": {
-                "time": 1720000000,
-                "minimumBaseFeeWei": 0
-            },
-            "osaka1": {
-                "time": 1820000000,
-                "minimumBaseFeeWei": 10000000000
-            }
-          }
-        }
-        "#;
-
-        let v: Value = serde_json::from_str(json).unwrap();
-        let other_fields = OtherFields::try_from(v).expect("must be a valid genesis config");
-
-        let cfg = BerachainGenesisConfig::try_from(&other_fields)
-            .expect("berachain field must deserialize");
+        let cfg = parse_config_with_osaka1(json!({
+            "time": 1820000000,
+            "minimumBaseFeeWei": 10000000000u64,
+            "minimumBlobBaseFeeWei": 10000000000u64
+        }))
+        .expect("berachain field must deserialize");
 
         let osaka1_config = cfg.osaka1.expect("Osaka1 should be configured");
         assert_eq!(osaka1_config.time, 1820000000);
         assert_eq!(osaka1_config.minimum_base_fee_wei, 10000000000);
+        assert_eq!(osaka1_config.minimum_blob_base_fee_wei, 10000000000);
+    }
+
+    #[test]
+    fn test_genesis_config_osaka1_missing_blob_floor_fails() {
+        // Both floors are consensus-critical, so omitting (or misspelling) either key must
+        // fail loudly instead of silently defaulting to 0.
+        let res = parse_config_with_osaka1(json!({
+            "time": 1820000000,
+            "minimumBaseFeeWei": 10000000000u64
+        }));
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn test_genesis_config_osaka1_zero_floor_fails() {
+        // A zero floor is a misconfiguration, not "no floor": for the blob fee it would drop
+        // below the EIP-4844 minimum, so both floors must be non-zero when Osaka1 is configured.
+        let res = parse_config_with_osaka1(json!({
+            "time": 1820000000,
+            "minimumBaseFeeWei": 10000000000u64,
+            "minimumBlobBaseFeeWei": 0
+        }));
+        assert!(res.is_err());
     }
 
     #[test]

--- a/src/genesis/mod.rs
+++ b/src/genesis/mod.rs
@@ -260,15 +260,15 @@ mod tests {
     fn test_genesis_config_valid_osaka1() {
         let cfg = parse_config_with_osaka1(json!({
             "time": 1820000000,
-            "minimumBaseFeeWei": 10000000000u64,
-            "minimumBlobBaseFeeWei": 10000000000u64
+            "minimumBaseFeeWei": 1000000000u64,
+            "minimumBlobBaseFeeWei": 1000000000u64
         }))
         .expect("berachain field must deserialize");
 
         let osaka1_config = cfg.osaka1.expect("Osaka1 should be configured");
         assert_eq!(osaka1_config.time, 1820000000);
-        assert_eq!(osaka1_config.minimum_base_fee_wei, 10000000000);
-        assert_eq!(osaka1_config.minimum_blob_base_fee_wei, 10000000000);
+        assert_eq!(osaka1_config.minimum_base_fee_wei, 1000000000);
+        assert_eq!(osaka1_config.minimum_blob_base_fee_wei, 1000000000);
     }
 
     #[test]
@@ -277,7 +277,7 @@ mod tests {
         // fail loudly instead of silently defaulting to 0.
         let res = parse_config_with_osaka1(json!({
             "time": 1820000000,
-            "minimumBaseFeeWei": 10000000000u64
+            "minimumBaseFeeWei": 1000000000u64
         }));
         assert!(res.is_err());
     }
@@ -288,7 +288,7 @@ mod tests {
         // below the EIP-4844 minimum, so both floors must be non-zero when Osaka1 is configured.
         let res = parse_config_with_osaka1(json!({
             "time": 1820000000,
-            "minimumBaseFeeWei": 10000000000u64,
+            "minimumBaseFeeWei": 1000000000u64,
             "minimumBlobBaseFeeWei": 0
         }));
         assert!(res.is_err());

--- a/src/hardforks/mod.rs
+++ b/src/hardforks/mod.rs
@@ -13,6 +13,8 @@ hardfork!(
         Prague3,
         /// Prague4 hardfork: Ends Prague3 restrictions
         Prague4,
+        /// Osaka1 hardfork: Raises the minimum base fee floor (anti-spam)
+        Osaka1,
     }
 );
 
@@ -42,6 +44,11 @@ pub trait BerachainHardforks: EthereumHardforks {
     fn is_prague4_active_at_timestamp(&self, timestamp: u64) -> bool {
         self.berachain_fork_activation(BerachainHardfork::Prague4).active_at_timestamp(timestamp)
     }
+
+    /// Checks if Osaka1 hardfork is active at given timestamp
+    fn is_osaka1_active_at_timestamp(&self, timestamp: u64) -> bool {
+        self.berachain_fork_activation(BerachainHardfork::Osaka1).active_at_timestamp(timestamp)
+    }
 }
 
 #[cfg(test)]
@@ -64,6 +71,7 @@ mod tests {
                 BerachainHardfork::Prague2 => ForkCondition::Timestamp(1000),
                 BerachainHardfork::Prague3 => ForkCondition::Timestamp(2000),
                 BerachainHardfork::Prague4 => ForkCondition::Timestamp(3000),
+                BerachainHardfork::Osaka1 => ForkCondition::Timestamp(4000),
             }
         }
     }
@@ -105,5 +113,12 @@ mod tests {
         assert!(!hardforks.is_prague4_active_at_timestamp(2999));
         assert!(hardforks.is_prague4_active_at_timestamp(3000));
         assert!(hardforks.is_prague4_active_at_timestamp(4000));
+
+        // Test Osaka1 activation and ordering
+        let activation = hardforks.berachain_fork_activation(BerachainHardfork::Osaka1);
+        assert_eq!(activation, ForkCondition::Timestamp(4000));
+        assert!(!hardforks.is_osaka1_active_at_timestamp(3999));
+        assert!(hardforks.is_osaka1_active_at_timestamp(4000));
+        assert!(hardforks.is_osaka1_active_at_timestamp(5000));
     }
 }

--- a/tests/e2e/deposit_test.rs
+++ b/tests/e2e/deposit_test.rs
@@ -100,12 +100,15 @@ async fn setup_deposit_test_with_osaka(
 ) -> eyre::Result<(Runtime, Arc<BerachainChainSpec>)> {
     let runtime = Runtime::with_existing_handle(tokio::runtime::Handle::current())?;
     let genesis_path = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/eth-genesis.json");
-    let genesis_json = std::fs::read_to_string(genesis_path)?;
-    let mut genesis: Genesis = parse_genesis(&genesis_json)?;
-    genesis.config.deposit_contract_address = Some(DEPOSIT_CONTRACT);
+    let mut genesis_json: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(genesis_path)?)?;
     if let Some(osaka_time) = osaka_time {
-        genesis.config.osaka_time = Some(osaka_time);
+        // Osaka1 must activate at or after Osaka, so it moves with it.
+        genesis_json["config"]["osakaTime"] = osaka_time.into();
+        genesis_json["config"]["berachain"]["osaka1"]["time"] = osaka_time.into();
     }
+    let mut genesis: Genesis = parse_genesis(&genesis_json.to_string())?;
+    genesis.config.deposit_contract_address = Some(DEPOSIT_CONTRACT);
     let bytecode = Bytes::from(alloy_primitives::hex::decode(DEPOSIT_EMITTER_BYTECODE).unwrap());
     genesis
         .alloc

--- a/tests/fixtures/bepolia-genesis.json
+++ b/tests/fixtures/bepolia-genesis.json
@@ -112,6 +112,11 @@
       "prague2": {
         "time": 1758124800,
         "minimumBaseFeeWei": 0
+      },
+      "osaka1": {
+        "time": 9999999999,
+        "minimumBaseFeeWei": 10000000000,
+        "minimumBlobBaseFeeWei": 10000000000
       }
     }
   },

--- a/tests/fixtures/bepolia-genesis.json
+++ b/tests/fixtures/bepolia-genesis.json
@@ -115,8 +115,8 @@
       },
       "osaka1": {
         "time": 1784736000,
-        "minimumBaseFeeWei": 10000000000,
-        "minimumBlobBaseFeeWei": 10000000000
+        "minimumBaseFeeWei": 1000000000,
+        "minimumBlobBaseFeeWei": 1000000000
       }
     }
   },

--- a/tests/fixtures/bepolia-genesis.json
+++ b/tests/fixtures/bepolia-genesis.json
@@ -114,7 +114,7 @@
         "minimumBaseFeeWei": 0
       },
       "osaka1": {
-        "time": 9999999999,
+        "time": 1784736000,
         "minimumBaseFeeWei": 10000000000,
         "minimumBlobBaseFeeWei": 10000000000
       }

--- a/tests/fixtures/eth-genesis.json
+++ b/tests/fixtures/eth-genesis.json
@@ -368,6 +368,11 @@
       "prague2": {
         "time": 0,
         "minimumBaseFeeWei": 0
+      },
+      "osaka1": {
+        "time": 9999999999,
+        "minimumBaseFeeWei": 10000000000,
+        "minimumBlobBaseFeeWei": 10000000000
       }
     },
     "berlinBlock": 0,

--- a/tests/fixtures/eth-genesis.json
+++ b/tests/fixtures/eth-genesis.json
@@ -371,8 +371,8 @@
       },
       "osaka1": {
         "time": 0,
-        "minimumBaseFeeWei": 10000000000,
-        "minimumBlobBaseFeeWei": 10000000000
+        "minimumBaseFeeWei": 1000000000,
+        "minimumBlobBaseFeeWei": 1000000000
       }
     },
     "berlinBlock": 0,

--- a/tests/fixtures/eth-genesis.json
+++ b/tests/fixtures/eth-genesis.json
@@ -370,7 +370,7 @@
         "minimumBaseFeeWei": 0
       },
       "osaka1": {
-        "time": 9999999999,
+        "time": 0,
         "minimumBaseFeeWei": 10000000000,
         "minimumBlobBaseFeeWei": 10000000000
       }


### PR DESCRIPTION
This PR introduces `Osaka1`, a Berachain EL hardfork that enforces a minimum base fee and a minimum blob base fee in consensus. This replaces the per-validator `minimum-priority-fee` flag deployed during the recent spam attack. The floors apply network-wide, and the fees are burned instead of paid to the proposer.

`Osaka1` is configured in genesis under `berachain.osaka1` with an activation time, `minimumBaseFeeWei`, and `minimumBlobBaseFeeWei`. Both floors are required and must be non-zero, and `Osaka1` must activate at or after `Osaka`. Misconfiguration fails at startup rather than silently disabling a floor. The base fee floor follows the same parent-timestamp convention as Prague1/Prague2, and the blob floor raises the base of the EIP-4844 fee curve (the EIP-7762 mechanism).

Osaka1 timestamp actication:
- Bepolia: `1784736000` (July 22, 2026 16:00 UTC), 1 gwei for both floors
- Mainnet: TBD
- Local dev and e2e genesis activate `Osaka1` at genesis, so the test suite runs with the floors live

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the Osaka1 hardfork in chain scheduling and activation.
  - Added configurable minimum base-fee and blob-fee floors for Osaka1.
  - Included Osaka1 settings in genesis configuration and hardfork status output.

- **Bug Fixes**
  - Ensured Osaka1 fee floors take precedence when active.
  - Added validation for missing, zero-valued, or incorrectly ordered Osaka1 settings.
  - Updated fork identification to reflect Osaka1 activation and terminal state.

- **Tests**
  - Expanded coverage for Osaka1 activation, fee-floor behavior, genesis validation, and fork IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->