### PR TITLE
fix(txpool): enforce minimum priority fee on legacy transactions

### DIFF
--- a/src/pool/mod.rs
+++ b/src/pool/mod.rs
@@ -1,7 +1,12 @@
 pub mod transaction;
+mod validate;
 
 use crate::{
-    chainspec::BerachainChainSpec, pool::transaction::BerachainPooledTransaction,
+    chainspec::BerachainChainSpec,
+    pool::{
+        transaction::BerachainPooledTransaction,
+        validate::LegacyMinimumPriorityFeeValidator,
+    },
     primitives::BerachainPrimitives,
 };
 use alloy_eips::{eip7840::BlobParams, merge::EPOCH_SLOTS};
@@ -58,20 +63,31 @@ where
         let blob_store =
             reth_node_builder::components::create_blob_store_with_cache(ctx, blob_cache_size)?;
 
-        let validator =
-            TransactionValidationTaskExecutor::eth_builder(ctx.provider().clone(), evm_config)
-                .set_eip4844(!blobs_disabled)
-                // BRIP-0010 Osaka does not adopt EIP-7594 (PeerDAS); keep EIP-4844 sidecars
-                // accepted across forks and reject EIP-7594 v1 sidecars.
-                .no_eip7594()
-                .with_max_tx_input_bytes(ctx.config().txpool.max_tx_input_bytes)
-                .kzg_settings(ctx.kzg_settings()?)
-                .with_local_transactions_config(pool_config.local_transactions_config.clone())
-                .set_tx_fee_cap(ctx.config().rpc.rpc_tx_fee_cap)
-                .with_max_tx_gas_limit(ctx.config().txpool.max_tx_gas_limit)
-                .with_minimum_priority_fee(ctx.config().txpool.minimum_priority_fee)
-                .with_additional_tasks(ctx.config().txpool.additional_validation_tasks)
-                .build_with_tasks(ctx.task_executor().clone(), blob_store.clone());
+        let minimum_priority_fee = ctx.config().txpool.minimum_priority_fee;
+        let local_transactions_config = pool_config.local_transactions_config.clone();
+        let provider = ctx.provider().clone();
+
+        let validator = TransactionValidationTaskExecutor::eth_builder(provider.clone(), evm_config)
+            .set_eip4844(!blobs_disabled)
+            // BRIP-0010 Osaka does not adopt EIP-7594 (PeerDAS); keep EIP-4844 sidecars
+            // accepted across forks and reject EIP-7594 v1 sidecars.
+            .no_eip7594()
+            .with_max_tx_input_bytes(ctx.config().txpool.max_tx_input_bytes)
+            .kzg_settings(ctx.kzg_settings()?)
+            .with_local_transactions_config(local_transactions_config.clone())
+            .set_tx_fee_cap(ctx.config().rpc.rpc_tx_fee_cap)
+            .with_max_tx_gas_limit(ctx.config().txpool.max_tx_gas_limit)
+            .with_minimum_priority_fee(minimum_priority_fee)
+            .with_additional_tasks(ctx.config().txpool.additional_validation_tasks)
+            .build_with_tasks(ctx.task_executor().clone(), blob_store.clone())
+            .map(move |inner| {
+                LegacyMinimumPriorityFeeValidator::new(
+                    inner,
+                    provider,
+                    minimum_priority_fee,
+                    local_transactions_config,
+                )
+            });
 
         if validator.validator().eip4844() {
             let kzg_settings = validator.validator().kzg_settings().clone();

--- a/src/pool/mod.rs
+++ b/src/pool/mod.rs
@@ -10,10 +10,7 @@ use crate::{
     primitives::BerachainPrimitives,
 };
 use alloy_eips::{eip7840::BlobParams, merge::EPOCH_SLOTS};
-use reth::{
-    api::NodeTypes,
-    transaction_pool::{EthTransactionPool, blobstore::DiskFileBlobStore},
-};
+use reth::{api::NodeTypes, transaction_pool::blobstore::DiskFileBlobStore};
 use reth_chainspec::EthChainSpec;
 use reth_evm::ConfigureEvm;
 use reth_node_api::FullNodeTypes;
@@ -21,8 +18,10 @@ use reth_node_builder::{
     BuilderContext,
     components::{PoolBuilder, TxPoolBuilder},
 };
-use reth_transaction_pool::TransactionValidationTaskExecutor;
-use std::{fmt::Debug, time::SystemTime};
+use reth_transaction_pool::{
+    CoinbaseTipOrdering, EthTransactionValidator, Pool, TransactionValidationTaskExecutor,
+};
+use std::{time::SystemTime};
 use tracing::{debug, info};
 
 #[derive(Debug, Default)]
@@ -34,8 +33,16 @@ where
     Node: FullNodeTypes<Types = Types>,
     Evm: ConfigureEvm<Primitives = BerachainPrimitives> + Clone + 'static,
 {
-    type Pool =
-        EthTransactionPool<Node::Provider, DiskFileBlobStore, Evm, BerachainPooledTransaction>;
+    type Pool = Pool<
+        TransactionValidationTaskExecutor<
+            LegacyMinimumPriorityFeeValidator<
+                EthTransactionValidator<Node::Provider, BerachainPooledTransaction, Evm>,
+                Node::Provider,
+            >,
+        >,
+        CoinbaseTipOrdering<BerachainPooledTransaction>,
+        DiskFileBlobStore,
+    >;
 
     async fn build_pool(
         self,
@@ -67,7 +74,7 @@ where
         let local_transactions_config = pool_config.local_transactions_config.clone();
         let provider = ctx.provider().clone();
 
-        let validator = TransactionValidationTaskExecutor::eth_builder(provider.clone(), evm_config)
+        let eth_validator = TransactionValidationTaskExecutor::eth_builder(provider.clone(), evm_config)
             .set_eip4844(!blobs_disabled)
             // BRIP-0010 Osaka does not adopt EIP-7594 (PeerDAS); keep EIP-4844 sidecars
             // accepted across forks and reject EIP-7594 v1 sidecars.
@@ -79,23 +86,24 @@ where
             .with_max_tx_gas_limit(ctx.config().txpool.max_tx_gas_limit)
             .with_minimum_priority_fee(minimum_priority_fee)
             .with_additional_tasks(ctx.config().txpool.additional_validation_tasks)
-            .build_with_tasks(ctx.task_executor().clone(), blob_store.clone())
-            .map(move |inner| {
-                LegacyMinimumPriorityFeeValidator::new(
-                    inner,
-                    provider,
-                    minimum_priority_fee,
-                    local_transactions_config,
-                )
-            });
+            .build_with_tasks(ctx.task_executor().clone(), blob_store.clone());
 
-        if validator.validator().eip4844() {
-            let kzg_settings = validator.validator().kzg_settings().clone();
+        if eth_validator.validator().eip4844() {
+            let kzg_settings = eth_validator.validator().kzg_settings().clone();
             ctx.task_executor().spawn_blocking_task(async move {
                 let _ = kzg_settings.get();
                 debug!(target: "reth::cli", "Initialized KZG settings");
             });
         }
+
+        let validator = eth_validator.map(move |inner| {
+            LegacyMinimumPriorityFeeValidator::new(
+                inner,
+                provider.clone(),
+                minimum_priority_fee,
+                local_transactions_config.clone(),
+            )
+        });
 
         let transaction_pool = TxPoolBuilder::new(ctx)
             .with_validator(validator)

--- a/src/pool/mod.rs
+++ b/src/pool/mod.rs
@@ -3,10 +3,7 @@ mod validate;
 
 use crate::{
     chainspec::BerachainChainSpec,
-    pool::{
-        transaction::BerachainPooledTransaction,
-        validate::LegacyMinimumPriorityFeeValidator,
-    },
+    pool::{transaction::BerachainPooledTransaction, validate::LegacyMinimumPriorityFeeValidator},
     primitives::BerachainPrimitives,
 };
 use alloy_eips::{eip7840::BlobParams, merge::EPOCH_SLOTS};
@@ -21,7 +18,7 @@ use reth_node_builder::{
 use reth_transaction_pool::{
     CoinbaseTipOrdering, EthTransactionValidator, Pool, TransactionValidationTaskExecutor,
 };
-use std::{time::SystemTime};
+use std::time::SystemTime;
 use tracing::{debug, info};
 
 #[derive(Debug, Default)]
@@ -74,19 +71,20 @@ where
         let local_transactions_config = pool_config.local_transactions_config.clone();
         let provider = ctx.provider().clone();
 
-        let eth_validator = TransactionValidationTaskExecutor::eth_builder(provider.clone(), evm_config)
-            .set_eip4844(!blobs_disabled)
-            // BRIP-0010 Osaka does not adopt EIP-7594 (PeerDAS); keep EIP-4844 sidecars
-            // accepted across forks and reject EIP-7594 v1 sidecars.
-            .no_eip7594()
-            .with_max_tx_input_bytes(ctx.config().txpool.max_tx_input_bytes)
-            .kzg_settings(ctx.kzg_settings()?)
-            .with_local_transactions_config(local_transactions_config.clone())
-            .set_tx_fee_cap(ctx.config().rpc.rpc_tx_fee_cap)
-            .with_max_tx_gas_limit(ctx.config().txpool.max_tx_gas_limit)
-            .with_minimum_priority_fee(minimum_priority_fee)
-            .with_additional_tasks(ctx.config().txpool.additional_validation_tasks)
-            .build_with_tasks(ctx.task_executor().clone(), blob_store.clone());
+        let eth_validator =
+            TransactionValidationTaskExecutor::eth_builder(provider.clone(), evm_config)
+                .set_eip4844(!blobs_disabled)
+                // BRIP-0010 Osaka does not adopt EIP-7594 (PeerDAS); keep EIP-4844 sidecars
+                // accepted across forks and reject EIP-7594 v1 sidecars.
+                .no_eip7594()
+                .with_max_tx_input_bytes(ctx.config().txpool.max_tx_input_bytes)
+                .kzg_settings(ctx.kzg_settings()?)
+                .with_local_transactions_config(local_transactions_config.clone())
+                .set_tx_fee_cap(ctx.config().rpc.rpc_tx_fee_cap)
+                .with_max_tx_gas_limit(ctx.config().txpool.max_tx_gas_limit)
+                .with_minimum_priority_fee(minimum_priority_fee)
+                .with_additional_tasks(ctx.config().txpool.additional_validation_tasks)
+                .build_with_tasks(ctx.task_executor().clone(), blob_store.clone());
 
         if eth_validator.validator().eip4844() {
             let kzg_settings = eth_validator.validator().kzg_settings().clone();

--- a/src/pool/validate.rs
+++ b/src/pool/validate.rs
@@ -11,8 +11,7 @@ use reth_primitives_traits::SealedBlock;
 use reth_storage_api::BlockReaderIdExt;
 use reth_transaction_pool::{
     LocalTransactionConfig, PoolTransaction, TransactionOrigin, TransactionValidationOutcome,
-    TransactionValidator,
-    error::InvalidPoolTransactionError,
+    TransactionValidator, error::InvalidPoolTransactionError,
 };
 
 /// Returns the configured minimum when a non-EIP-1559 transaction's effective tip is too low.
@@ -72,15 +71,13 @@ where
         origin: TransactionOrigin,
         transaction: Self::Transaction,
     ) -> TransactionValidationOutcome<Tx> {
-        let outcome =
-            self.inner.validate_transaction(origin, transaction.clone()).await;
+        let outcome = self.inner.validate_transaction(origin, transaction.clone()).await;
 
         let TransactionValidationOutcome::Valid { .. } = outcome else {
             return outcome;
         };
 
-        let is_local =
-            self.local_transactions_config.is_local(origin, transaction.sender_ref());
+        let is_local = self.local_transactions_config.is_local(origin, transaction.sender_ref());
 
         let base_fee = match self.client.latest_header() {
             Ok(Some(header)) => header.base_fee_per_gas().unwrap_or_default(),
@@ -122,26 +119,17 @@ mod tests {
 
     #[test]
     fn accepts_legacy_tip_at_floor() {
-        assert_eq!(
-            legacy_priority_fee_violation(false, false, Some(10_000_000), 10_000_000),
-            None
-        );
+        assert_eq!(legacy_priority_fee_violation(false, false, Some(10_000_000), 10_000_000), None);
     }
 
     #[test]
     fn skips_dynamic_fee_transactions() {
-        assert_eq!(
-            legacy_priority_fee_violation(true, false, Some(10_000_000), 1),
-            None
-        );
+        assert_eq!(legacy_priority_fee_violation(true, false, Some(10_000_000), 1), None);
     }
 
     #[test]
     fn skips_local_transactions() {
-        assert_eq!(
-            legacy_priority_fee_violation(false, true, Some(10_000_000), 1),
-            None
-        );
+        assert_eq!(legacy_priority_fee_violation(false, true, Some(10_000_000), 1), None);
     }
 
     #[test]

--- a/src/pool/validate.rs
+++ b/src/pool/validate.rs
@@ -4,7 +4,10 @@
 //! transactions. Legacy and access-list transactions bypass that check, which lets
 //! low-tip spam evade validator-side filters.
 
-use reth_primitives_traits::{BlockHeader, SealedBlock};
+use std::fmt;
+
+use alloy_consensus::BlockHeader;
+use reth_primitives_traits::SealedBlock;
 use reth_storage_api::BlockReaderIdExt;
 use reth_transaction_pool::{
     LocalTransactionConfig, PoolTransaction, TransactionOrigin, TransactionValidationOutcome,
@@ -28,12 +31,20 @@ pub(crate) fn legacy_priority_fee_violation(
 
 /// Wraps an inner [`TransactionValidator`] and rejects non-EIP-1559 transactions whose
 /// effective priority fee is below the configured minimum.
-#[derive(Debug)]
 pub struct LegacyMinimumPriorityFeeValidator<V, Client> {
     inner: V,
     client: Client,
     minimum_priority_fee: Option<u128>,
     local_transactions_config: LocalTransactionConfig,
+}
+
+impl<V: fmt::Debug, Client> fmt::Debug for LegacyMinimumPriorityFeeValidator<V, Client> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("LegacyMinimumPriorityFeeValidator")
+            .field("inner", &self.inner)
+            .field("minimum_priority_fee", &self.minimum_priority_fee)
+            .finish_non_exhaustive()
+    }
 }
 
 impl<V, Client> LegacyMinimumPriorityFeeValidator<V, Client> {
@@ -49,7 +60,7 @@ impl<V, Client> LegacyMinimumPriorityFeeValidator<V, Client> {
 
 impl<V, Client, Tx> TransactionValidator for LegacyMinimumPriorityFeeValidator<V, Client>
 where
-    V: TransactionValidator<Transaction = Tx>,
+    V: TransactionValidator<Transaction = Tx> + fmt::Debug,
     Client: BlockReaderIdExt,
     Tx: PoolTransaction,
 {

--- a/src/pool/validate.rs
+++ b/src/pool/validate.rs
@@ -1,0 +1,140 @@
+//! Berachain-specific transaction pool validation extensions.
+//!
+//! Upstream reth only enforces `--txpool.minimum-priority-fee` for EIP-1559 (type-2)
+//! transactions. Legacy and access-list transactions bypass that check, which lets
+//! low-tip spam evade validator-side filters.
+
+use reth_primitives_traits::{BlockHeader, SealedBlock};
+use reth_storage_api::BlockReaderIdExt;
+use reth_transaction_pool::{
+    LocalTransactionConfig, PoolTransaction, TransactionOrigin, TransactionValidationOutcome,
+    TransactionValidator,
+    error::InvalidPoolTransactionError,
+};
+
+/// Returns the configured minimum when a non-EIP-1559 transaction's effective tip is too low.
+pub(crate) fn legacy_priority_fee_violation(
+    is_dynamic_fee: bool,
+    is_local: bool,
+    minimum_priority_fee: Option<u128>,
+    effective_tip: u128,
+) -> Option<u128> {
+    let minimum_priority_fee = minimum_priority_fee?;
+    if is_local || is_dynamic_fee {
+        return None;
+    }
+    (effective_tip < minimum_priority_fee).then_some(minimum_priority_fee)
+}
+
+/// Wraps an inner [`TransactionValidator`] and rejects non-EIP-1559 transactions whose
+/// effective priority fee is below the configured minimum.
+#[derive(Debug)]
+pub struct LegacyMinimumPriorityFeeValidator<V, Client> {
+    inner: V,
+    client: Client,
+    minimum_priority_fee: Option<u128>,
+    local_transactions_config: LocalTransactionConfig,
+}
+
+impl<V, Client> LegacyMinimumPriorityFeeValidator<V, Client> {
+    pub const fn new(
+        inner: V,
+        client: Client,
+        minimum_priority_fee: Option<u128>,
+        local_transactions_config: LocalTransactionConfig,
+    ) -> Self {
+        Self { inner, client, minimum_priority_fee, local_transactions_config }
+    }
+}
+
+impl<V, Client, Tx> TransactionValidator for LegacyMinimumPriorityFeeValidator<V, Client>
+where
+    V: TransactionValidator<Transaction = Tx>,
+    Client: BlockReaderIdExt,
+    Tx: PoolTransaction,
+{
+    type Transaction = Tx;
+    type Block = V::Block;
+
+    async fn validate_transaction(
+        &self,
+        origin: TransactionOrigin,
+        transaction: Self::Transaction,
+    ) -> TransactionValidationOutcome<Tx> {
+        let outcome =
+            self.inner.validate_transaction(origin, transaction.clone()).await;
+
+        let TransactionValidationOutcome::Valid { .. } = outcome else {
+            return outcome;
+        };
+
+        let is_local =
+            self.local_transactions_config.is_local(origin, transaction.sender_ref());
+
+        let base_fee = match self.client.latest_header() {
+            Ok(Some(header)) => header.base_fee_per_gas().unwrap_or_default(),
+            Ok(None) | Err(_) => return outcome,
+        };
+
+        let effective_tip = transaction.effective_tip_per_gas(base_fee).unwrap_or(0);
+        if let Some(minimum_priority_fee) = legacy_priority_fee_violation(
+            transaction.is_dynamic_fee(),
+            is_local,
+            self.minimum_priority_fee,
+            effective_tip,
+        ) {
+            return TransactionValidationOutcome::Invalid(
+                transaction,
+                InvalidPoolTransactionError::PriorityFeeBelowMinimum { minimum_priority_fee },
+            );
+        }
+
+        outcome
+    }
+
+    fn on_new_head_block(&self, new_tip_block: &SealedBlock<Self::Block>) {
+        self.inner.on_new_head_block(new_tip_block);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::legacy_priority_fee_violation;
+
+    #[test]
+    fn rejects_low_legacy_tip() {
+        assert_eq!(
+            legacy_priority_fee_violation(false, false, Some(10_000_000), 2),
+            Some(10_000_000)
+        );
+    }
+
+    #[test]
+    fn accepts_legacy_tip_at_floor() {
+        assert_eq!(
+            legacy_priority_fee_violation(false, false, Some(10_000_000), 10_000_000),
+            None
+        );
+    }
+
+    #[test]
+    fn skips_dynamic_fee_transactions() {
+        assert_eq!(
+            legacy_priority_fee_violation(true, false, Some(10_000_000), 1),
+            None
+        );
+    }
+
+    #[test]
+    fn skips_local_transactions() {
+        assert_eq!(
+            legacy_priority_fee_violation(false, true, Some(10_000_000), 1),
+            None
+        );
+    }
+
+    #[test]
+    fn disabled_when_minimum_unset() {
+        assert_eq!(legacy_priority_fee_violation(false, false, None, 1), None);
+    }
+}


### PR DESCRIPTION
## Summary

- Wrap the eth transaction validator so `--txpool.minimum-priority-fee` also applies to legacy (type 0) and access-list (type 1) transactions.
- Upstream reth only checks `minimum_priority_fee` for EIP-1559 (`is_dynamic_fee()`) txs; spam operators switched to legacy txs with ~1–2 wei effective tip (`gasPrice - baseFee`) to bypass validator-side filters.
- Reject non-local legacy/access-list txs when `effective_tip_per_gas < minimum_priority_fee`, matching geth `MinTip` semantics.

## Context

Mainnet factory spam workers moved from type-2 (`maxPriorityFeePerGas: 1`) to type-0 (`gasPrice ≈ baseFee + 1–2 wei`) after validators rolled out `--txpool.minimum-priority-fee=10000000`.

## Test plan

- [x] `cargo test pool::validate --locked`
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] CI: fmt, clippy, deny, machete, nextest, docs


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for stricter transaction pool validation for legacy transactions, helping enforce a minimum priority fee when applicable.
  * Improved transaction handling in the pool with updated validation and ordering behavior.

* **Bug Fixes**
  * Transactions that are local, dynamic-fee, or missing fee data now bypass the minimum-fee check as expected.
  * Validation now consistently rejects legacy transactions that fall below the configured priority fee threshold.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->