### PR TITLE
fix(txpool): enforce min effective tip on all txs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1449,7 +1449,7 @@ checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
 name = "bera-reth"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bera-reth"
-version = "1.4.1"
+version = "1.4.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ alloy-rpc-types-trace = "1.6.3"
 eyre = "0.6.12"
 reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.4" }
 reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.4" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.4", features = ["test-utils"] }
 reth-trie-common = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.4" }
 revm-inspectors = "0.34.2"
 test-fuzz = "7"

--- a/src/pool/min_priority_fee.rs
+++ b/src/pool/min_priority_fee.rs
@@ -1,0 +1,182 @@
+//! [`MinPriorityFeeValidator`]: enforce a minimum priority fee (tip) on every transaction
+//! type.
+//!
+//! reth's built-in `--txpool.minimum-priority-fee` has two gaps a spammer can exploit:
+//!   1. it only checks *dynamic-fee* transactions (`is_dynamic_fee()`), so legacy and EIP-2930
+//!      transactions bypass it entirely, and
+//!   2. it compares the declared `max_priority_fee_per_gas` *cap*, not the tip actually paid, so a
+//!      transaction with `maxFeePerGas == baseFee` pays a zero effective tip while still passing
+//!      the cap check.
+//!
+//! This wrapper closes both. It derives the *effective* tip for every transaction type
+//! against the next-block (pending) base fee, the same base fee the pool's own fee policy
+//! uses, and rejects externally-received transactions below the floor. While the floor is
+//! active, non-local transactions that cannot cover the base fee are rejected rather than
+//! parked, because the pool promotes parked transactions without re-validation once the
+//! base fee dips, which would readmit zero-tip spam.
+//!
+//! The floor is enforced at admission only, like reth's built-in check. A transaction
+//! admitted at the floor can later be demoted by a base fee rise and re-promoted without
+//! re-validation once the base fee dips, paying below the floor at inclusion. It is a
+//! mempool policy only (it never changes block validity), so it is safe to deploy without
+//! a fork, with the usual caveat that it only governs what this node admits and builds.
+
+use std::sync::{
+    Arc,
+    atomic::{AtomicU64, Ordering},
+};
+
+use alloy_consensus::{BlockHeader, Transaction};
+use reth_chainspec::EthChainSpec;
+use reth_primitives_traits::{Block, SealedBlock};
+use reth_transaction_pool::{
+    LocalTransactionConfig, PoolTransaction, TransactionOrigin, TransactionValidationOutcome,
+    TransactionValidator, error::InvalidPoolTransactionError,
+};
+
+/// Reassembles batch outcomes in input order, filling the empty slots from `validated`.
+fn merge_outcomes<T>(slots: Vec<Option<T>>, validated: impl IntoIterator<Item = T>) -> Vec<T> {
+    let mut validated = validated.into_iter();
+    slots
+        .into_iter()
+        .map(|slot| {
+            slot.unwrap_or_else(|| {
+                validated.next().expect("inner validator returns one outcome per transaction")
+            })
+        })
+        .collect()
+}
+
+/// Wraps a [`TransactionValidator`] and rejects non-local transactions whose effective tip
+/// is below `minimum_priority_fee`, across all transaction types.
+#[derive(Debug)]
+pub struct MinPriorityFeeValidator<V, C> {
+    inner: V,
+    /// Minimum effective tip in wei. `0` disables the check.
+    minimum_priority_fee: u128,
+    /// Local-transaction policy (honors `--txpool.locals` / `--txpool.no-locals`) that
+    /// decides which transactions are exempt from the tip floor.
+    local_transactions_config: LocalTransactionConfig,
+    /// Chain spec used to derive the next-block base fee from each new head.
+    chain_spec: Arc<C>,
+    /// Next-block (pending) base fee in wei, matching the base fee the pool's own fee
+    /// policy uses, so admission mirrors what the transaction would pay if included in the
+    /// next block. Seeded at construction so the floor is live before the first canonical
+    /// block arrives, then re-derived from every new head.
+    base_fee: AtomicU64,
+}
+
+impl<V, C> MinPriorityFeeValidator<V, C> {
+    /// Wrap `inner`, requiring at least `minimum_priority_fee` wei of effective tip from
+    /// non-local transactions. `initial_base_fee` should be the next-block base fee of the
+    /// current head so the floor is enforced from startup.
+    pub const fn new(
+        inner: V,
+        minimum_priority_fee: u128,
+        local_transactions_config: LocalTransactionConfig,
+        chain_spec: Arc<C>,
+        initial_base_fee: u64,
+    ) -> Self {
+        Self {
+            inner,
+            minimum_priority_fee,
+            local_transactions_config,
+            chain_spec,
+            base_fee: AtomicU64::new(initial_base_fee),
+        }
+    }
+}
+
+impl<V, C> MinPriorityFeeValidator<V, C>
+where
+    V: TransactionValidator,
+{
+    /// Whether the floor applies to this transaction and its effective tip falls below it.
+    ///
+    /// A transaction that cannot cover the base fee (`effective_tip_per_gas` returns
+    /// `None`) is treated as paying no tip, so the floor rejects it instead of letting the
+    /// pool park it and promote it later without re-validation.
+    fn is_below_minimum(&self, origin: TransactionOrigin, transaction: &V::Transaction) -> bool {
+        self.minimum_priority_fee > 0 &&
+            !self.local_transactions_config.is_local(origin, transaction.sender_ref()) &&
+            transaction
+                .effective_tip_per_gas(self.base_fee.load(Ordering::Relaxed))
+                .unwrap_or_default() <
+                self.minimum_priority_fee
+    }
+
+    fn reject(&self, transaction: V::Transaction) -> TransactionValidationOutcome<V::Transaction> {
+        TransactionValidationOutcome::Invalid(
+            transaction,
+            InvalidPoolTransactionError::PriorityFeeBelowMinimum {
+                minimum_priority_fee: self.minimum_priority_fee,
+            },
+        )
+    }
+}
+
+impl<V, C> TransactionValidator for MinPriorityFeeValidator<V, C>
+where
+    V: TransactionValidator,
+    C: EthChainSpec<Header = <V::Block as Block>::Header>,
+{
+    type Transaction = V::Transaction;
+    type Block = V::Block;
+
+    async fn validate_transaction(
+        &self,
+        origin: TransactionOrigin,
+        transaction: Self::Transaction,
+    ) -> TransactionValidationOutcome<Self::Transaction> {
+        if self.is_below_minimum(origin, &transaction) {
+            return self.reject(transaction);
+        }
+        self.inner.validate_transaction(origin, transaction).await
+    }
+
+    /// Overridden so batches keep the inner validator's batch path, which shares one state
+    /// provider across the whole batch. The trait default would fall back to per-transaction
+    /// validation and acquire a fresh provider for every transaction.
+    async fn validate_transactions(
+        &self,
+        transactions: impl IntoIterator<Item = (TransactionOrigin, Self::Transaction), IntoIter: Send>
+        + Send,
+    ) -> Vec<TransactionValidationOutcome<Self::Transaction>> {
+        let mut slots = Vec::new();
+        let mut to_validate = Vec::new();
+        for (origin, transaction) in transactions {
+            if self.is_below_minimum(origin, &transaction) {
+                slots.push(Some(self.reject(transaction)));
+            } else {
+                slots.push(None);
+                to_validate.push((origin, transaction));
+            }
+        }
+        merge_outcomes(slots, self.inner.validate_transactions(to_validate).await)
+    }
+
+    fn on_new_head_block(&self, new_tip_block: &SealedBlock<Self::Block>) {
+        if let Some(base_fee) = self
+            .chain_spec
+            .next_block_base_fee(new_tip_block.header(), new_tip_block.header().timestamp())
+        {
+            self.base_fee.store(base_fee, Ordering::Relaxed);
+        }
+        self.inner.on_new_head_block(new_tip_block);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::merge_outcomes;
+
+    #[test]
+    fn merge_outcomes_preserves_input_order() {
+        // Rejected slots (Some) interleave with inner-validated outcomes in input order.
+        let merged = merge_outcomes(vec![None, Some(10), None, Some(11), None], vec![0, 1, 2]);
+        assert_eq!(merged, vec![0, 10, 1, 11, 2]);
+
+        let all_rejected = merge_outcomes(vec![Some(10), Some(11)], vec![]);
+        assert_eq!(all_rejected, vec![10, 11]);
+    }
+}

--- a/src/pool/min_priority_fee.rs
+++ b/src/pool/min_priority_fee.rs
@@ -168,15 +168,136 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::merge_outcomes;
+    use super::MinPriorityFeeValidator;
+    use crate::{
+        chainspec::BerachainChainSpec,
+        primitives::{BerachainBlock, BerachainHeader},
+    };
+    use alloy_genesis::Genesis;
+    use alloy_primitives::U256;
+    use reth::rpc::types::serde_helpers::OtherFields;
+    use reth_chainspec::EthChainSpec;
+    use reth_primitives_traits::SealedBlock;
+    use reth_transaction_pool::{
+        LocalTransactionConfig, PoolTransaction,
+        TransactionOrigin::{self, External, Local},
+        TransactionValidationOutcome::{self, Invalid},
+        TransactionValidator,
+        error::InvalidPoolTransactionError::{PriorityFeeBelowMinimum, Underpriced},
+        test_utils::MockTransaction,
+    };
+    use serde_json::json;
+    use std::sync::Arc;
 
-    #[test]
-    fn merge_outcomes_preserves_input_order() {
-        // Rejected slots (Some) interleave with inner-validated outcomes in input order.
-        let merged = merge_outcomes(vec![None, Some(10), None, Some(11), None], vec![0, 1, 2]);
-        assert_eq!(merged, vec![0, 10, 1, 11, 2]);
+    const FLOOR: u128 = 1_000_000_000;
+    const BASE_FEE: u128 = 50_000_000_000;
 
-        let all_rejected = merge_outcomes(vec![Some(10), Some(11)], vec![]);
-        assert_eq!(all_rejected, vec![10, 11]);
+    type Wrapper = MinPriorityFeeValidator<SentinelInner, BerachainChainSpec>;
+
+    /// Inner stub marking every transaction it receives with a sentinel error, so tests can
+    /// tell whether the wrapper forwarded a transaction or floor-rejected it first.
+    #[derive(Debug)]
+    struct SentinelInner;
+
+    impl TransactionValidator for SentinelInner {
+        type Transaction = MockTransaction;
+        type Block = BerachainBlock;
+
+        async fn validate_transaction(
+            &self,
+            _origin: TransactionOrigin,
+            transaction: Self::Transaction,
+        ) -> TransactionValidationOutcome<Self::Transaction> {
+            Invalid(transaction, Underpriced)
+        }
+    }
+
+    fn chain_spec() -> Arc<BerachainChainSpec> {
+        let mut genesis = Genesis::default();
+        genesis.config.cancun_time = Some(0);
+        genesis.config.prague_time = Some(0);
+        genesis.config.terminal_total_difficulty = Some(U256::ZERO);
+        genesis.config.extra_fields = OtherFields::try_from(json!({
+            "berachain": {
+                "prague1": { "time": 0, "baseFeeChangeDenominator": 48, "minimumBaseFeeWei": 10,
+                             "polDistributorAddress": "0x4200000000000000000000000000000000000042" },
+                "prague2": { "time": 0, "minimumBaseFeeWei": 0 }
+            }
+        }))
+        .unwrap();
+        Arc::new(BerachainChainSpec::from(genesis))
+    }
+
+    fn validator(floor: u128) -> Wrapper {
+        let locals = LocalTransactionConfig::default();
+        MinPriorityFeeValidator::new(SentinelInner, floor, locals, chain_spec(), BASE_FEE as u64)
+    }
+
+    async fn rejects(v: &Wrapper, origin: TransactionOrigin, tx: MockTransaction) -> bool {
+        let outcome = v.validate_transaction(origin, tx).await;
+        matches!(outcome, Invalid(_, PriorityFeeBelowMinimum { .. }))
+    }
+
+    fn legacy(gas_price: u128) -> MockTransaction {
+        MockTransaction::legacy().with_gas_price(gas_price)
+    }
+
+    fn eip1559(max_fee: u128, tip_cap: u128) -> MockTransaction {
+        MockTransaction::eip1559().with_max_fee(max_fee).with_priority_fee(tip_cap)
+    }
+
+    #[tokio::test]
+    async fn enforces_effective_tip_floor_on_external_transactions() {
+        let v = validator(FLOOR);
+        // The two gaps in reth's built-in check: legacy is exempt entirely, and a declared
+        // cap clearing the floor passes even when maxFee == baseFee makes the paid tip zero.
+        assert!(rejects(&v, External, legacy(BASE_FEE)).await);
+        assert!(rejects(&v, External, eip1559(BASE_FEE, 10 * FLOOR)).await);
+        assert!(rejects(&v, External, eip1559(BASE_FEE + FLOOR, FLOOR - 1)).await);
+        assert!(!rejects(&v, External, eip1559(BASE_FEE + FLOOR, FLOOR)).await);
+        // Local transactions are exempt, and floor 0 disables the check entirely.
+        assert!(!rejects(&v, Local, legacy(BASE_FEE)).await);
+        assert!(!rejects(&validator(0), External, legacy(BASE_FEE)).await);
+    }
+
+    #[tokio::test]
+    async fn batch_preserves_input_order_with_interleaved_rejections() {
+        let v = validator(FLOOR);
+        let txs = vec![
+            eip1559(BASE_FEE + FLOOR, FLOOR),
+            legacy(BASE_FEE),
+            eip1559(BASE_FEE + 2 * FLOOR, 2 * FLOOR),
+            eip1559(BASE_FEE, 10 * FLOOR),
+        ];
+        let hashes: Vec<_> = txs.iter().map(|tx| *tx.hash()).collect();
+        let outcomes = v.validate_transactions(txs.into_iter().map(|tx| (External, tx))).await;
+
+        for (i, expect_rejected) in [false, true, false, true].into_iter().enumerate() {
+            let Invalid(tx, err) = &outcomes[i] else { panic!("bad outcome: {:?}", outcomes[i]) };
+            assert_eq!(*tx.hash(), hashes[i], "outcome {i} does not match input order");
+            assert_eq!(matches!(err, PriorityFeeBelowMinimum { .. }), expect_rejected);
+        }
+    }
+
+    #[tokio::test]
+    async fn new_head_updates_floor_to_next_block_base_fee() {
+        let v = validator(FLOOR);
+        // A full block, so the next-block base fee rises above the head's own base fee.
+        let header = BerachainHeader {
+            timestamp: 1000,
+            gas_limit: 30_000_000,
+            gas_used: 30_000_000,
+            base_fee_per_gas: Some(BASE_FEE as u64),
+            ..Default::default()
+        };
+        let pending = u128::from(chain_spec().next_block_base_fee(&header, 1000).unwrap());
+        assert!(pending > BASE_FEE);
+        let head = SealedBlock::seal_slow(BerachainBlock { header, body: Default::default() });
+        v.on_new_head_block(&head);
+
+        // The floor boundary now sits exactly at the derived next-block base fee. Evaluating
+        // against the head's own (lower) base fee would let the second transaction through.
+        assert!(!rejects(&v, External, eip1559(pending + FLOOR, FLOOR)).await);
+        assert!(rejects(&v, External, eip1559(pending + FLOOR - 1, FLOOR)).await);
     }
 }

--- a/src/pool/mod.rs
+++ b/src/pool/mod.rs
@@ -1,14 +1,14 @@
+pub mod min_priority_fee;
 pub mod transaction;
 
 use crate::{
-    chainspec::BerachainChainSpec, pool::transaction::BerachainPooledTransaction,
+    chainspec::BerachainChainSpec,
+    pool::{min_priority_fee::MinPriorityFeeValidator, transaction::BerachainPooledTransaction},
     primitives::BerachainPrimitives,
 };
+use alloy_consensus::BlockHeader;
 use alloy_eips::{eip7840::BlobParams, merge::EPOCH_SLOTS};
-use reth::{
-    api::NodeTypes,
-    transaction_pool::{EthTransactionPool, blobstore::DiskFileBlobStore},
-};
+use reth::{api::NodeTypes, transaction_pool::blobstore::DiskFileBlobStore};
 use reth_chainspec::EthChainSpec;
 use reth_evm::ConfigureEvm;
 use reth_node_api::FullNodeTypes;
@@ -16,7 +16,10 @@ use reth_node_builder::{
     BuilderContext,
     components::{PoolBuilder, TxPoolBuilder},
 };
-use reth_transaction_pool::TransactionValidationTaskExecutor;
+use reth_storage_api::BlockReaderIdExt;
+use reth_transaction_pool::{
+    CoinbaseTipOrdering, EthTransactionValidator, Pool, TransactionValidationTaskExecutor,
+};
 use std::{fmt::Debug, time::SystemTime};
 use tracing::{debug, info};
 
@@ -29,8 +32,16 @@ where
     Node: FullNodeTypes<Types = Types>,
     Evm: ConfigureEvm<Primitives = BerachainPrimitives> + Clone + 'static,
 {
-    type Pool =
-        EthTransactionPool<Node::Provider, DiskFileBlobStore, Evm, BerachainPooledTransaction>;
+    type Pool = Pool<
+        TransactionValidationTaskExecutor<
+            MinPriorityFeeValidator<
+                EthTransactionValidator<Node::Provider, BerachainPooledTransaction, Evm>,
+                BerachainChainSpec,
+            >,
+        >,
+        CoinbaseTipOrdering<BerachainPooledTransaction>,
+        DiskFileBlobStore,
+    >;
 
     async fn build_pool(
         self,
@@ -69,7 +80,6 @@ where
                 .with_local_transactions_config(pool_config.local_transactions_config.clone())
                 .set_tx_fee_cap(ctx.config().rpc.rpc_tx_fee_cap)
                 .with_max_tx_gas_limit(ctx.config().txpool.max_tx_gas_limit)
-                .with_minimum_priority_fee(ctx.config().txpool.minimum_priority_fee)
                 .with_additional_tasks(ctx.config().txpool.additional_validation_tasks)
                 .build_with_tasks(ctx.task_executor().clone(), blob_store.clone());
 
@@ -80,6 +90,27 @@ where
                 debug!(target: "reth::cli", "Initialized KZG settings");
             });
         }
+
+        // Enforce the configured minimum priority fee across ALL transaction types. reth's
+        // built-in filter exempts legacy/EIP-2930 and checks the declared fee cap instead of
+        // the effective tip, both of which a spammer can exploit.
+        let minimum_priority_fee = ctx.config().txpool.minimum_priority_fee.unwrap_or(0);
+        let chain_spec = ctx.chain_spec();
+        let initial_base_fee = ctx
+            .provider()
+            .latest_header()?
+            .and_then(|header| chain_spec.next_block_base_fee(header.header(), header.timestamp()))
+            .unwrap_or_default();
+        let local_transactions_config = pool_config.local_transactions_config.clone();
+        let validator = validator.map(move |inner| {
+            MinPriorityFeeValidator::new(
+                inner,
+                minimum_priority_fee,
+                local_transactions_config.clone(),
+                chain_spec.clone(),
+                initial_base_fee,
+            )
+        });
 
         let transaction_pool = TxPoolBuilder::new(ctx)
             .with_validator(validator)


### PR DESCRIPTION
Builds upon #269, which enforces `--txpool.minimum-priority-fee` on legacy transactions. This PR extends the same idea to every transaction type. The gap left open after #269 is that dynamic-fee transactions are still only checked against their declared priority-fee cap, not the tip they actually pay. A spam transaction can declare a high cap, set `maxFeePerGas ≈ baseFee`, pass the check, and tip the validator ~0.

The new `MinPriorityFeeValidator` closes this by computing the effective tip each transaction would pay at the current base fee and rejecting non-local transactions below the configured floor. The check runs before reth's own validation, so spam is dropped cheaply, and batches keep reth's shared state view. Transactions that cannot cover the base fee are rejected instead of parked, because the pool would later promote them without re-checking the floor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added minimum effective priority-fee enforcement for non-local transactions, improving transaction prioritization based on tips relative to the next-block base fee.
  - Updated pool validation so batch results remain in the original input order while applying fee checks consistently across transaction types.
- **Chores**
  - Bumped the package version to `1.4.2`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->