### PR TITLE
chore: set bera-reth version to 1.4.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1449,7 +1449,7 @@ checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
 name = "bera-reth"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bera-reth"
-version = "1.4.2"
+version = "1.4.3"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 


### PR DESCRIPTION
see title

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Bumped the package version from 1.4.2 to 1.4.3.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->