### PR TITLE
chore(ci): stop rebuilding cross on every release run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,9 @@ jobs:
     needs: extract-version
     continue-on-error: ${{ matrix.configs.allow_fail }}
     strategy:
-      fail-fast: true
+      # Keep sibling targets running so a flaky target can be re-run on its own
+      # instead of forcing a rebuild of the whole matrix.
+      fail-fast: false
       matrix:
         configs:
           - target: x86_64-unknown-linux-gnu
@@ -83,20 +85,21 @@ jobs:
             allow_fail: false
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
-      - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # staging
-        if: runner.os == 'Linux'
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: stable
           target: ${{ matrix.configs.target }}
+      # Must stay ahead of `cargo install` so CARGO_HOME/bin and the .crates
+      # manifests are restored before cross is resolved, otherwise cross is
+      # rebuilt from source on every run.
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          cache-on-failure: true
       - name: Install cross
         if: runner.os == 'Linux'
         # Pinned to a cross main commit (last release v0.2.5 is too stale); bump deliberately.
         run: |
           cargo install cross --locked --git https://github.com/cross-rs/cross --rev 29d00c7803f221f1b3f35e561b03792368fb8339 # main @ 2026-06-06
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          cache-on-failure: true
 
       - name: Build Bera-Reth
         run: make PROFILE=${{ matrix.configs.profile }} build-${{ matrix.configs.target }}


### PR DESCRIPTION
## Summary

Three low-risk fixes to the release matrix. None of them change the compiled binary or the release artifacts.

**`cross` was recompiled from source on every run.** `Swatinem/rust-cache` was ordered *after* `cargo install cross`, so `CARGO_HOME/bin`, `.crates.toml` and `.crates2.json` were restored too late for cargo to see that the pinned rev was already installed. On top of that, the action's save step only keeps binaries that appeared *after* it ran, so `cross` was never written to the cache in the first place. Moving the cache step ahead of the install fixes both halves. It cost ~48s on each Linux job in every release today (v1.4.3-rc.1, v1.4.3, v1.4.4-rc.0, v1.4.4).

**`setup-mold` did nothing.** Both Linux targets build via `cross build`, which compiles inside the `ubuntu:24.04` container declared in `Cross.toml`. A linker installed on the host isn't visible there, and neither `Cross.toml` nor `.cargo/config.toml` selects it (`rg -i 'mold|fuse-ld'` matched only this step). Removed. Making mold actually apply inside the container is worth doing separately, but it changes linking under `-C target-feature=+crt-static` and shouldn't ride along with a release-critical change.

**`fail-fast: true` on a release matrix.** A transient failure in one target (an `apt-get` hiccup in the cross container, for instance) cancelled the other two and required re-running all three ~25 minute builds. Now a single target can be retried on its own.

## Follow-ups not included here

- `aarch64-apple-darwin` on the 3-core `macos-14` runner is the critical path in every release (28m / 27m / 20m build step vs 21–26m on Linux). Since the matrix runs in parallel, a larger Apple-silicon runner is the only thing that shortens wall-clock release time.
- `v1.4.4-rc.0` and `v1.4.4` share the tree `48c10a88edb4467d44157aef3ff6808f265e8ac6`, so identical source was compiled twice ~35 minutes apart. Keying artifact reuse on the tree SHA would let an rc→final promotion re-sign the existing binaries instead of rebuilding.
- `maxperf` is `lto = "fat"` with `codegen-units = 1`, which is where most of the 20–28 minutes goes. Thin LTO for `-rc` tags only would be measurable to evaluate without affecting shipped builds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Release builds now continue testing remaining targets when one matrix target fails.
  * Updated build setup and toolchain caching steps to improve release workflow reliability.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->