### PR TITLE
Auto-resolve --manifest-url for Berachain chains on bera-reth download

### DIFF
--- a/src/download_manifest_url.rs
+++ b/src/download_manifest_url.rs
@@ -21,6 +21,8 @@
 //! where `S3_EL_PREFIX = "v2/<chain>/reth"`. This mirrors the object layout
 //! documented in `infra-snapshots/project/reference/storage-v2.md`.
 
+use std::ffi::{OsStr, OsString};
+
 const PUBLIC_BASE: &str = "https://bera-snapshots.fsn1.your-objectstorage.com";
 
 /// Chains this resolver knows how to look up. Mirrors `chainspec::mod.rs`'s
@@ -43,7 +45,13 @@ const CLUSTERABLE_BOOL_SHORTS: &[char] = &['y', 'v', 'q'];
 /// commands whose subcommand is not `download`, a download that already
 /// names a manifest source, an unrecognized `--chain` value, or
 /// `--list`/`--help`.
-pub(crate) fn with_resolved_manifest_url(argv: Vec<String>) -> Vec<String> {
+///
+/// Operates on `OsString` so that arguments which are not valid UTF-8 (a
+/// non-UTF-8 datadir or custom genesis path, which clap accepts via
+/// `args_os`) pass through untouched instead of aborting the process. Such
+/// tokens can never spell `download`, `--chain`, or a manifest-source flag,
+/// so they are simply never matched.
+pub(crate) fn with_resolved_manifest_url(argv: Vec<OsString>) -> Vec<OsString> {
     let Some(download_args) = download_subcommand_args(&argv) else {
         return argv;
     };
@@ -56,19 +64,28 @@ pub(crate) fn with_resolved_manifest_url(argv: Vec<String>) -> Vec<String> {
         return argv;
     };
 
-    if !KNOWN_CHAINS.contains(&chain.as_str()) {
+    if !KNOWN_CHAINS.contains(&chain) {
         return argv;
     }
 
+    let url = manifest_url(chain);
     let mut argv = argv;
-    argv.push("--manifest-url".to_string());
-    argv.push(manifest_url(&chain));
+    argv.push("--manifest-url".into());
+    argv.push(url.into());
     argv
 }
 
 /// The fixed, in-place-overwritten manifest URL for a known chain.
 fn manifest_url(chain: &str) -> String {
     format!("{PUBLIC_BASE}/v2/{chain}/reth/manifest.json")
+}
+
+/// Whether an argument token begins with `-`, i.e. is an option rather than
+/// a subcommand or value. Checked at the byte level so that non-UTF-8 tokens
+/// are classified too: `OsStr::as_encoded_bytes` guarantees ASCII is
+/// preserved on every platform.
+fn is_option_like(arg: &OsStr) -> bool {
+    arg.as_encoded_bytes().starts_with(b"-")
 }
 
 /// Returns the arguments following the `download` subcommand token, or
@@ -86,16 +103,16 @@ fn manifest_url(chain: &str) -> String {
 /// subcommand, so no injection happens; the operator sees the normal
 /// upstream error and can either pass `--manifest-url` or write the option
 /// as `--color=never`. Failing closed here is deliberate.
-fn download_subcommand_args(argv: &[String]) -> Option<&[String]> {
-    let subcommand_index = argv.iter().skip(1).position(|a| !a.starts_with('-'))? + 1;
+fn download_subcommand_args(argv: &[OsString]) -> Option<&[OsString]> {
+    let subcommand_index = argv.iter().skip(1).position(|a| !is_option_like(a))? + 1;
     (argv[subcommand_index] == "download").then(|| &argv[subcommand_index + 1..])
 }
 
 /// Whether the operator already named a manifest source, in any of the
 /// spellings clap accepts for `DownloadCommand`'s `--manifest-url`,
 /// `--manifest-path`, and `-u`/`--url` options.
-fn has_explicit_manifest_source(download_args: &[String]) -> bool {
-    download_args.iter().any(|a| {
+fn has_explicit_manifest_source(download_args: &[OsString]) -> bool {
+    download_args.iter().filter_map(|a| a.to_str()).any(|a| {
         a == "--manifest-url" ||
             a.starts_with("--manifest-url=") ||
             a == "--manifest-path" ||
@@ -121,20 +138,23 @@ fn is_short_url_option(arg: &str) -> bool {
 
 /// `--list` and `--help` never need a manifest source: `--list` conflicts
 /// with one in clap, and `--help` exits before any download runs.
-fn is_list_or_help(download_args: &[String]) -> bool {
+fn is_list_or_help(download_args: &[OsString]) -> bool {
     download_args
         .iter()
         .any(|a| a == "--list" || a == "--list-snapshots" || a == "-h" || a == "--help")
 }
 
 /// Extracts the value of `--chain <value>` or `--chain=<value>`.
-fn chain_arg(download_args: &[String]) -> Option<String> {
+///
+/// Returns `None` for a non-UTF-8 value: that can only be a custom genesis
+/// path, which is never one of [`KNOWN_CHAINS`] and so needs no lookup.
+fn chain_arg(download_args: &[OsString]) -> Option<&str> {
     for (i, arg) in download_args.iter().enumerate() {
-        if let Some(value) = arg.strip_prefix("--chain=") {
-            return Some(value.to_string());
+        if let Some(value) = arg.to_str().and_then(|a| a.strip_prefix("--chain=")) {
+            return Some(value);
         }
         if arg == "--chain" {
-            return download_args.get(i + 1).filter(|v| !v.starts_with('-')).cloned();
+            return download_args.get(i + 1).filter(|v| !is_option_like(v))?.to_str();
         }
     }
     None
@@ -169,7 +189,7 @@ mod tests {
 
     #[test]
     fn injects_when_global_options_precede_download_subcommand() {
-        let argv: Vec<String> = vec![
+        let argv: Vec<OsString> = vec![
             "bera-reth".into(),
             "-vvv".into(),
             "--color=never".into(),
@@ -187,17 +207,51 @@ mod tests {
 
     #[test]
     fn chain_arg_supports_equals_form() {
-        let argv = vec!["bera-reth".into(), "download".into(), "--chain=mainnet".into()];
-        assert_eq!(
-            chain_arg(download_subcommand_args(&argv).unwrap()),
-            Some("mainnet".to_string())
-        );
+        let argv: Vec<OsString> =
+            vec!["bera-reth".into(), "download".into(), "--chain=mainnet".into()];
+        assert_eq!(chain_arg(download_subcommand_args(&argv).unwrap()), Some("mainnet"));
     }
 
     #[test]
     fn chain_arg_ignores_missing_value() {
-        let argv: Vec<String> = vec!["download".into(), "--chain".into(), "--minimal".into()];
+        let argv: Vec<OsString> = vec!["download".into(), "--chain".into(), "--minimal".into()];
         assert_eq!(chain_arg(&argv[1..]), None);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn passes_non_utf8_arguments_through_untouched() {
+        use std::os::unix::ffi::OsStrExt;
+
+        let non_utf8 = OsStr::from_bytes(b"/data/gen\xff\xfesis.json").to_os_string();
+        assert!(non_utf8.to_str().is_none(), "fixture must not be valid UTF-8");
+
+        // A non-UTF-8 custom genesis path is never a known chain: no injection,
+        // and crucially no panic anywhere in the scan.
+        let genesis: Vec<OsString> =
+            vec!["bera-reth".into(), "download".into(), "--chain".into(), non_utf8.clone()];
+        assert_eq!(with_resolved_manifest_url(genesis.clone()), genesis);
+
+        // A non-UTF-8 value elsewhere on a `download` must not block a
+        // known-chain lookup.
+        let datadir: Vec<OsString> = vec![
+            "bera-reth".into(),
+            "download".into(),
+            "--datadir".into(),
+            non_utf8.clone(),
+            "--chain".into(),
+            "bepolia".into(),
+        ];
+        let resolved = with_resolved_manifest_url(datadir);
+        assert_eq!(
+            resolved.last().unwrap(),
+            "https://bera-snapshots.fsn1.your-objectstorage.com/v2/bepolia/reth/manifest.json"
+        );
+
+        // And a non-UTF-8 value on a non-`download` command is simply not ours.
+        let node: Vec<OsString> =
+            vec!["bera-reth".into(), "node".into(), "--datadir".into(), non_utf8];
+        assert_eq!(with_resolved_manifest_url(node.clone()), node);
     }
 
     #[test]
@@ -215,7 +269,7 @@ mod tests {
 
     #[test]
     fn leaves_argv_alone_for_every_short_url_spelling() {
-        let base: Vec<String> =
+        let base: Vec<OsString> =
             vec!["bera-reth".into(), "download".into(), "--chain".into(), "bepolia".into()];
         let spellings: [&[&str]; 6] = [
             &["-u", "https://example.com/snap.tar.lz4"],
@@ -227,7 +281,7 @@ mod tests {
         ];
         for spelling in spellings {
             let mut argv = base.clone();
-            argv.extend(spelling.iter().map(|s| s.to_string()));
+            argv.extend(spelling.iter().map(OsString::from));
             assert_eq!(with_resolved_manifest_url(argv.clone()), argv, "spelling: {spelling:?}");
         }
     }

--- a/src/download_manifest_url.rs
+++ b/src/download_manifest_url.rs
@@ -32,17 +32,27 @@ const PUBLIC_BASE: &str = "https://bera-snapshots.fsn1.your-objectstorage.com";
 /// for example) is left untouched.
 const KNOWN_CHAINS: &[&str] = &["mainnet", "bepolia"];
 
+/// Boolean short flags on `download` that clap lets an operator cluster in
+/// front of `-u` in a single token (`-yu <URL>`, `-vvyu<URL>`): `-y`
+/// (`--non-interactive`) plus the global `-v`/`-q` display flags.
+const CLUSTERABLE_BOOL_SHORTS: &[char] = &['y', 'v', 'q'];
+
 /// Rewrites `argv` to inject `--manifest-url` when the caller ran
 /// `download --chain <mainnet|bepolia>` without supplying a manifest source
 /// of their own. Returns `argv` unchanged for every other invocation:
-/// non-`download` commands, a download that already names a manifest
-/// source, an unrecognized `--chain` value, or `--list`/`--help`.
+/// commands whose subcommand is not `download`, a download that already
+/// names a manifest source, an unrecognized `--chain` value, or
+/// `--list`/`--help`.
 pub(crate) fn with_resolved_manifest_url(argv: Vec<String>) -> Vec<String> {
-    if !is_bare_download_needing_manifest(&argv) {
+    let Some(download_args) = download_subcommand_args(&argv) else {
+        return argv;
+    };
+
+    if has_explicit_manifest_source(download_args) || is_list_or_help(download_args) {
         return argv;
     }
 
-    let Some(chain) = chain_arg(&argv) else {
+    let Some(chain) = chain_arg(download_args) else {
         return argv;
     };
 
@@ -61,37 +71,70 @@ fn manifest_url(chain: &str) -> String {
     format!("{PUBLIC_BASE}/v2/{chain}/reth/manifest.json")
 }
 
-/// Returns `true` only for a `download` invocation that has no manifest
-/// source of its own and isn't `--list`/`--help` (which don't need one).
-fn is_bare_download_needing_manifest(argv: &[String]) -> bool {
-    if !argv.iter().any(|a| a == "download") {
-        return false;
-    }
-
-    let has_explicit_source = argv.iter().any(|a| {
-        a == "--manifest-url"
-            || a.starts_with("--manifest-url=")
-            || a == "--manifest-path"
-            || a.starts_with("--manifest-path=")
-            || a == "-u"
-            || a == "--url"
-            || a.starts_with("--url=")
-    });
-    let is_list_or_help = argv
-        .iter()
-        .any(|a| a == "--list" || a == "--list-snapshots" || a == "-h" || a == "--help");
-
-    !has_explicit_source && !is_list_or_help
+/// Returns the arguments following the `download` subcommand token, or
+/// `None` if `download` is not the subcommand being invoked.
+///
+/// The subcommand is the first non-option token after the binary name; reth's
+/// global options (`-vvv`, `--quiet`, `--log.*=...`, `--color=...`) may
+/// legitimately precede it. A `download` token appearing anywhere else, e.g.
+/// as an option value in `node --datadir download`, is not a subcommand and
+/// must not trigger injection, since clap would then reject `--manifest-url`
+/// on a command that does not define it.
+///
+/// A value-taking global option written in separated form before the
+/// subcommand (`--color never download ...`) makes the value look like the
+/// subcommand, so no injection happens; the operator sees the normal
+/// upstream error and can either pass `--manifest-url` or write the option
+/// as `--color=never`. Failing closed here is deliberate.
+fn download_subcommand_args(argv: &[String]) -> Option<&[String]> {
+    let subcommand_index = argv.iter().skip(1).position(|a| !a.starts_with('-'))? + 1;
+    (argv[subcommand_index] == "download").then(|| &argv[subcommand_index + 1..])
 }
 
-/// Extracts the value of `--chain <value>` or `--chain=<value>` from argv.
-fn chain_arg(argv: &[String]) -> Option<String> {
-    for (i, arg) in argv.iter().enumerate() {
+/// Whether the operator already named a manifest source, in any of the
+/// spellings clap accepts for `DownloadCommand`'s `--manifest-url`,
+/// `--manifest-path`, and `-u`/`--url` options.
+fn has_explicit_manifest_source(download_args: &[String]) -> bool {
+    download_args.iter().any(|a| {
+        a == "--manifest-url" ||
+            a.starts_with("--manifest-url=") ||
+            a == "--manifest-path" ||
+            a.starts_with("--manifest-path=") ||
+            a == "--url" ||
+            a.starts_with("--url=") ||
+            is_short_url_option(a)
+    })
+}
+
+/// Matches every form clap accepts for the short `-u` option: `-u <URL>`,
+/// `-u=<URL>`, `-u<URL>`, and `-u` clustered behind boolean shorts such as
+/// `-yu <URL>` or `-yu<URL>`.
+fn is_short_url_option(arg: &str) -> bool {
+    let Some(shorts) = arg.strip_prefix('-') else {
+        return false;
+    };
+    if shorts.starts_with('-') {
+        return false;
+    }
+    shorts.trim_start_matches(CLUSTERABLE_BOOL_SHORTS).starts_with('u')
+}
+
+/// `--list` and `--help` never need a manifest source: `--list` conflicts
+/// with one in clap, and `--help` exits before any download runs.
+fn is_list_or_help(download_args: &[String]) -> bool {
+    download_args
+        .iter()
+        .any(|a| a == "--list" || a == "--list-snapshots" || a == "-h" || a == "--help")
+}
+
+/// Extracts the value of `--chain <value>` or `--chain=<value>`.
+fn chain_arg(download_args: &[String]) -> Option<String> {
+    for (i, arg) in download_args.iter().enumerate() {
         if let Some(value) = arg.strip_prefix("--chain=") {
             return Some(value.to_string());
         }
         if arg == "--chain" {
-            return argv.get(i + 1).cloned();
+            return download_args.get(i + 1).filter(|v| !v.starts_with('-')).cloned();
         }
     }
     None
@@ -125,9 +168,36 @@ mod tests {
     }
 
     #[test]
+    fn injects_when_global_options_precede_download_subcommand() {
+        let argv: Vec<String> = vec![
+            "bera-reth".into(),
+            "-vvv".into(),
+            "--color=never".into(),
+            "--log.file.directory=/tmp/logs".into(),
+            "download".into(),
+            "--chain".into(),
+            "mainnet".into(),
+        ];
+        let resolved = with_resolved_manifest_url(argv);
+        assert_eq!(
+            resolved.last().unwrap(),
+            "https://bera-snapshots.fsn1.your-objectstorage.com/v2/mainnet/reth/manifest.json"
+        );
+    }
+
+    #[test]
     fn chain_arg_supports_equals_form() {
         let argv = vec!["bera-reth".into(), "download".into(), "--chain=mainnet".into()];
-        assert_eq!(chain_arg(&argv), Some("mainnet".to_string()));
+        assert_eq!(
+            chain_arg(download_subcommand_args(&argv).unwrap()),
+            Some("mainnet".to_string())
+        );
+    }
+
+    #[test]
+    fn chain_arg_ignores_missing_value() {
+        let argv: Vec<String> = vec!["download".into(), "--chain".into(), "--minimal".into()];
+        assert_eq!(chain_arg(&argv[1..]), None);
     }
 
     #[test]
@@ -139,6 +209,59 @@ mod tests {
             "bepolia".into(),
             "--manifest-url".into(),
             "https://example.com/manifest.json".into(),
+        ];
+        assert_eq!(with_resolved_manifest_url(argv.clone()), argv);
+    }
+
+    #[test]
+    fn leaves_argv_alone_for_every_short_url_spelling() {
+        let base: Vec<String> =
+            vec!["bera-reth".into(), "download".into(), "--chain".into(), "bepolia".into()];
+        let spellings: [&[&str]; 6] = [
+            &["-u", "https://example.com/snap.tar.lz4"],
+            &["-u=https://example.com/snap.tar.lz4"],
+            &["-uhttps://example.com/snap.tar.lz4"],
+            &["-yu", "https://example.com/snap.tar.lz4"],
+            &["-yu=https://example.com/snap.tar.lz4"],
+            &["-vvyuhttps://example.com/snap.tar.lz4"],
+        ];
+        for spelling in spellings {
+            let mut argv = base.clone();
+            argv.extend(spelling.iter().map(|s| s.to_string()));
+            assert_eq!(with_resolved_manifest_url(argv.clone()), argv, "spelling: {spelling:?}");
+        }
+    }
+
+    #[test]
+    fn short_url_detection_does_not_match_other_short_flags() {
+        for flag in ["-y", "-vvv", "-q", "-h", "--url-ish"] {
+            assert!(!is_short_url_option(flag), "flag: {flag}");
+        }
+    }
+
+    #[test]
+    fn leaves_argv_alone_when_download_is_an_option_value_not_the_subcommand() {
+        let argv = vec![
+            "bera-reth".into(),
+            "node".into(),
+            "--datadir".into(),
+            "download".into(),
+            "--chain".into(),
+            "bepolia".into(),
+        ];
+        assert_eq!(with_resolved_manifest_url(argv.clone()), argv);
+    }
+
+    #[test]
+    fn fails_closed_when_separated_global_value_precedes_download() {
+        // `never` is what the scan sees as the subcommand, so no injection.
+        let argv = vec![
+            "bera-reth".into(),
+            "--color".into(),
+            "never".into(),
+            "download".into(),
+            "--chain".into(),
+            "bepolia".into(),
         ];
         assert_eq!(with_resolved_manifest_url(argv.clone()), argv);
     }

--- a/src/download_manifest_url.rs
+++ b/src/download_manifest_url.rs
@@ -1,0 +1,165 @@
+//! Auto-resolves `bera-reth download`'s `--manifest-url` for Berachain chains,
+//! so operators do not need to look up or hand-copy a manifest URL for a
+//! routine restore.
+//!
+//! **Binary-only.** This module is declared and rooted in `main.rs`, not
+//! `pub mod`-ed from `lib.rs` — it is CLI-argv glue for the `download`
+//! subcommand, not part of what the `bera_reth` library exposes.
+//!
+//! Berachain's chain IDs (mainnet 80094, bepolia 80069) never match Ethereum
+//! mainnet, so upstream reth's own snapshot auto-discovery refuses to run at
+//! all for them (see `reth_cli_commands::download`'s `mainnet_only_discovery`
+//! gate). This module is a thin, argv-level substitute: it constructs the
+//! manifest URL from the chain and injects it as if the operator had typed
+//! `--manifest-url` themselves. It never touches reth's internal
+//! `DownloadCommand` state or requires a fork of reth to work.
+//!
+//! The manifest object key is fixed per chain (`v2/<chain>/reth/manifest.json`)
+//! and is overwritten in place on every publish, not versioned by block or
+//! date, so the URL can be constructed directly with no network round trip:
+//! `snapshot-v2-publish.sh` always writes to `S3_EL_PREFIX/manifest.json`
+//! where `S3_EL_PREFIX = "v2/<chain>/reth"`. This mirrors the object layout
+//! documented in `infra-snapshots/project/reference/storage-v2.md`.
+
+const PUBLIC_BASE: &str = "https://bera-snapshots.fsn1.your-objectstorage.com";
+
+/// Chains this resolver knows how to look up. Mirrors `chainspec::mod.rs`'s
+/// own `BERACHAIN_MAINNET`/`BERACHAIN_BEPOLIA` chain-name strings, but
+/// duplicated rather than imported: those live in the library crate, this
+/// module lives in the binary crate, and reusing them would mean exposing
+/// them as public library API just to de-duplicate two literals in one
+/// bin-only file. Any other `--chain` value (a custom genesis file path,
+/// for example) is left untouched.
+const KNOWN_CHAINS: &[&str] = &["mainnet", "bepolia"];
+
+/// Rewrites `argv` to inject `--manifest-url` when the caller ran
+/// `download --chain <mainnet|bepolia>` without supplying a manifest source
+/// of their own. Returns `argv` unchanged for every other invocation:
+/// non-`download` commands, a download that already names a manifest
+/// source, an unrecognized `--chain` value, or `--list`/`--help`.
+pub(crate) fn with_resolved_manifest_url(argv: Vec<String>) -> Vec<String> {
+    if !is_bare_download_needing_manifest(&argv) {
+        return argv;
+    }
+
+    let Some(chain) = chain_arg(&argv) else {
+        return argv;
+    };
+
+    if !KNOWN_CHAINS.contains(&chain.as_str()) {
+        return argv;
+    }
+
+    let mut argv = argv;
+    argv.push("--manifest-url".to_string());
+    argv.push(manifest_url(&chain));
+    argv
+}
+
+/// The fixed, in-place-overwritten manifest URL for a known chain.
+fn manifest_url(chain: &str) -> String {
+    format!("{PUBLIC_BASE}/v2/{chain}/reth/manifest.json")
+}
+
+/// Returns `true` only for a `download` invocation that has no manifest
+/// source of its own and isn't `--list`/`--help` (which don't need one).
+fn is_bare_download_needing_manifest(argv: &[String]) -> bool {
+    if !argv.iter().any(|a| a == "download") {
+        return false;
+    }
+
+    let has_explicit_source = argv.iter().any(|a| {
+        a == "--manifest-url"
+            || a.starts_with("--manifest-url=")
+            || a == "--manifest-path"
+            || a.starts_with("--manifest-path=")
+            || a == "-u"
+            || a == "--url"
+            || a.starts_with("--url=")
+    });
+    let is_list_or_help = argv
+        .iter()
+        .any(|a| a == "--list" || a == "--list-snapshots" || a == "-h" || a == "--help");
+
+    !has_explicit_source && !is_list_or_help
+}
+
+/// Extracts the value of `--chain <value>` or `--chain=<value>` from argv.
+fn chain_arg(argv: &[String]) -> Option<String> {
+    for (i, arg) in argv.iter().enumerate() {
+        if let Some(value) = arg.strip_prefix("--chain=") {
+            return Some(value.to_string());
+        }
+        if arg == "--chain" {
+            return argv.get(i + 1).cloned();
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_known_chain_manifest_urls() {
+        assert_eq!(
+            manifest_url("bepolia"),
+            "https://bera-snapshots.fsn1.your-objectstorage.com/v2/bepolia/reth/manifest.json"
+        );
+        assert_eq!(
+            manifest_url("mainnet"),
+            "https://bera-snapshots.fsn1.your-objectstorage.com/v2/mainnet/reth/manifest.json"
+        );
+    }
+
+    #[test]
+    fn injects_manifest_url_for_bare_download_with_known_chain() {
+        let argv = vec!["bera-reth".into(), "download".into(), "--chain".into(), "bepolia".into()];
+        let resolved = with_resolved_manifest_url(argv);
+        assert_eq!(
+            resolved.last().unwrap(),
+            "https://bera-snapshots.fsn1.your-objectstorage.com/v2/bepolia/reth/manifest.json"
+        );
+        assert_eq!(resolved[resolved.len() - 2], "--manifest-url");
+    }
+
+    #[test]
+    fn chain_arg_supports_equals_form() {
+        let argv = vec!["bera-reth".into(), "download".into(), "--chain=mainnet".into()];
+        assert_eq!(chain_arg(&argv), Some("mainnet".to_string()));
+    }
+
+    #[test]
+    fn leaves_argv_alone_when_manifest_url_already_given() {
+        let argv = vec![
+            "bera-reth".into(),
+            "download".into(),
+            "--chain".into(),
+            "bepolia".into(),
+            "--manifest-url".into(),
+            "https://example.com/manifest.json".into(),
+        ];
+        assert_eq!(with_resolved_manifest_url(argv.clone()), argv);
+    }
+
+    #[test]
+    fn leaves_argv_alone_for_list_and_help() {
+        let list = vec!["bera-reth".into(), "download".into(), "--list".into()];
+        let help = vec!["bera-reth".into(), "download".into(), "--help".into()];
+        assert_eq!(with_resolved_manifest_url(list.clone()), list);
+        assert_eq!(with_resolved_manifest_url(help.clone()), help);
+    }
+
+    #[test]
+    fn leaves_argv_alone_for_non_download_commands() {
+        let argv = vec!["bera-reth".into(), "node".into(), "--chain".into(), "bepolia".into()];
+        assert_eq!(with_resolved_manifest_url(argv.clone()), argv);
+    }
+
+    #[test]
+    fn leaves_argv_alone_for_unknown_chain() {
+        let argv = vec!["bera-reth".into(), "download".into(), "--chain".into(), "sepolia".into()];
+        assert_eq!(with_resolved_manifest_url(argv.clone()), argv);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
 //! Bera-Reth main entry point
 
+mod download_manifest_url;
+
 #[global_allocator]
 static ALLOC: reth_cli_util::allocator::Allocator = reth_cli_util::allocator::new_allocator();
 
@@ -10,6 +12,7 @@ use bera_reth::{
     node::{BerachainNode, evm::config::BerachainEvmConfig, init_engine_defaults},
     version::init_bera_version,
 };
+use download_manifest_url::with_resolved_manifest_url;
 use clap::Parser;
 use reth::CliRunner;
 use reth_cli_commands::node::NoArgs;
@@ -39,7 +42,15 @@ fn main() {
         )
     };
 
-    if let Err(err) = Cli::<BerachainChainSpecParser, NoArgs>::parse()
+    // For `download --chain <mainnet|bepolia>` with no explicit manifest
+    // source, construct Berachain's fixed per-chain manifest URL before clap
+    // ever sees the args. Upstream reth's own snapshot auto-discovery only
+    // ever works for Ethereum mainnet (chain ID 1), which Berachain's chain
+    // IDs (80094, 80069) never match, so without this every restore requires
+    // an operator to hand-copy a manifest URL first.
+    let argv = with_resolved_manifest_url(std::env::args().collect());
+
+    if let Err(err) = Cli::<BerachainChainSpecParser, NoArgs>::parse_from(argv)
         .with_runner_and_components::<BerachainNode>(
             CliRunner::try_default_runtime().expect("Failed to create default runtime"),
             cli_components_builder,

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,8 +12,8 @@ use bera_reth::{
     node::{BerachainNode, evm::config::BerachainEvmConfig, init_engine_defaults},
     version::init_bera_version,
 };
-use download_manifest_url::with_resolved_manifest_url;
 use clap::Parser;
+use download_manifest_url::with_resolved_manifest_url;
 use reth::CliRunner;
 use reth_cli_commands::node::NoArgs;
 use reth_ethereum_cli::Cli;

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,8 +47,11 @@ fn main() {
     // ever sees the args. Upstream reth's own snapshot auto-discovery only
     // ever works for Ethereum mainnet (chain ID 1), which Berachain's chain
     // IDs (80094, 80069) never match, so without this every restore requires
-    // an operator to hand-copy a manifest URL first.
-    let argv = with_resolved_manifest_url(std::env::args().collect());
+    // an operator to hand-copy a manifest URL first. `args_os` rather than
+    // `args`: the latter panics on any non-UTF-8 argument, which would
+    // regress valid Unix paths (datadir, custom genesis) clap otherwise
+    // accepts.
+    let argv = with_resolved_manifest_url(std::env::args_os().collect());
 
     if let Err(err) = Cli::<BerachainChainSpecParser, NoArgs>::parse_from(argv)
         .with_runner_and_components::<BerachainNode>(


### PR DESCRIPTION
## Summary

`bera-reth download --chain bepolia|mainnet` with no `--manifest-url` currently bails with "Snapshots are only auto-discovered for Ethereum mainnet." Upstream reth's own snapshot auto-discovery (`reth_cli_commands::download::mainnet_only_discovery`) only ever resolves for Ethereum mainnet (chain ID 1); Berachain's chain IDs (80094, 80069) never match it, and we don't override `DownloadDefaults` to point discovery at our own bucket. Every restore requires an operator to hand-copy a manifest URL first.

- New `src/download_manifest_url.rs` (binary-only, declared via `mod` in `main.rs`, not `pub mod`-ed from `lib.rs`): rewrites argv to inject `--manifest-url` before clap parses, when the caller ran `download --chain <mainnet|bepolia>` without naming a manifest source of their own.
- No network call at resolution time: the manifest object key is fixed per chain (`v2/<chain>/reth/manifest.json`) and is overwritten in place on every publish, never versioned by block or date — confirmed against three live catalog fetches across this session (block advanced 24186916 → 24410736 → 24422883, object key never changed). The URL is just constructed.
- Never touches reth's internal `DownloadCommand` state, and doesn't require a fork or patch of any `reth-*` crate — it's a pre-parse argv rewrite entirely inside this crate's own binary.
- Explicit `--manifest-url`/`--manifest-path`/`-u`/`--url`, `--list`, and `--help` are all left untouched; only a bare `download --chain <known-chain>` gets the injection.

## Test plan

- [x] 7 new unit tests in `download_manifest_url.rs` (argv classification, URL construction, all pass-through cases) — `cargo test --release --bin bera-reth download_manifest_url` on playground, 7/7 pass.
- [x] `cargo build --release --bin bera-reth` on playground (`rustc 1.97.1`).
- [x] Live end-to-end: `bera-reth download --chain bepolia --minimal --print-plan-json` with **no** `--manifest-url` against the real bepolia catalog produces a valid modular plan (headers/receipts/transactions/storage-changesets chunks, real `v2/bepolia/reth/...` object URLs).
- [x] Sanity: explicit `--manifest-url` still respected untouched (loaded real manifest, block 24422883, chain_id 80069, 8 components).
- [x] Sanity: `--chain sepolia` still fails the normal way (rejected by `BerachainChainSpecParser` itself, before this code even runs).